### PR TITLE
Adapters should have crates.io dependencies

### DIFF
--- a/adapter-packages/Cargo.toml
+++ b/adapter-packages/Cargo.toml
@@ -46,11 +46,11 @@ semver = "1.0"
 cw-semver = { version = "1.0" }
 cw-orch = { version = "0.13" }
 
-abstract-testing = { version = "0.16.1", path = "../framework/packages/abstract-testing" }
-abstract-core = { version = "0.16.1", path = "../framework/packages/abstract-core" }
-abstract-interface = { version = "0.16.1", path = "../framework/packages/abstract-interface" }
-abstract-sdk = { version = "0.16.1", path = "../framework/packages/abstract-sdk" }
-abstract-adapter = { version = "0.16.1", path = "../framework/packages/abstract-adapter" }
+abstract-testing = { version = "0.16.1" }
+abstract-core = { version = "0.16.1" }
+abstract-interface = { version = "0.16.1" }
+abstract-sdk = { version = "0.16.1" }
+abstract-adapter = { version = "0.16.1" }
 
 ## Testing
 rstest = "0.16.0"

--- a/adapters/Cargo.toml
+++ b/adapters/Cargo.toml
@@ -48,11 +48,11 @@ cw-orch = { version = "0.13.2" }
 
 tokio = { version = "1.4", features = ["full"] }
 
-abstract-testing = { version = "0.16.1", path = "../framework/packages/abstract-testing" }
-abstract-core = { version = "0.16.1", path = "../framework/packages/abstract-core" }
-abstract-interface = { version = "0.16.1", path = "../framework/packages/abstract-interface" }
-abstract-sdk = { version = "0.16.1", path = "../framework/packages/abstract-sdk" }
-abstract-adapter = { version = "0.16.1", path = "../framework/packages/abstract-adapter" }
+abstract-testing = { version = "0.16.1" }
+abstract-core = { version = "0.16.1" }
+abstract-interface = { version = "0.16.1"}
+abstract-sdk = { version = "0.16.1"}
+abstract-adapter = { version = "0.16.1" }
 
 ## Testing
 rstest = "0.16.0"

--- a/adapters/Cargo.toml
+++ b/adapters/Cargo.toml
@@ -50,8 +50,8 @@ tokio = { version = "1.4", features = ["full"] }
 
 abstract-testing = { version = "0.16.1" }
 abstract-core = { version = "0.16.1" }
-abstract-interface = { version = "0.16.1"}
-abstract-sdk = { version = "0.16.1"}
+abstract-interface = { version = "0.16.1" }
+abstract-sdk = { version = "0.16.1" }
 abstract-adapter = { version = "0.16.1" }
 
 ## Testing

--- a/adapters/contracts/dex/tests/swap.rs
+++ b/adapters/contracts/dex/tests/swap.rs
@@ -60,7 +60,7 @@ fn setup_mock() -> anyhow::Result<(
 
 #[test]
 fn swap_native() -> anyhow::Result<()> {
-    let (chain, _, dex_adapter, os, abstr) = setup_mock()?;
+    let (chain, _, dex_adapter, os, _abstr) = setup_mock()?;
     let proxy_addr = os.proxy.address()?;
 
     // swap 100 EUR to USD
@@ -74,7 +74,7 @@ fn swap_native() -> anyhow::Result<()> {
     assert_that!(usd_balance.u128()).is_equal_to(98);
 
     // assert that OS 0 received the swap fee
-    let os0_proxy = AbstractAccount::new(&abstr, Some(0)).proxy.address()?;
+    let os0_proxy = AbstractAccount::new(chain.clone(), Some(0)).proxy.address()?;
     let os0_eur_balance = chain.query_balance(&os0_proxy, EUR)?;
     assert_that!(os0_eur_balance.u128()).is_equal_to(1);
 
@@ -83,7 +83,7 @@ fn swap_native() -> anyhow::Result<()> {
 
 #[test]
 fn swap_native_without_chain() -> anyhow::Result<()> {
-    let (chain, _, dex_adapter, os, abstr) = setup_mock()?;
+    let (chain, _, dex_adapter, os, _abstr) = setup_mock()?;
     let proxy_addr = os.proxy.address()?;
 
     // swap 100 EUR to USD
@@ -97,7 +97,7 @@ fn swap_native_without_chain() -> anyhow::Result<()> {
     assert_that!(usd_balance.u128()).is_equal_to(98);
 
     // assert that OS 0 received the swap fee
-    let os0_proxy = AbstractAccount::new(&abstr, Some(0)).proxy.address()?;
+    let os0_proxy = AbstractAccount::new(chain.clone(), Some(0)).proxy.address()?;
     let os0_eur_balance = chain.query_balance(&os0_proxy, EUR)?;
     assert_that!(os0_eur_balance.u128()).is_equal_to(1);
 
@@ -106,7 +106,7 @@ fn swap_native_without_chain() -> anyhow::Result<()> {
 
 #[test]
 fn swap_raw() -> anyhow::Result<()> {
-    let (chain, wyndex, dex_adapter, os, abstr) = setup_mock()?;
+    let (chain, wyndex, dex_adapter, os, _abstr) = setup_mock()?;
     let proxy_addr = os.proxy.address()?;
 
     // trnasfer raw
@@ -127,7 +127,7 @@ fn swap_raw() -> anyhow::Result<()> {
     assert_that!(eur_balance.u128()).is_equal_to(10098);
 
     // assert that OS 0 received the swap fee
-    let account0_proxy = AbstractAccount::new(&abstr, Some(0)).proxy.address()?;
+    let account0_proxy = AbstractAccount::new(chain, Some(0)).proxy.address()?;
     let os0_raw_balance = wyndex.raw_token.balance(account0_proxy.to_string())?;
     assert_that!(os0_raw_balance.balance.u128()).is_equal_to(1);
 

--- a/adapters/contracts/dex/tests/swap.rs
+++ b/adapters/contracts/dex/tests/swap.rs
@@ -74,7 +74,9 @@ fn swap_native() -> anyhow::Result<()> {
     assert_that!(usd_balance.u128()).is_equal_to(98);
 
     // assert that OS 0 received the swap fee
-    let os0_proxy = AbstractAccount::new(chain.clone(), Some(0)).proxy.address()?;
+    let os0_proxy = AbstractAccount::new(chain.clone(), Some(0))
+        .proxy
+        .address()?;
     let os0_eur_balance = chain.query_balance(&os0_proxy, EUR)?;
     assert_that!(os0_eur_balance.u128()).is_equal_to(1);
 
@@ -97,7 +99,9 @@ fn swap_native_without_chain() -> anyhow::Result<()> {
     assert_that!(usd_balance.u128()).is_equal_to(98);
 
     // assert that OS 0 received the swap fee
-    let os0_proxy = AbstractAccount::new(chain.clone(), Some(0)).proxy.address()?;
+    let os0_proxy = AbstractAccount::new(chain.clone(), Some(0))
+        .proxy
+        .address()?;
     let os0_eur_balance = chain.query_balance(&os0_proxy, EUR)?;
     assert_that!(os0_eur_balance.u128()).is_equal_to(1);
 

--- a/integration-bundles/Cargo.toml
+++ b/integration-bundles/Cargo.toml
@@ -39,8 +39,8 @@ cw-asset = { version = "3.0" }
 cw-semver = { version = "1.0" }
 cw-orch = { version = "0.13.2" }
 
-abstract-core = { path = "../framework/packages/abstract-core" }
-abstract-interface = { path = "../framework/packages/abstract-interface" }
+abstract-core = { version="0.16.1" }
+abstract-interface = { version="0.16.1" }
 
 ## Testing
 cw-multi-test = { version = "0.16.2" }

--- a/integrations/astroport/packages/abstract-adapter/Cargo.toml
+++ b/integrations/astroport/packages/abstract-adapter/Cargo.toml
@@ -22,7 +22,7 @@ full_integration = [
 cosmwasm-std = { version = "1.1" }
 abstract-staking-adapter-traits = { path = "../../../../adapter-packages/staking" }
 abstract-dex-adapter-traits = { path = "../../../../adapter-packages/dex" }
-abstract-sdk = { path = "../../../../framework/packages/abstract-sdk" }
+abstract-sdk = { version="0.16.1" }
 
 
 cw20 = { version = "0.15", optional = true }

--- a/integrations/osmosis/packages/abstract-adapter/Cargo.toml
+++ b/integrations/osmosis/packages/abstract-adapter/Cargo.toml
@@ -18,13 +18,13 @@ full_integration = [
 
 [dependencies]
 cosmwasm-std = { version = "1.1.2", features = ["stargate"] }
-abstract-core = { path = "../../../../framework/packages/abstract-core" }
+abstract-core = { version="0.16.1" }
 abstract-staking-adapter-traits = { path = "../../../../adapter-packages/staking" }
 abstract-dex-adapter-traits = { path = "../../../../adapter-packages/dex" }
 
 #Abstract dependencies 
 cw20 = { version = "0.15", optional = true }
-abstract-sdk = { path = "../../../../framework/packages/abstract-sdk", optional = true }
+abstract-sdk = { version="0.16.1", optional = true }
 cw-asset = { version = "3.0.0", optional = true }
 cw-utils = { version = "1.0.1", optional = true }
 osmosis-std = { path = "../osmosis-std/", optional = true }

--- a/integrations/wyndex/packages/wyndex-adapter/Cargo.toml
+++ b/integrations/wyndex/packages/wyndex-adapter/Cargo.toml
@@ -23,7 +23,7 @@ full_integration = [
 [dependencies]
 cosmwasm-std = { workspace = true }
 
-abstract-sdk = { path = "../../../../framework/packages/abstract-sdk" }
+abstract-sdk = { version="0.16.1" }
 abstract-staking-adapter-traits = { path = "../../../../adapter-packages/staking" }
 abstract-dex-adapter-traits = { path = "../../../../adapter-packages/dex" }
 # Optional


### PR DESCRIPTION
This PR aims at allowing users to import abstract from a crates.io dependency and adapter from this git monorepo