### PR TITLE
Integrate dao-dao with Abstract

### DIFF
--- a/framework/contracts/account/proxy/src/lib.rs
+++ b/framework/contracts/account/proxy/src/lib.rs
@@ -1,7 +1,7 @@
-mod commands;
+pub mod commands;
 pub mod contract;
-mod error;
-mod queries;
+pub mod error;
+pub mod queries;
 pub mod reply;
 
 #[cfg(test)]

--- a/integrations/daodao-proxy/.cargo/config
+++ b/integrations/daodao-proxy/.cargo/config
@@ -1,0 +1,4 @@
+[alias]
+wasm = "build --release --target wasm32-unknown-unknown"
+unit-test = "test --lib"
+schema = "run --example schema"

--- a/integrations/daodao-proxy/Cargo.toml
+++ b/integrations/daodao-proxy/Cargo.toml
@@ -22,7 +22,7 @@ cosmwasm-std = { version = "1.1.2", features = ["stargate"] }
 # abstract-sdk = { version = "0.17.0" }
 # abstract-core = { version = "0.17.0" }
 abstract-proxy = { version = "0.17.0", path = "../../framework/contracts/account/proxy" }
-cw-asset = { version = "3.0.0", optional = true }
+cw-asset = { version = "3.0.0" }
 cw2 = "1.1.0"
 abstract-sdk = { path = "../../framework/packages/abstract-sdk" }
 abstract-macros = { path = "../../framework/packages/abstract-macros" }
@@ -31,6 +31,13 @@ semver = "1.0.17"
 thiserror = "1.0.43"
 dao-dao-core = "2.2.0"
 cosmwasm-schema = "1.2.7"
+dao-interface = "2.2.0"
+cw721 = "0.18.0"
+cw20 = "1.1.0"
+cw-utils = "0.16"
+cw-storage-plus = "1.1.0"
+cw-controllers = "1.1.0"
+speculoos = "0.11.0"
 
 [profile.release]
 rpath = false

--- a/integrations/daodao-proxy/Cargo.toml
+++ b/integrations/daodao-proxy/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "abstract-dao-proxy"
+version = "0.0.1"
+authors = ["Abstract","DAO-DAO"]
+edition = "2021"
+description = "Abstract Dao Proxy Contract"
+license = "GPL-3.0"
+readme = "README.md"
+repository = "https://github.com/AbstractSDK/abstract"
+
+exclude = ["contract.wasm", "hash.txt"]
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+default = ["export"]
+export = []
+
+[dependencies]
+cosmwasm-std = { version = "1.1.2", features = ["stargate"] }
+# abstract-sdk = { version = "0.17.0" }
+# abstract-core = { version = "0.17.0" }
+abstract-proxy ={ version = "0.17.0", path = "../../framework/contracts/account/proxy" }
+cw-asset = { version = "3.0.0", optional = true }
+cw2 = "1.1.0"
+abstract-sdk = { path = "../../framework/packages/abstract-sdk" }
+abstract-macros = {path = "../../framework/packages/abstract-macros" }
+abstract-core = { path = "../../framework/packages/abstract-core" }
+semver = "1.0.17"
+thiserror = "1.0.43"
+dao-dao-core = "2.2.0"
+cosmwasm-schema = "1.2.7"
+
+[profile.release]
+rpath = false
+lto = true
+overflow-checks = true
+opt-level = 3
+debug = false
+debug-assertions = false
+codegen-units = 1
+panic = 'abort'
+incremental = false

--- a/integrations/daodao-proxy/Cargo.toml
+++ b/integrations/daodao-proxy/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "abstract-dao-proxy"
 version = "0.0.1"
-authors = ["Abstract","DAO-DAO"]
+authors = ["Abstract", "DAO-DAO"]
 edition = "2021"
 description = "Abstract Dao Proxy Contract"
 license = "GPL-3.0"
@@ -21,11 +21,11 @@ export = []
 cosmwasm-std = { version = "1.1.2", features = ["stargate"] }
 # abstract-sdk = { version = "0.17.0" }
 # abstract-core = { version = "0.17.0" }
-abstract-proxy ={ version = "0.17.0", path = "../../framework/contracts/account/proxy" }
+abstract-proxy = { version = "0.17.0", path = "../../framework/contracts/account/proxy" }
 cw-asset = { version = "3.0.0", optional = true }
 cw2 = "1.1.0"
 abstract-sdk = { path = "../../framework/packages/abstract-sdk" }
-abstract-macros = {path = "../../framework/packages/abstract-macros" }
+abstract-macros = { path = "../../framework/packages/abstract-macros" }
 abstract-core = { path = "../../framework/packages/abstract-core" }
 semver = "1.0.17"
 thiserror = "1.0.43"

--- a/integrations/daodao-proxy/README.md
+++ b/integrations/daodao-proxy/README.md
@@ -1,0 +1,1 @@
+# Abstract Proxy

--- a/integrations/daodao-proxy/examples/schema.rs
+++ b/integrations/daodao-proxy/examples/schema.rs
@@ -1,0 +1,58 @@
+use abstract_sdk::core::proxy::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
+use cosmwasm_schema::write_api;
+
+fn main() {
+    write_api! {
+        instantiate: InstantiateMsg,
+        query: QueryMsg,
+        execute: ExecuteMsg,
+        migrate: MigrateMsg,
+    };
+    // let mut out_dir = current_dir().unwrap();
+    // out_dir.push("schema");
+    // create_dir_all(&out_dir).unwrap();
+    // remove_schemas(&out_dir).unwrap();
+
+    // export_schema(&schema_for!(InstantiateMsg), &out_dir);
+    // export_schema(&schema_for!(ExecuteMsg), &out_dir);
+    // export_schema(&schema_for!(QueryMsg), &out_dir);
+    // export_schema(&schema_for!(State), &out_dir);
+    // export_schema(&schema_for!(ProxyAsset), &out_dir);
+    // export_schema(&schema_for!(UncheckedProxyAsset), &out_dir);
+    // export_schema(&schema_for!(BaseAssetResponse), &out_dir);
+    // export_schema_with_title(&schema_for!(ConfigResponse), &out_dir, "ConfigResponse");
+    // export_schema_with_title(
+    //     &schema_for!(TotalValueResponse),
+    //     &out_dir,
+    //     "TotalValueResponse",
+    // );
+    // export_schema_with_title(
+    //     &schema_for!(HoldingValueResponse),
+    //     &out_dir,
+    //     "HoldingValueResponse",
+    // );
+    // export_schema_with_title(
+    //     &schema_for!(HoldingAmountResponse),
+    //     &out_dir,
+    //     "HoldingAmountResponse",
+    // );
+    // export_schema_with_title(
+    //     &schema_for!(AssetConfigResponse),
+    //     &out_dir,
+    //     "AssetConfigResponse",
+    // );
+    // export_schema_with_title(&schema_for!(AssetsResponse), &out_dir, "AssetsResponse");
+    // export_schema_with_title(
+    //     &schema_for!(ValidityResponse),
+    //     &out_dir,
+    //     "CheckValidityResponse",
+    // );
+
+    // export_schema_with_title(
+    //     &schema_for!(CosmosMsg<Empty>),
+    //     &out_dir,
+    //     "CosmosMsg_for_Empty",
+    // );
+
+    // export_schema_with_title(&schema_for!(AssetInfo), &out_dir, "AssetInfoBase_for_Addr");
+}

--- a/integrations/daodao-proxy/rustfmt.toml
+++ b/integrations/daodao-proxy/rustfmt.toml
@@ -1,0 +1,14 @@
+# stable
+newline_style = "unix"
+hard_tabs = false
+tab_spaces = 4
+
+# unstable... should we require `rustup run nightly cargo fmt` ?
+# or just update the style guide when they are stable?
+#fn_single_line = true
+#format_code_in_doc_comments = true
+#overflow_delimited_expr = true
+#reorder_impl_items = true
+#struct_field_align_threshold = 20
+#struct_lit_single_line = true
+#report_todo = "Always"

--- a/integrations/daodao-proxy/src/contract.rs
+++ b/integrations/daodao-proxy/src/contract.rs
@@ -1,24 +1,22 @@
 use crate::patch::execute_module_action_response;
-use abstract_core::proxy::AssetConfigResponse;
-use dao_dao_core::state::PAUSED;
 use crate::{error::DaoProxyError, msg::*};
-use abstract_proxy::*;
 use abstract_core::objects::module_version::assert_contract_upgrade;
 use abstract_core::objects::oracle::Oracle;
+use abstract_core::proxy::AssetConfigResponse;
 use abstract_macros::abstract_response;
+use abstract_proxy::*;
 use abstract_sdk::{
     core::{
         objects::account_id::ACCOUNT_ID,
-        proxy::{
-            state::{State, ANS_HOST, STATE},
-        },
+        proxy::state::{State, ANS_HOST, STATE},
         PROXY,
     },
     feature_objects::AnsHost,
 };
 use cosmwasm_std::{
-    to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response, SubMsgResult, Empty,
+    to_binary, Binary, Deps, DepsMut, Empty, Env, MessageInfo, Reply, Response, SubMsgResult,
 };
+use dao_dao_core::state::PAUSED;
 
 use semver::Version;
 
@@ -37,12 +35,7 @@ pub type DaoProxyResult<T = Response> = Result<T, DaoProxyError>;
 */
 
 #[cfg_attr(feature = "export", cosmwasm_std::entry_point)]
-pub fn instantiate(
-    _deps: DepsMut,
-    _env: Env,
-    _info: MessageInfo,
-    _msg: Empty,
-) -> DaoProxyResult {
+pub fn instantiate(_deps: DepsMut, _env: Env, _info: MessageInfo, _msg: Empty) -> DaoProxyResult {
     panic!("Only use this contract through a migration.");
 }
 
@@ -56,53 +49,116 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> D
     }
     match msg {
         // Abstract Proxy Messages
-        ExecuteMsg::ModuleAction { msgs } => abstract_proxy::commands::execute_module_action(deps, info, msgs).map_err(Into::into),
+        ExecuteMsg::ModuleAction { msgs } => {
+            abstract_proxy::commands::execute_module_action(deps, info, msgs).map_err(Into::into)
+        }
         // This action is patched on purpose to be able to differentiate between reply ids
-        ExecuteMsg::ModuleActionWithData { msg } => execute_module_action_response(deps, info, msg).map_err(Into::into),
-        ExecuteMsg::IbcAction { msgs } => abstract_proxy::commands::execute_ibc_action(deps, info, msgs).map_err(Into::into),
-        ExecuteMsg::SetAdmin { admin } => abstract_proxy::commands::set_admin(deps, info, &admin).map_err(Into::into),
-        ExecuteMsg::AddModule { module } => abstract_proxy::commands::add_module(deps, info, module).map_err(Into::into),
-        ExecuteMsg::RemoveModule { module } => abstract_proxy::commands::remove_module(deps, info, module).map_err(Into::into),
+        ExecuteMsg::ModuleActionWithData { msg } => {
+            execute_module_action_response(deps, info, msg).map_err(Into::into)
+        }
+        ExecuteMsg::IbcAction { msgs } => {
+            abstract_proxy::commands::execute_ibc_action(deps, info, msgs).map_err(Into::into)
+        }
+        ExecuteMsg::SetAdmin { admin } => {
+            abstract_proxy::commands::set_admin(deps, info, &admin).map_err(Into::into)
+        }
+        ExecuteMsg::AddModule { module } => {
+            abstract_proxy::commands::add_module(deps, info, module).map_err(Into::into)
+        }
+        ExecuteMsg::RemoveModule { module } => {
+            abstract_proxy::commands::remove_module(deps, info, module).map_err(Into::into)
+        }
         ExecuteMsg::UpdateAssets { to_add, to_remove } => {
-            abstract_proxy::commands::update_assets(deps, info, to_add, to_remove).map_err(Into::into)
-        },
+            abstract_proxy::commands::update_assets(deps, info, to_add, to_remove)
+                .map_err(Into::into)
+        }
 
         // DaoDao Proxy Messages
         ExecuteMsg::ExecuteAdminMsgs { msgs } => {
-            dao_dao_core::contract::execute_admin_msgs(deps.as_ref(), info.sender, msgs).map_err(Into::into)
+            dao_dao_core::contract::execute_admin_msgs(deps.as_ref(), info.sender, msgs)
+                .map_err(Into::into)
         }
         ExecuteMsg::ExecuteProposalHook { msgs } => {
-            dao_dao_core::contract::execute_proposal_hook(deps.as_ref(), info.sender, msgs).map_err(Into::into)
+            dao_dao_core::contract::execute_proposal_hook(deps.as_ref(), info.sender, msgs)
+                .map_err(Into::into)
         }
-        ExecuteMsg::Pause { duration } => dao_dao_core::contract::execute_pause(deps, env, info.sender, duration).map_err(Into::into),
-        ExecuteMsg::Receive(_) => dao_dao_core::contract::execute_receive_cw20(deps, info.sender).map_err(Into::into),
-        ExecuteMsg::ReceiveNft(_) => dao_dao_core::contract::execute_receive_cw721(deps, info.sender).map_err(Into::into),
-        ExecuteMsg::RemoveItem { key } => dao_dao_core::contract::execute_remove_item(deps, env, info.sender, key).map_err(Into::into),
-        ExecuteMsg::SetItem { key, value } => dao_dao_core::contract::execute_set_item(deps, env, info.sender, key, value).map_err(Into::into),
+        ExecuteMsg::Pause { duration } => {
+            dao_dao_core::contract::execute_pause(deps, env, info.sender, duration)
+                .map_err(Into::into)
+        }
+        ExecuteMsg::Receive(_) => {
+            dao_dao_core::contract::execute_receive_cw20(deps, info.sender).map_err(Into::into)
+        }
+        ExecuteMsg::ReceiveNft(_) => {
+            dao_dao_core::contract::execute_receive_cw721(deps, info.sender).map_err(Into::into)
+        }
+        ExecuteMsg::RemoveItem { key } => {
+            dao_dao_core::contract::execute_remove_item(deps, env, info.sender, key)
+                .map_err(Into::into)
+        }
+        ExecuteMsg::SetItem { key, value } => {
+            dao_dao_core::contract::execute_set_item(deps, env, info.sender, key, value)
+                .map_err(Into::into)
+        }
         ExecuteMsg::UpdateConfig { config } => {
-            dao_dao_core::contract::execute_update_config(deps, env, info.sender, config).map_err(Into::into)
+            dao_dao_core::contract::execute_update_config(deps, env, info.sender, config)
+                .map_err(Into::into)
         }
         ExecuteMsg::UpdateCw20List { to_add, to_remove } => {
-            dao_dao_core::contract::execute_update_cw20_list(deps, env, info.sender, to_add, to_remove).map_err(Into::into)
+            dao_dao_core::contract::execute_update_cw20_list(
+                deps,
+                env,
+                info.sender,
+                to_add,
+                to_remove,
+            )
+            .map_err(Into::into)
         }
         ExecuteMsg::UpdateCw721List { to_add, to_remove } => {
-            dao_dao_core::contract::execute_update_cw721_list(deps, env, info.sender, to_add, to_remove).map_err(Into::into)
+            dao_dao_core::contract::execute_update_cw721_list(
+                deps,
+                env,
+                info.sender,
+                to_add,
+                to_remove,
+            )
+            .map_err(Into::into)
         }
         ExecuteMsg::UpdateVotingModule { module } => {
-            dao_dao_core::contract::execute_update_voting_module(env, info.sender, module).map_err(Into::into)
+            dao_dao_core::contract::execute_update_voting_module(env, info.sender, module)
+                .map_err(Into::into)
         }
         ExecuteMsg::UpdateProposalModules { to_add, to_disable } => {
-            dao_dao_core::contract::execute_update_proposal_modules(deps, env, info.sender, to_add, to_disable).map_err(Into::into)
+            dao_dao_core::contract::execute_update_proposal_modules(
+                deps,
+                env,
+                info.sender,
+                to_add,
+                to_disable,
+            )
+            .map_err(Into::into)
         }
         ExecuteMsg::NominateAdmin { admin } => {
-            dao_dao_core::contract::execute_nominate_admin(deps, env, info.sender, admin).map_err(Into::into)
+            dao_dao_core::contract::execute_nominate_admin(deps, env, info.sender, admin)
+                .map_err(Into::into)
         }
-        ExecuteMsg::AcceptAdminNomination {} => dao_dao_core::contract::execute_accept_admin_nomination(deps, info.sender).map_err(Into::into),
+        ExecuteMsg::AcceptAdminNomination {} => {
+            dao_dao_core::contract::execute_accept_admin_nomination(deps, info.sender)
+                .map_err(Into::into)
+        }
         ExecuteMsg::WithdrawAdminNomination {} => {
-            dao_dao_core::contract::execute_withdraw_admin_nomination(deps, info.sender).map_err(Into::into)
+            dao_dao_core::contract::execute_withdraw_admin_nomination(deps, info.sender)
+                .map_err(Into::into)
         }
         ExecuteMsg::UpdateSubDaos { to_add, to_remove } => {
-            dao_dao_core::contract::execute_update_sub_daos_list(deps, env, info.sender, to_add, to_remove).map_err(Into::into)
+            dao_dao_core::contract::execute_update_sub_daos_list(
+                deps,
+                env,
+                info.sender,
+                to_add,
+                to_remove,
+            )
+            .map_err(Into::into)
         }
     }
 }
@@ -136,29 +192,33 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> DaoProxyResult<Binary> {
     match msg {
         // Abstract Proxy Messages
         QueryMsg::AbstractConfig {} => to_binary(&abstract_proxy::queries::query_config(deps)?),
-        QueryMsg::TotalValue {} => to_binary(&abstract_proxy::queries::query_total_value(deps, env)?),
-        QueryMsg::HoldingAmount { identifier } => {
-            to_binary(&abstract_proxy::queries::query_holding_amount(deps, env, identifier)?)
+        QueryMsg::TotalValue {} => {
+            to_binary(&abstract_proxy::queries::query_total_value(deps, env)?)
         }
-        QueryMsg::TokenValue { identifier } => {
-            to_binary(&abstract_proxy::queries::query_token_value(deps, env, identifier)?)
-        }
+        QueryMsg::HoldingAmount { identifier } => to_binary(
+            &abstract_proxy::queries::query_holding_amount(deps, env, identifier)?,
+        ),
+        QueryMsg::TokenValue { identifier } => to_binary(
+            &abstract_proxy::queries::query_token_value(deps, env, identifier)?,
+        ),
         QueryMsg::AssetConfig { identifier } => to_binary(&AssetConfigResponse {
             price_source: Oracle::new().asset_config(deps, &identifier)?,
         }),
-        QueryMsg::AssetsConfig { start_after, limit } => {
-            to_binary(&abstract_proxy::queries::query_oracle_asset_config(deps, start_after, limit)?)
-        }
-        QueryMsg::AssetsInfo { start_after, limit } => {
-            to_binary(&abstract_proxy::queries::query_oracle_asset_info(deps, start_after, limit)?)
-        }
+        QueryMsg::AssetsConfig { start_after, limit } => to_binary(
+            &abstract_proxy::queries::query_oracle_asset_config(deps, start_after, limit)?,
+        ),
+        QueryMsg::AssetsInfo { start_after, limit } => to_binary(
+            &abstract_proxy::queries::query_oracle_asset_info(deps, start_after, limit)?,
+        ),
         QueryMsg::BaseAsset {} => to_binary(&abstract_proxy::queries::query_base_asset(deps)?),
 
         // DaoDao Proxy Messages
         QueryMsg::Admin {} => dao_dao_core::contract::query_admin(deps),
         QueryMsg::AdminNomination {} => dao_dao_core::contract::query_admin_nomination(deps),
         QueryMsg::Config {} => dao_dao_core::contract::query_config(deps),
-        QueryMsg::Cw20TokenList { start_after, limit } => dao_dao_core::contract::query_cw20_list(deps, start_after, limit),
+        QueryMsg::Cw20TokenList { start_after, limit } => {
+            dao_dao_core::contract::query_cw20_list(deps, start_after, limit)
+        }
         QueryMsg::Cw20Balances { start_after, limit } => {
             dao_dao_core::contract::query_cw20_balances(deps, env, start_after, limit)
         }
@@ -168,13 +228,19 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> DaoProxyResult<Binary> {
         QueryMsg::DumpState {} => dao_dao_core::contract::query_dump_state(deps, env),
         QueryMsg::GetItem { key } => dao_dao_core::contract::query_get_item(deps, key),
         QueryMsg::Info {} => dao_dao_core::contract::query_info(deps),
-        QueryMsg::ListItems { start_after, limit } => dao_dao_core::contract::query_list_items(deps, start_after, limit),
+        QueryMsg::ListItems { start_after, limit } => {
+            dao_dao_core::contract::query_list_items(deps, start_after, limit)
+        }
         QueryMsg::PauseInfo {} => dao_dao_core::contract::query_paused(deps, env),
         QueryMsg::ProposalModules { start_after, limit } => {
             dao_dao_core::contract::query_proposal_modules(deps, start_after, limit)
         }
-        QueryMsg::ProposalModuleCount {} => dao_dao_core::contract::query_proposal_module_count(deps),
-        QueryMsg::TotalPowerAtHeight { height } => dao_dao_core::contract::query_total_power_at_height(deps, height),
+        QueryMsg::ProposalModuleCount {} => {
+            dao_dao_core::contract::query_proposal_module_count(deps)
+        }
+        QueryMsg::TotalPowerAtHeight { height } => {
+            dao_dao_core::contract::query_total_power_at_height(deps, height)
+        }
         QueryMsg::VotingModule {} => dao_dao_core::contract::query_voting_module(deps),
         QueryMsg::VotingPowerAtHeight { address, height } => {
             dao_dao_core::contract::query_voting_power_at_height(deps, address, height)
@@ -186,7 +252,6 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> DaoProxyResult<Binary> {
             dao_dao_core::contract::query_list_sub_daos(deps, start_after, limit)
         }
         QueryMsg::DaoURI {} => dao_dao_core::contract::query_dao_uri(deps),
-
     }
     .map_err(Into::into)
 }
@@ -194,13 +259,12 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> DaoProxyResult<Binary> {
 /// This just stores the result for future query
 #[cfg_attr(feature = "export", cosmwasm_std::entry_point)]
 pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> DaoProxyResult {
-
-    match msg{
+    match msg {
         Reply {
             id: RESPONSE_REPLY_ID,
             result: SubMsgResult::Ok(_),
         } => reply::forward_response_data(msg).map_err(Into::into),
-        _=> dao_dao_core::contract::reply(deps, env, msg).map_err(Into::into),
+        _ => dao_dao_core::contract::reply(deps, env, msg).map_err(Into::into),
     }
 }
 
@@ -215,25 +279,36 @@ mod tests {
         use super::*;
         use abstract_core::AbstractError;
 
+        fn mock_init(deps: DepsMut) -> DaoProxyResult<()> {
+            cw2::set_contract_version(deps.storage, PROXY, CONTRACT_VERSION)?;
+            Ok(())
+        }
+
         #[test]
         fn disallow_same_version() -> DaoProxyResult<()> {
             let mut deps = mock_dependencies();
-            mock_init(deps.as_mut());
+            mock_init(deps.as_mut())?;
 
             let version: Version = CONTRACT_VERSION.parse().unwrap();
 
-            let res = contract::migrate(deps.as_mut(), mock_env(), MigrateMsg { 
-                abstract_account_id: 1, 
-                ans_host_address: "ANS_HOST".to_string()
-            });
-
-            assert_that!(res).is_err().is_equal_to(DaoProxyError::Abstract(
-                AbstractError::CannotDowngradeContract {
-                    contract: PROXY.to_string(),
-                    from: version.clone(),
-                    to: version,
+            let res = contract::migrate(
+                deps.as_mut(),
+                mock_env(),
+                MigrateMsg {
+                    abstract_account_id: 1,
+                    ans_host_address: "ans_host".to_string(),
                 },
-            ));
+            );
+
+            assert_that!(res)
+                .is_err()
+                .is_equal_to(DaoProxyError::Abstract(
+                    AbstractError::CannotDowngradeContract {
+                        contract: PROXY.to_string(),
+                        from: version.clone(),
+                        to: version,
+                    },
+                ));
 
             Ok(())
         }
@@ -241,25 +316,31 @@ mod tests {
         #[test]
         fn disallow_downgrade() -> DaoProxyResult<()> {
             let mut deps = mock_dependencies();
-            mock_init(deps.as_mut());
+            mock_init(deps.as_mut())?;
 
             let big_version = "999.999.999";
             cw2::set_contract_version(deps.as_mut().storage, PROXY, big_version)?;
 
             let version: Version = CONTRACT_VERSION.parse().unwrap();
 
-            let res = contract::migrate(deps.as_mut(), mock_env(), MigrateMsg { 
-                abstract_account_id: 1, 
-                ans_host_address: "ANS_HOST".to_string()
-            });
-
-            assert_that!(res).is_err().is_equal_to(DaoProxyError::Abstract(
-                AbstractError::CannotDowngradeContract {
-                    contract: PROXY.to_string(),
-                    from: big_version.parse().unwrap(),
-                    to: version,
+            let res = contract::migrate(
+                deps.as_mut(),
+                mock_env(),
+                MigrateMsg {
+                    abstract_account_id: 1,
+                    ans_host_address: "ans_host".to_string(),
                 },
-            ));
+            );
+
+            assert_that!(res)
+                .is_err()
+                .is_equal_to(DaoProxyError::Abstract(
+                    AbstractError::CannotDowngradeContract {
+                        contract: PROXY.to_string(),
+                        from: big_version.parse().unwrap(),
+                        to: version,
+                    },
+                ));
 
             Ok(())
         }
@@ -267,23 +348,29 @@ mod tests {
         #[test]
         fn disallow_name_change() -> DaoProxyResult<()> {
             let mut deps = mock_dependencies();
-            mock_init(deps.as_mut());
+            mock_init(deps.as_mut())?;
 
             let old_version = "0.0.0";
             let old_name = "old:contract";
             cw2::set_contract_version(deps.as_mut().storage, old_name, old_version)?;
 
-            let res = contract::migrate(deps.as_mut(), mock_env(), MigrateMsg { 
-                abstract_account_id: 1, 
-                ans_host_address: "ANS_HOST".to_string()
-            });
-
-            assert_that!(res).is_err().is_equal_to(DaoProxyError::Abstract(
-                AbstractError::ContractNameMismatch {
-                    from: old_name.parse().unwrap(),
-                    to: PROXY.parse().unwrap(),
+            let res = contract::migrate(
+                deps.as_mut(),
+                mock_env(),
+                MigrateMsg {
+                    abstract_account_id: 1,
+                    ans_host_address: "ans_host".to_string(),
                 },
-            ));
+            );
+
+            assert_that!(res)
+                .is_err()
+                .is_equal_to(DaoProxyError::Abstract(
+                    AbstractError::ContractNameMismatch {
+                        from: old_name.parse().unwrap(),
+                        to: PROXY.parse().unwrap(),
+                    },
+                ));
 
             Ok(())
         }
@@ -291,17 +378,21 @@ mod tests {
         #[test]
         fn works() -> DaoProxyResult<()> {
             let mut deps = mock_dependencies();
-            mock_init(deps.as_mut());
+            mock_init(deps.as_mut())?;
 
             let small_version = "0.0.0";
             cw2::set_contract_version(deps.as_mut().storage, PROXY, small_version)?;
 
             let version: Version = CONTRACT_VERSION.parse().unwrap();
 
-            let res = contract::migrate(deps.as_mut(), mock_env(), MigrateMsg { 
-                abstract_account_id: 1, 
-                ans_host_address: "ANS_HOST".to_string()
-            })?;
+            let res = contract::migrate(
+                deps.as_mut(),
+                mock_env(),
+                MigrateMsg {
+                    abstract_account_id: 1,
+                    ans_host_address: "ans_host".to_string(),
+                },
+            )?;
             assert_that!(res.messages).has_length(0);
 
             assert_that!(cw2::get_contract_version(&deps.storage)?.version)

--- a/integrations/daodao-proxy/src/contract.rs
+++ b/integrations/daodao-proxy/src/contract.rs
@@ -1,3 +1,6 @@
+use crate::patch::execute_module_action_response;
+use abstract_core::proxy::AssetConfigResponse;
+use dao_dao_core::state::PAUSED;
 use crate::{error::DaoProxyError, msg::*};
 use abstract_proxy::*;
 use abstract_core::objects::module_version::assert_contract_upgrade;
@@ -7,7 +10,7 @@ use abstract_sdk::{
     core::{
         objects::account_id::ACCOUNT_ID,
         proxy::{
-            state::{State, ADMIN, ANS_HOST, STATE},
+            state::{State, ANS_HOST, STATE},
         },
         PROXY,
     },
@@ -20,7 +23,7 @@ use cosmwasm_std::{
 use semver::Version;
 
 pub const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
-pub(crate) const RESPONSE_REPLY_ID: u64 = 1;
+pub(crate) const RESPONSE_REPLY_ID: u64 = 1111;
 
 #[abstract_response(PROXY)]
 pub struct ProxyResponse;
@@ -35,10 +38,10 @@ pub type DaoProxyResult<T = Response> = Result<T, DaoProxyError>;
 
 #[cfg_attr(feature = "export", cosmwasm_std::entry_point)]
 pub fn instantiate(
-    deps: DepsMut,
+    _deps: DepsMut,
     _env: Env,
-    info: MessageInfo,
-    msg: Empty,
+    _info: MessageInfo,
+    _msg: Empty,
 ) -> DaoProxyResult {
     panic!("Only use this contract through a migration.");
 }
@@ -48,13 +51,14 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> D
     // No actions can be performed while the DAO is paused.
     if let Some(expiration) = PAUSED.may_load(deps.storage)? {
         if !expiration.is_expired(&env.block) {
-            return Err(ContractError::Paused {});
+            return Err(dao_dao_core::ContractError::Paused {}.into());
         }
     }
     match msg {
         // Abstract Proxy Messages
         ExecuteMsg::ModuleAction { msgs } => abstract_proxy::commands::execute_module_action(deps, info, msgs).map_err(Into::into),
-        ExecuteMsg::ModuleActionWithData { msg } => abstract_proxy::commands::execute_module_action_response(deps, info, msg).map_err(Into::into),
+        // This action is patched on purpose to be able to differentiate between reply ids
+        ExecuteMsg::ModuleActionWithData { msg } => execute_module_action_response(deps, info, msg).map_err(Into::into),
         ExecuteMsg::IbcAction { msgs } => abstract_proxy::commands::execute_ibc_action(deps, info, msgs).map_err(Into::into),
         ExecuteMsg::SetAdmin { admin } => abstract_proxy::commands::set_admin(deps, info, &admin).map_err(Into::into),
         ExecuteMsg::AddModule { module } => abstract_proxy::commands::add_module(deps, info, module).map_err(Into::into),
@@ -62,6 +66,7 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> D
         ExecuteMsg::UpdateAssets { to_add, to_remove } => {
             abstract_proxy::commands::update_assets(deps, info, to_add, to_remove).map_err(Into::into)
         },
+
         // DaoDao Proxy Messages
         ExecuteMsg::ExecuteAdminMsgs { msgs } => {
             dao_dao_core::contract::execute_admin_msgs(deps.as_ref(), info.sender, msgs).map_err(Into::into)
@@ -105,8 +110,7 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> D
 #[cfg_attr(feature = "export", cosmwasm_std::entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> DaoProxyResult {
     // Use CW2 to set the contract version, this is needed for migrations
-    cw2::set_contract_version(deps.storage, PROXY, CONTRACT_VERSION)?;
-    ACCOUNT_ID.save(deps.storage, &msg.account_id)?;
+    ACCOUNT_ID.save(deps.storage, &msg.abstract_account_id)?;
     STATE.save(deps.storage, &State { modules: vec![] })?;
     ANS_HOST.save(
         deps.storage,
@@ -114,9 +118,14 @@ pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> DaoProxyResult {
             address: deps.api.addr_validate(&msg.ans_host_address)?,
         },
     )?;
-    let admin_addr = Some(info.sender);
-    ADMIN.set(deps, admin_addr)?;
+    // Don't need to setup the admin, they already have an admin field in the dao-dao contract
+    // TODO, to erase
+    /*
+        let admin_addr = Some(dao_dao_core::contract::query_admin(deps))?;
+        ADMIN.set(deps, admin_addr)?;
+    */
 
+    let version: Version = CONTRACT_VERSION.parse().unwrap();
     assert_contract_upgrade(deps.storage, PROXY, version)?;
     cw2::set_contract_version(deps.storage, PROXY, CONTRACT_VERSION)?;
     Ok(Response::default())
@@ -125,37 +134,73 @@ pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> DaoProxyResult {
 #[cfg_attr(feature = "export", cosmwasm_std::entry_point)]
 pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> DaoProxyResult<Binary> {
     match msg {
-        QueryMsg::Config {} => to_binary(&query_config(deps)?),
-        QueryMsg::TotalValue {} => to_binary(&query_total_value(deps, env)?),
+        // Abstract Proxy Messages
+        QueryMsg::AbstractConfig {} => to_binary(&abstract_proxy::queries::query_config(deps)?),
+        QueryMsg::TotalValue {} => to_binary(&abstract_proxy::queries::query_total_value(deps, env)?),
         QueryMsg::HoldingAmount { identifier } => {
-            to_binary(&query_holding_amount(deps, env, identifier)?)
+            to_binary(&abstract_proxy::queries::query_holding_amount(deps, env, identifier)?)
         }
         QueryMsg::TokenValue { identifier } => {
-            to_binary(&query_token_value(deps, env, identifier)?)
+            to_binary(&abstract_proxy::queries::query_token_value(deps, env, identifier)?)
         }
         QueryMsg::AssetConfig { identifier } => to_binary(&AssetConfigResponse {
             price_source: Oracle::new().asset_config(deps, &identifier)?,
         }),
         QueryMsg::AssetsConfig { start_after, limit } => {
-            to_binary(&query_oracle_asset_config(deps, start_after, limit)?)
+            to_binary(&abstract_proxy::queries::query_oracle_asset_config(deps, start_after, limit)?)
         }
         QueryMsg::AssetsInfo { start_after, limit } => {
-            to_binary(&query_oracle_asset_info(deps, start_after, limit)?)
+            to_binary(&abstract_proxy::queries::query_oracle_asset_info(deps, start_after, limit)?)
         }
-        QueryMsg::BaseAsset {} => to_binary(&query_base_asset(deps)?),
+        QueryMsg::BaseAsset {} => to_binary(&abstract_proxy::queries::query_base_asset(deps)?),
+
+        // DaoDao Proxy Messages
+        QueryMsg::Admin {} => dao_dao_core::contract::query_admin(deps),
+        QueryMsg::AdminNomination {} => dao_dao_core::contract::query_admin_nomination(deps),
+        QueryMsg::Config {} => dao_dao_core::contract::query_config(deps),
+        QueryMsg::Cw20TokenList { start_after, limit } => dao_dao_core::contract::query_cw20_list(deps, start_after, limit),
+        QueryMsg::Cw20Balances { start_after, limit } => {
+            dao_dao_core::contract::query_cw20_balances(deps, env, start_after, limit)
+        }
+        QueryMsg::Cw721TokenList { start_after, limit } => {
+            dao_dao_core::contract::query_cw721_list(deps, start_after, limit)
+        }
+        QueryMsg::DumpState {} => dao_dao_core::contract::query_dump_state(deps, env),
+        QueryMsg::GetItem { key } => dao_dao_core::contract::query_get_item(deps, key),
+        QueryMsg::Info {} => dao_dao_core::contract::query_info(deps),
+        QueryMsg::ListItems { start_after, limit } => dao_dao_core::contract::query_list_items(deps, start_after, limit),
+        QueryMsg::PauseInfo {} => dao_dao_core::contract::query_paused(deps, env),
+        QueryMsg::ProposalModules { start_after, limit } => {
+            dao_dao_core::contract::query_proposal_modules(deps, start_after, limit)
+        }
+        QueryMsg::ProposalModuleCount {} => dao_dao_core::contract::query_proposal_module_count(deps),
+        QueryMsg::TotalPowerAtHeight { height } => dao_dao_core::contract::query_total_power_at_height(deps, height),
+        QueryMsg::VotingModule {} => dao_dao_core::contract::query_voting_module(deps),
+        QueryMsg::VotingPowerAtHeight { address, height } => {
+            dao_dao_core::contract::query_voting_power_at_height(deps, address, height)
+        }
+        QueryMsg::ActiveProposalModules { start_after, limit } => {
+            dao_dao_core::contract::query_active_proposal_modules(deps, start_after, limit)
+        }
+        QueryMsg::ListSubDaos { start_after, limit } => {
+            dao_dao_core::contract::query_list_sub_daos(deps, start_after, limit)
+        }
+        QueryMsg::DaoURI {} => dao_dao_core::contract::query_dao_uri(deps),
+
     }
     .map_err(Into::into)
 }
 
 /// This just stores the result for future query
 #[cfg_attr(feature = "export", cosmwasm_std::entry_point)]
-pub fn reply(_deps: DepsMut, _env: Env, msg: Reply) -> DaoProxyResult {
-    match &msg {
+pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> DaoProxyResult {
+
+    match msg{
         Reply {
             id: RESPONSE_REPLY_ID,
             result: SubMsgResult::Ok(_),
-        } => reply::forward_response_data(msg),
-        _ => Err(ProxyError::UnexpectedReply {}),
+        } => reply::forward_response_data(msg).map_err(Into::into),
+        _=> dao_dao_core::contract::reply(deps, env, msg).map_err(Into::into),
     }
 }
 
@@ -163,7 +208,6 @@ pub fn reply(_deps: DepsMut, _env: Env, msg: Reply) -> DaoProxyResult {
 mod tests {
     use super::*;
     use crate::contract;
-    use crate::test_common::*;
     use cosmwasm_std::testing::*;
     use speculoos::prelude::*;
 
@@ -178,9 +222,12 @@ mod tests {
 
             let version: Version = CONTRACT_VERSION.parse().unwrap();
 
-            let res = contract::migrate(deps.as_mut(), mock_env(), MigrateMsg {});
+            let res = contract::migrate(deps.as_mut(), mock_env(), MigrateMsg { 
+                abstract_account_id: 1, 
+                ans_host_address: "ANS_HOST".to_string()
+            });
 
-            assert_that!(res).is_err().is_equal_to(ProxyError::Abstract(
+            assert_that!(res).is_err().is_equal_to(DaoProxyError::Abstract(
                 AbstractError::CannotDowngradeContract {
                     contract: PROXY.to_string(),
                     from: version.clone(),
@@ -201,9 +248,12 @@ mod tests {
 
             let version: Version = CONTRACT_VERSION.parse().unwrap();
 
-            let res = contract::migrate(deps.as_mut(), mock_env(), MigrateMsg {});
+            let res = contract::migrate(deps.as_mut(), mock_env(), MigrateMsg { 
+                abstract_account_id: 1, 
+                ans_host_address: "ANS_HOST".to_string()
+            });
 
-            assert_that!(res).is_err().is_equal_to(ProxyError::Abstract(
+            assert_that!(res).is_err().is_equal_to(DaoProxyError::Abstract(
                 AbstractError::CannotDowngradeContract {
                     contract: PROXY.to_string(),
                     from: big_version.parse().unwrap(),
@@ -223,9 +273,12 @@ mod tests {
             let old_name = "old:contract";
             cw2::set_contract_version(deps.as_mut().storage, old_name, old_version)?;
 
-            let res = contract::migrate(deps.as_mut(), mock_env(), MigrateMsg {});
+            let res = contract::migrate(deps.as_mut(), mock_env(), MigrateMsg { 
+                abstract_account_id: 1, 
+                ans_host_address: "ANS_HOST".to_string()
+            });
 
-            assert_that!(res).is_err().is_equal_to(ProxyError::Abstract(
+            assert_that!(res).is_err().is_equal_to(DaoProxyError::Abstract(
                 AbstractError::ContractNameMismatch {
                     from: old_name.parse().unwrap(),
                     to: PROXY.parse().unwrap(),
@@ -245,7 +298,10 @@ mod tests {
 
             let version: Version = CONTRACT_VERSION.parse().unwrap();
 
-            let res = contract::migrate(deps.as_mut(), mock_env(), MigrateMsg {})?;
+            let res = contract::migrate(deps.as_mut(), mock_env(), MigrateMsg { 
+                abstract_account_id: 1, 
+                ans_host_address: "ANS_HOST".to_string()
+            })?;
             assert_that!(res.messages).has_length(0);
 
             assert_that!(cw2::get_contract_version(&deps.storage)?.version)

--- a/integrations/daodao-proxy/src/contract.rs
+++ b/integrations/daodao-proxy/src/contract.rs
@@ -1,0 +1,256 @@
+use crate::{error::DaoProxyError, msg::*};
+use abstract_proxy::*;
+use abstract_core::objects::module_version::assert_contract_upgrade;
+use abstract_core::objects::oracle::Oracle;
+use abstract_macros::abstract_response;
+use abstract_sdk::{
+    core::{
+        objects::account_id::ACCOUNT_ID,
+        proxy::{
+            state::{State, ADMIN, ANS_HOST, STATE},
+        },
+        PROXY,
+    },
+    feature_objects::AnsHost,
+};
+use cosmwasm_std::{
+    to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response, SubMsgResult, Empty,
+};
+
+use semver::Version;
+
+pub const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub(crate) const RESPONSE_REPLY_ID: u64 = 1;
+
+#[abstract_response(PROXY)]
+pub struct ProxyResponse;
+
+/// The result type for the proxy contract.
+pub type DaoProxyResult<T = Response> = Result<T, DaoProxyError>;
+
+/*
+    The proxy is the bank account of the account. It owns the liquidity and acts as a proxy contract.
+    Whitelisted dApps construct messages for this contract. The dApps are controlled by the Manager.
+*/
+
+#[cfg_attr(feature = "export", cosmwasm_std::entry_point)]
+pub fn instantiate(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    msg: Empty,
+) -> DaoProxyResult {
+    panic!("Only use this contract through a migration.");
+}
+
+#[cfg_attr(feature = "export", cosmwasm_std::entry_point)]
+pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> DaoProxyResult {
+    // No actions can be performed while the DAO is paused.
+    if let Some(expiration) = PAUSED.may_load(deps.storage)? {
+        if !expiration.is_expired(&env.block) {
+            return Err(ContractError::Paused {});
+        }
+    }
+    match msg {
+        // Abstract Proxy Messages
+        ExecuteMsg::ModuleAction { msgs } => abstract_proxy::commands::execute_module_action(deps, info, msgs).map_err(Into::into),
+        ExecuteMsg::ModuleActionWithData { msg } => abstract_proxy::commands::execute_module_action_response(deps, info, msg).map_err(Into::into),
+        ExecuteMsg::IbcAction { msgs } => abstract_proxy::commands::execute_ibc_action(deps, info, msgs).map_err(Into::into),
+        ExecuteMsg::SetAdmin { admin } => abstract_proxy::commands::set_admin(deps, info, &admin).map_err(Into::into),
+        ExecuteMsg::AddModule { module } => abstract_proxy::commands::add_module(deps, info, module).map_err(Into::into),
+        ExecuteMsg::RemoveModule { module } => abstract_proxy::commands::remove_module(deps, info, module).map_err(Into::into),
+        ExecuteMsg::UpdateAssets { to_add, to_remove } => {
+            abstract_proxy::commands::update_assets(deps, info, to_add, to_remove).map_err(Into::into)
+        },
+        // DaoDao Proxy Messages
+        ExecuteMsg::ExecuteAdminMsgs { msgs } => {
+            dao_dao_core::contract::execute_admin_msgs(deps.as_ref(), info.sender, msgs).map_err(Into::into)
+        }
+        ExecuteMsg::ExecuteProposalHook { msgs } => {
+            dao_dao_core::contract::execute_proposal_hook(deps.as_ref(), info.sender, msgs).map_err(Into::into)
+        }
+        ExecuteMsg::Pause { duration } => dao_dao_core::contract::execute_pause(deps, env, info.sender, duration).map_err(Into::into),
+        ExecuteMsg::Receive(_) => dao_dao_core::contract::execute_receive_cw20(deps, info.sender).map_err(Into::into),
+        ExecuteMsg::ReceiveNft(_) => dao_dao_core::contract::execute_receive_cw721(deps, info.sender).map_err(Into::into),
+        ExecuteMsg::RemoveItem { key } => dao_dao_core::contract::execute_remove_item(deps, env, info.sender, key).map_err(Into::into),
+        ExecuteMsg::SetItem { key, value } => dao_dao_core::contract::execute_set_item(deps, env, info.sender, key, value).map_err(Into::into),
+        ExecuteMsg::UpdateConfig { config } => {
+            dao_dao_core::contract::execute_update_config(deps, env, info.sender, config).map_err(Into::into)
+        }
+        ExecuteMsg::UpdateCw20List { to_add, to_remove } => {
+            dao_dao_core::contract::execute_update_cw20_list(deps, env, info.sender, to_add, to_remove).map_err(Into::into)
+        }
+        ExecuteMsg::UpdateCw721List { to_add, to_remove } => {
+            dao_dao_core::contract::execute_update_cw721_list(deps, env, info.sender, to_add, to_remove).map_err(Into::into)
+        }
+        ExecuteMsg::UpdateVotingModule { module } => {
+            dao_dao_core::contract::execute_update_voting_module(env, info.sender, module).map_err(Into::into)
+        }
+        ExecuteMsg::UpdateProposalModules { to_add, to_disable } => {
+            dao_dao_core::contract::execute_update_proposal_modules(deps, env, info.sender, to_add, to_disable).map_err(Into::into)
+        }
+        ExecuteMsg::NominateAdmin { admin } => {
+            dao_dao_core::contract::execute_nominate_admin(deps, env, info.sender, admin).map_err(Into::into)
+        }
+        ExecuteMsg::AcceptAdminNomination {} => dao_dao_core::contract::execute_accept_admin_nomination(deps, info.sender).map_err(Into::into),
+        ExecuteMsg::WithdrawAdminNomination {} => {
+            dao_dao_core::contract::execute_withdraw_admin_nomination(deps, info.sender).map_err(Into::into)
+        }
+        ExecuteMsg::UpdateSubDaos { to_add, to_remove } => {
+            dao_dao_core::contract::execute_update_sub_daos_list(deps, env, info.sender, to_add, to_remove).map_err(Into::into)
+        }
+    }
+}
+
+#[cfg_attr(feature = "export", cosmwasm_std::entry_point)]
+pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> DaoProxyResult {
+    // Use CW2 to set the contract version, this is needed for migrations
+    cw2::set_contract_version(deps.storage, PROXY, CONTRACT_VERSION)?;
+    ACCOUNT_ID.save(deps.storage, &msg.account_id)?;
+    STATE.save(deps.storage, &State { modules: vec![] })?;
+    ANS_HOST.save(
+        deps.storage,
+        &AnsHost {
+            address: deps.api.addr_validate(&msg.ans_host_address)?,
+        },
+    )?;
+    let admin_addr = Some(info.sender);
+    ADMIN.set(deps, admin_addr)?;
+
+    assert_contract_upgrade(deps.storage, PROXY, version)?;
+    cw2::set_contract_version(deps.storage, PROXY, CONTRACT_VERSION)?;
+    Ok(Response::default())
+}
+
+#[cfg_attr(feature = "export", cosmwasm_std::entry_point)]
+pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> DaoProxyResult<Binary> {
+    match msg {
+        QueryMsg::Config {} => to_binary(&query_config(deps)?),
+        QueryMsg::TotalValue {} => to_binary(&query_total_value(deps, env)?),
+        QueryMsg::HoldingAmount { identifier } => {
+            to_binary(&query_holding_amount(deps, env, identifier)?)
+        }
+        QueryMsg::TokenValue { identifier } => {
+            to_binary(&query_token_value(deps, env, identifier)?)
+        }
+        QueryMsg::AssetConfig { identifier } => to_binary(&AssetConfigResponse {
+            price_source: Oracle::new().asset_config(deps, &identifier)?,
+        }),
+        QueryMsg::AssetsConfig { start_after, limit } => {
+            to_binary(&query_oracle_asset_config(deps, start_after, limit)?)
+        }
+        QueryMsg::AssetsInfo { start_after, limit } => {
+            to_binary(&query_oracle_asset_info(deps, start_after, limit)?)
+        }
+        QueryMsg::BaseAsset {} => to_binary(&query_base_asset(deps)?),
+    }
+    .map_err(Into::into)
+}
+
+/// This just stores the result for future query
+#[cfg_attr(feature = "export", cosmwasm_std::entry_point)]
+pub fn reply(_deps: DepsMut, _env: Env, msg: Reply) -> DaoProxyResult {
+    match &msg {
+        Reply {
+            id: RESPONSE_REPLY_ID,
+            result: SubMsgResult::Ok(_),
+        } => reply::forward_response_data(msg),
+        _ => Err(ProxyError::UnexpectedReply {}),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::contract;
+    use crate::test_common::*;
+    use cosmwasm_std::testing::*;
+    use speculoos::prelude::*;
+
+    mod migrate {
+        use super::*;
+        use abstract_core::AbstractError;
+
+        #[test]
+        fn disallow_same_version() -> DaoProxyResult<()> {
+            let mut deps = mock_dependencies();
+            mock_init(deps.as_mut());
+
+            let version: Version = CONTRACT_VERSION.parse().unwrap();
+
+            let res = contract::migrate(deps.as_mut(), mock_env(), MigrateMsg {});
+
+            assert_that!(res).is_err().is_equal_to(ProxyError::Abstract(
+                AbstractError::CannotDowngradeContract {
+                    contract: PROXY.to_string(),
+                    from: version.clone(),
+                    to: version,
+                },
+            ));
+
+            Ok(())
+        }
+
+        #[test]
+        fn disallow_downgrade() -> DaoProxyResult<()> {
+            let mut deps = mock_dependencies();
+            mock_init(deps.as_mut());
+
+            let big_version = "999.999.999";
+            cw2::set_contract_version(deps.as_mut().storage, PROXY, big_version)?;
+
+            let version: Version = CONTRACT_VERSION.parse().unwrap();
+
+            let res = contract::migrate(deps.as_mut(), mock_env(), MigrateMsg {});
+
+            assert_that!(res).is_err().is_equal_to(ProxyError::Abstract(
+                AbstractError::CannotDowngradeContract {
+                    contract: PROXY.to_string(),
+                    from: big_version.parse().unwrap(),
+                    to: version,
+                },
+            ));
+
+            Ok(())
+        }
+
+        #[test]
+        fn disallow_name_change() -> DaoProxyResult<()> {
+            let mut deps = mock_dependencies();
+            mock_init(deps.as_mut());
+
+            let old_version = "0.0.0";
+            let old_name = "old:contract";
+            cw2::set_contract_version(deps.as_mut().storage, old_name, old_version)?;
+
+            let res = contract::migrate(deps.as_mut(), mock_env(), MigrateMsg {});
+
+            assert_that!(res).is_err().is_equal_to(ProxyError::Abstract(
+                AbstractError::ContractNameMismatch {
+                    from: old_name.parse().unwrap(),
+                    to: PROXY.parse().unwrap(),
+                },
+            ));
+
+            Ok(())
+        }
+
+        #[test]
+        fn works() -> DaoProxyResult<()> {
+            let mut deps = mock_dependencies();
+            mock_init(deps.as_mut());
+
+            let small_version = "0.0.0";
+            cw2::set_contract_version(deps.as_mut().storage, PROXY, small_version)?;
+
+            let version: Version = CONTRACT_VERSION.parse().unwrap();
+
+            let res = contract::migrate(deps.as_mut(), mock_env(), MigrateMsg {})?;
+            assert_that!(res.messages).has_length(0);
+
+            assert_that!(cw2::get_contract_version(&deps.storage)?.version)
+                .is_equal_to(version.to_string());
+            Ok(())
+        }
+    }
+}

--- a/integrations/daodao-proxy/src/error.rs
+++ b/integrations/daodao-proxy/src/error.rs
@@ -1,6 +1,6 @@
 use abstract_core::AbstractError;
 use abstract_sdk::AbstractSdkError;
-use cosmwasm_std::{StdError};
+use cosmwasm_std::StdError;
 use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq)]

--- a/integrations/daodao-proxy/src/error.rs
+++ b/integrations/daodao-proxy/src/error.rs
@@ -1,0 +1,23 @@
+use abstract_core::AbstractError;
+use abstract_sdk::AbstractSdkError;
+use cosmwasm_std::{StdError, Uint128};
+use cw_asset::AssetError;
+use thiserror::Error;
+
+#[derive(Error, Debug, PartialEq)]
+pub enum DaoProxyError {
+    #[error("{0}")]
+    Std(#[from] StdError),
+
+    #[error("{0}")]
+    Abstract(#[from] AbstractError),
+
+    #[error("{0}")]
+    AbstractSdk(#[from] AbstractSdkError),
+
+    #[error("{0}")]
+    ProxyError(#[from] abstract_proxy::error::ProxyError),
+
+    #[error("{0}")]
+    DaoDao(#[from] dao_dao_core::ContractError),
+}

--- a/integrations/daodao-proxy/src/error.rs
+++ b/integrations/daodao-proxy/src/error.rs
@@ -1,7 +1,6 @@
 use abstract_core::AbstractError;
 use abstract_sdk::AbstractSdkError;
-use cosmwasm_std::{StdError, Uint128};
-use cw_asset::AssetError;
+use cosmwasm_std::{StdError};
 use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq)]

--- a/integrations/daodao-proxy/src/lib.rs
+++ b/integrations/daodao-proxy/src/lib.rs
@@ -1,0 +1,21 @@
+pub mod contract;
+mod error;
+pub mod msg;
+
+// #[cfg(test)]
+// mod test_common {
+//     use crate::contract;
+//     use abstract_core::proxy::InstantiateMsg;
+//     use abstract_testing::prelude::*;
+//     use cosmwasm_std::testing::{mock_env, mock_info, MOCK_CONTRACT_ADDR};
+//     use cosmwasm_std::DepsMut;
+
+//     pub fn mock_init(deps: DepsMut) {
+//         let info = mock_info(TEST_MANAGER, &[]);
+//         let msg = InstantiateMsg {
+//             account_id: 0,
+//             ans_host_address: MOCK_CONTRACT_ADDR.to_string(),
+//         };
+//         let _res = contract::instantiate(deps, mock_env(), info, msg).unwrap();
+//     }
+// }

--- a/integrations/daodao-proxy/src/lib.rs
+++ b/integrations/daodao-proxy/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod contract;
 mod error;
 pub mod msg;
+mod patch;
 
 // #[cfg(test)]
 // mod test_common {

--- a/integrations/daodao-proxy/src/msg.rs
+++ b/integrations/daodao-proxy/src/msg.rs
@@ -1,0 +1,182 @@
+//! # Dao Account Proxy
+
+use crate::{
+    ibc_client::ExecuteMsg as IbcClientMsg,
+    objects::{
+        account_id::AccountId,
+        oracle::{AccountValue, Complexity},
+        price_source::{PriceSource, UncheckedPriceSource},
+        AssetEntry,
+    },
+};
+use cosmwasm_schema::QueryResponses;
+use cosmwasm_std::{CosmosMsg, Empty, Uint128};
+use cw_asset::{Asset, AssetInfo};
+
+pub mod state {
+    pub use crate::objects::account_id::ACCOUNT_ID;
+    use cw_controllers::Admin;
+
+    use cosmwasm_std::Addr;
+    use cw_storage_plus::Item;
+
+    use crate::objects::{ans_host::AnsHost, common_namespace::ADMIN_NAMESPACE};
+    #[cosmwasm_schema::cw_serde]
+    pub struct State {
+        pub modules: Vec<Addr>,
+    }
+    pub const ANS_HOST: Item<AnsHost> = Item::new("\u{0}{6}ans_host");
+    pub const STATE: Item<State> = Item::new("\u{0}{5}state");
+    pub const ADMIN: Admin = Admin::new(ADMIN_NAMESPACE);
+}
+
+#[cosmwasm_schema::cw_serde]
+pub struct MigrateMsg {
+
+}
+
+
+#[cosmwasm_schema::cw_serde]
+#[cfg_attr(feature = "interface", derive(cw_orch::ExecuteFns))]
+pub enum ExecuteMsg {
+    
+    // # Abstract Messages
+    /// Sets the admin
+    SetAdmin { admin: String },
+    /// Executes the provided messages if sender is whitelisted
+    ModuleAction { msgs: Vec<CosmosMsg<Empty>> },
+    /// Execute a message and forward the Response data
+    ModuleActionWithData { msg: CosmosMsg<Empty> },
+    /// Execute IBC action on Client
+    IbcAction { msgs: Vec<IbcClientMsg> },
+    /// Adds the provided address to whitelisted dapps
+    AddModule { module: String },
+    /// Removes the provided address from the whitelisted dapps
+    RemoveModule { module: String },
+    /// Updates the VAULT_ASSETS map
+    UpdateAssets {
+        to_add: Vec<(AssetEntry, UncheckedPriceSource)>,
+        to_remove: Vec<AssetEntry>,
+    },
+    
+    // # DAO-DAO Messages
+    /// Callable by the Admin, if one is configured.
+    /// Executes messages in order.
+    ExecuteAdminMsgs { msgs: Vec<CosmosMsg<Empty>> },
+    /// Callable by proposal modules. The DAO will execute the
+    /// messages in the hook in order.
+    ExecuteProposalHook { msgs: Vec<CosmosMsg<Empty>> },
+    /// Pauses the DAO for a set duration.
+    /// When paused the DAO is unable to execute proposals
+    Pause { duration: Duration },
+    /// Executed when the contract receives a cw20 token. Depending on
+    /// the contract's configuration the contract will automatically
+    /// add the token to its treasury.
+    Receive(cw20::Cw20ReceiveMsg),
+    /// Executed when the contract receives a cw721 token. Depending
+    /// on the contract's configuration the contract will
+    /// automatically add the token to its treasury.
+    ReceiveNft(cw721::Cw721ReceiveMsg),
+    /// Removes an item from the governance contract's item map.
+    RemoveItem { key: String },
+    /// Adds an item to the governance contract's item map. If the
+    /// item already exists the existing value is overridden. If the
+    /// item does not exist a new item is added.
+    SetItem { key: String, value: String },
+    /// Callable by the admin of the contract. If ADMIN is None the
+    /// admin is set as the contract itself so that it may be updated
+    /// later by vote. If ADMIN is Some a new admin is proposed and
+    /// that new admin may become the admin by executing the
+    /// `AcceptAdminNomination` message.
+    ///
+    /// If there is already a pending admin nomination the
+    /// `WithdrawAdminNomination` message must be executed before a
+    /// new admin may be nominated.
+    NominateAdmin { admin: Option<String> },
+    /// Callable by a nominated admin. Admins are nominated via the
+    /// `NominateAdmin` message. Accepting a nomination will make the
+    /// nominated address the new admin.
+    ///
+    /// Requiring that the new admin accepts the nomination before
+    /// becoming the admin protects against a typo causing the admin
+    /// to change to an invalid address.
+    AcceptAdminNomination {},
+    /// Callable by the current admin. Withdraws the current admin
+    /// nomination.
+    WithdrawAdminNomination {},
+    /// Callable by the core contract. Replaces the current
+    /// governance contract config with the provided config.
+    UpdateConfig { config: Config },
+    /// Updates the list of cw20 tokens this contract has registered.
+    UpdateCw20List {
+        to_add: Vec<String>,
+        to_remove: Vec<String>,
+    },
+    /// Updates the list of cw721 tokens this contract has registered.
+    UpdateCw721List {
+        to_add: Vec<String>,
+        to_remove: Vec<String>,
+    },
+    /// Updates the governance contract's governance modules. Module
+    /// instantiate info in `to_add` is used to create new modules and
+    /// install them.
+    UpdateProposalModules {
+        /// NOTE: the pre-propose-base package depends on it being the
+        /// case that the core module instantiates its proposal module.
+        to_add: Vec<ModuleInstantiateInfo>,
+        to_disable: Vec<String>,
+    },
+    /// Callable by the core contract. Replaces the current
+    /// voting module with a new one instantiated by the governance
+    /// contract.
+    UpdateVotingModule { module: ModuleInstantiateInfo },
+    /// Update the core module to add/remove SubDAOs and their charters
+    UpdateSubDaos {
+        to_add: Vec<SubDao>,
+        to_remove: Vec<String>,
+    },
+}
+
+#[cosmwasm_schema::cw_serde]
+#[derive(QueryResponses)]
+#[cfg_attr(feature = "interface", derive(cw_orch::QueryFns))]
+pub enum QueryMsg {
+    /// Contains the enabled modules
+    /// Returns [`ConfigResponse`]
+    #[returns(abstract_core::proxy::ConfigResponse)]
+    Config {},
+    /// Returns the total value of the assets held by this account
+    /// [`AccountValue`]
+    #[returns(abstract_core::objects::oracle::AccountValue)]
+    TotalValue {},
+    /// Returns the value of one token with an optional amount set.
+    /// If amount is not set, the account's balance of the token is used.
+    /// [`TokenValueResponse`]
+    #[returns(abstract_core::proxy::TokenValueResponse)]
+    TokenValue { identifier: AssetEntry },
+    /// Returns the amount of specified tokens this contract holds
+    /// [`HoldingAmountResponse`]
+    #[returns(abstract_core::proxy::HoldingAmountResponse)]
+    HoldingAmount { identifier: AssetEntry },
+    /// Returns the oracle configuration value for the specified key
+    /// [`AssetConfigResponse`]
+    #[returns(abstract_core::proxy::AssetConfigResponse)]
+    AssetConfig { identifier: AssetEntry },
+    /// Returns [`AssetsConfigResponse`]
+    /// Human readable
+    #[returns(abstract_core::proxy::AssetsConfigResponse)]
+    AssetsConfig {
+        start_after: Option<AssetEntry>,
+        limit: Option<u8>,
+    },
+    /// Returns [`AssetsInfoResponse`]
+    /// Not human readable
+    #[returns(abstract_core::proxy::AssetsInfoResponse)]
+    AssetsInfo {
+        start_after: Option<AssetInfo>,
+        limit: Option<u8>,
+    },
+    /// Returns [`BaseAssetResponse`]
+    #[returns(abstract_core::proxy::BaseAssetResponse)]
+    BaseAsset {},
+}

--- a/integrations/daodao-proxy/src/msg.rs
+++ b/integrations/daodao-proxy/src/msg.rs
@@ -1,17 +1,14 @@
 //! # Dao Account Proxy
 
-use cw_utils::Duration;
-use dao_interface::state::ModuleInstantiateInfo;
 use abstract_core::{
     ibc_client::ExecuteMsg as IbcClientMsg,
-    objects::{
-        price_source::{UncheckedPriceSource},
-        AssetEntry,
-    },
+    objects::{price_source::UncheckedPriceSource, AssetEntry},
 };
 use cosmwasm_schema::QueryResponses;
 use cosmwasm_std::{CosmosMsg, Empty};
-use cw_asset::{AssetInfo};
+use cw_asset::AssetInfo;
+use cw_utils::Duration;
+use dao_interface::state::ModuleInstantiateInfo;
 
 pub mod state {
     pub use abstract_core::objects::account_id::ACCOUNT_ID;
@@ -36,11 +33,9 @@ pub struct MigrateMsg {
     pub ans_host_address: String,
 }
 
-
 #[cosmwasm_schema::cw_serde]
 #[cfg_attr(feature = "interface", derive(cw_orch::ExecuteFns))]
 pub enum ExecuteMsg {
-    
     // # Abstract Messages
     /// Sets the admin
     SetAdmin { admin: String },
@@ -59,7 +54,7 @@ pub enum ExecuteMsg {
         to_add: Vec<(AssetEntry, UncheckedPriceSource)>,
         to_remove: Vec<AssetEntry>,
     },
-    
+
     // # DAO-DAO Messages
     /// Callable by the Admin, if one is configured.
     /// Executes messages in order.
@@ -107,7 +102,9 @@ pub enum ExecuteMsg {
     WithdrawAdminNomination {},
     /// Callable by the core contract. Replaces the current
     /// governance contract config with the provided config.
-    UpdateConfig { config: dao_interface::state::Config },
+    UpdateConfig {
+        config: dao_interface::state::Config,
+    },
     /// Updates the list of cw20 tokens this contract has registered.
     UpdateCw20List {
         to_add: Vec<String>,
@@ -142,7 +139,6 @@ pub enum ExecuteMsg {
 #[derive(QueryResponses)]
 #[cfg_attr(feature = "interface", derive(cw_orch::QueryFns))]
 pub enum QueryMsg {
-
     // # Abstract Messages
     /// Contains the enabled modules
     /// Returns [`ConfigResponse`]
@@ -182,7 +178,6 @@ pub enum QueryMsg {
     /// Returns [`BaseAssetResponse`]
     #[returns(abstract_core::proxy::BaseAssetResponse)]
     BaseAsset {},
-
 
     // # DAO-DAO Messages
     /// Get's the DAO's admin. Returns `Addr`.
@@ -224,7 +219,7 @@ pub enum QueryMsg {
     DumpState {},
     /// Gets the address associated with an item key.
     #[returns(dao_interface::query::GetItemResponse)]
-    GetItem { key: String }, 
+    GetItem { key: String },
     /// Lists all of the items associted with the contract. For
     /// example, given the items `{ "group": "foo", "subdao": "bar"}`
     /// this query would return `[("group", "foo"), ("subdao",

--- a/integrations/daodao-proxy/src/patch.rs
+++ b/integrations/daodao-proxy/src/patch.rs
@@ -1,0 +1,32 @@
+
+
+use abstract_proxy::error::ProxyError;
+use cosmwasm_std::SubMsg;
+use crate::contract::RESPONSE_REPLY_ID;
+use abstract_core::proxy::state::STATE;
+use abstract_proxy::contract::ProxyResponse;
+use cosmwasm_std::Empty;
+use abstract_proxy::contract::ProxyResult;
+use cosmwasm_std::DepsMut;
+
+use cosmwasm_std::MessageInfo;
+
+use cosmwasm_std::CosmosMsg;
+
+/// Executes actions forwarded by whitelisted contracts
+/// This contracts acts as a proxy contract for the dApps
+/// This function patches the one defined in the original crate to have a different reply id for the module action submsg
+pub fn execute_module_action_response(
+    deps: DepsMut,
+    msg_info: MessageInfo,
+    msg: CosmosMsg<Empty>,
+) -> ProxyResult {
+    let state = STATE.load(deps.storage)?;
+    if !state.modules.contains(&msg_info.sender) {
+        return Err(ProxyError::SenderNotWhitelisted {});
+    }
+
+    let submsg = SubMsg::reply_on_success(msg, RESPONSE_REPLY_ID);
+
+    Ok(ProxyResponse::action("execute_module_action_response").add_submessage(submsg))
+}

--- a/integrations/daodao-proxy/src/patch.rs
+++ b/integrations/daodao-proxy/src/patch.rs
@@ -1,13 +1,11 @@
-
-
-use abstract_proxy::error::ProxyError;
-use cosmwasm_std::SubMsg;
 use crate::contract::RESPONSE_REPLY_ID;
 use abstract_core::proxy::state::STATE;
 use abstract_proxy::contract::ProxyResponse;
-use cosmwasm_std::Empty;
 use abstract_proxy::contract::ProxyResult;
+use abstract_proxy::error::ProxyError;
 use cosmwasm_std::DepsMut;
+use cosmwasm_std::Empty;
+use cosmwasm_std::SubMsg;
 
 use cosmwasm_std::MessageInfo;
 


### PR DESCRIPTION
This integration allows dao's to be merged with abstract accounts. 


## Process

The process is triggered by a dao migration. During the migration the required account-specific data is set on the proxy by the account factory (account-id). In essence only the version control contract should be provided in the migrate message as the other data can be queried from that address. A new endpoint on the factory should be introduced that allows a proxy contract to register itself to the account registry. The validity of the proxy contract can be checked by asserting that the contract's code-id is available in the registry under a specific key (abstract:dao-proxy).

The dao proxy contract is a mix of the dao-dao and abstract proxy contracts. During migration a new manager is created and its owner is set to the proxy contract. This allows for dao-managed account execution as well as sub-accounts owned by the dao (proxy).

The beauty about this way of implementing the integration is that the code to maintain is minimal (we import and re-use all the execute and query logic). It's also fully compatible with both codebases as the entry point messages are merged.

## Goal

Dao's will be able to manage and monetize dao-owned code and create and manage applications as sub-accounts.