### PR TITLE
Update nightly cron job

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,4 +1,4 @@
-name: nightly-package
+name: nightly-build
 
 on:
   schedule:
@@ -29,4 +29,4 @@ jobs:
         uses: extractions/setup-just@v1
 
       - name: Install dependencies 🔧
-        run: just pre-release
+        run: just nightly-build

--- a/justfile
+++ b/justfile
@@ -30,5 +30,5 @@ check path:
 check-all path:
     (cd {{path}}; cargo check --all-features)
 
-pre-release:
-  (cd framework && cargo package --all-features)
+nightly-build:
+  just cargo-all build --all-features


### PR DESCRIPTION
Updates the nightly cron-job to run `cargo build --all-features` instead of packaging. 