### PR TITLE
Deprecate old macros of abstract-app

### DIFF
--- a/framework/packages/abstract-app/src/interface.rs
+++ b/framework/packages/abstract-app/src/interface.rs
@@ -150,6 +150,6 @@ macro_rules! cw_orch_interface {
 #[macro_export]
 macro_rules! create_interface {
     ($app_const:expr, $app_type:ident) => {
-        abstract_app::cw_orch_interface!($app_const, $app_type, $app_type);
+        $crate::cw_orch_interface!($app_const, $app_type, $app_type);
     };
 }

--- a/framework/packages/abstract-app/src/msgs.rs
+++ b/framework/packages/abstract-app/src/msgs.rs
@@ -45,6 +45,6 @@ macro_rules! app_msg_types {
 #[macro_export]
 macro_rules! app_messages {
     ($app_type:ty, $app_execute_msg: ty, $app_query_msg: ty) => {
-        abstract_app::app_msg_types!($app_type, $app_execute_msg, $app_query_msg);
+        $crate::app_msg_types!($app_type, $app_execute_msg, $app_query_msg);
     };
 }


### PR DESCRIPTION
Small followup on https://github.com/AbstractSDK/contracts/pull/376

This PR aims to make easier discover of renamed macros