### PR TITLE
Add lazy_static initialization for astroport chains

### DIFF
--- a/framework/contracts/account/manager/tests/adapters.rs
+++ b/framework/contracts/account/manager/tests/adapters.rs
@@ -371,7 +371,7 @@ fn installing_specific_version_should_install_expected() -> AResult {
 fn account_install_adapter() -> AResult {
     let sender = Addr::unchecked(common::OWNER);
     let chain = Mock::new(&sender);
-    let deployment = Abstract::deploy_on(chain.clone(), common::OWNER.to_string())?;
+    let deployment = Abstract::deploy_on(chain.clone(), sender.to_string())?;
     let account = create_default_account(&deployment.account_factory)?;
 
     deployment

--- a/framework/contracts/account/manager/tests/adapters.rs
+++ b/framework/contracts/account/manager/tests/adapters.rs
@@ -371,7 +371,7 @@ fn installing_specific_version_should_install_expected() -> AResult {
 fn account_install_adapter() -> AResult {
     let sender = Addr::unchecked(common::OWNER);
     let chain = Mock::new(&sender);
-    let deployment = Abstract::deploy_on(chain.clone(), Empty {})?;
+    let deployment = Abstract::deploy_on(chain.clone(), common::OWNER.to_string())?;
     let account = create_default_account(&deployment.account_factory)?;
 
     deployment

--- a/framework/contracts/account/manager/tests/apps.rs
+++ b/framework/contracts/account/manager/tests/apps.rs
@@ -59,7 +59,7 @@ fn execute_on_proxy_through_manager() -> AResult {
 fn account_install_app() -> AResult {
     let sender = Addr::unchecked(common::OWNER);
     let chain = Mock::new(&sender);
-    let deployment = Abstract::deploy_on(chain.clone(), Empty {})?;
+    let deployment = Abstract::deploy_on(chain.clone(), sender.to_string())?;
     let account = create_default_account(&deployment.account_factory)?;
 
     deployment

--- a/framework/contracts/account/manager/tests/upgrades.rs
+++ b/framework/contracts/account/manager/tests/upgrades.rs
@@ -363,7 +363,7 @@ fn update_adapter_with_authorized_addrs() -> AResult {
 fn upgrade_manager_last() -> AResult {
     let sender = Addr::unchecked(common::OWNER);
     let chain = Mock::new(&sender);
-    let abstr = Abstract::deploy_on(chain.clone(), None)?;
+    let abstr = Abstract::deploy_on(chain.clone(), sender.to_string())?;
     let account = create_default_account(&abstr.account_factory)?;
     let AbstractAccount { manager, proxy: _ } = &account;
 

--- a/framework/packages/abstract-core/src/registry.rs
+++ b/framework/packages/abstract-core/src/registry.rs
@@ -19,9 +19,10 @@ pub const ICS20: &str = "ics-20";
 
 // chain-id prefixes based on `https://cosmos.directory/`
 pub const JUNO: &[&str] = &["juno", "uni"];
-pub const OSMOSIS: &[&str] = &["osmosis", "osmo"];
+pub const OSMOSIS: &[&str] = &["osmosis", "osmo", "osmo-test"];
 pub const TERRA: &[&str] = &["phoenix", "pisco"];
 pub const KUJIRA: &[&str] = &["kaiyo", "harpoon"];
+pub const NEUTRON: &[&str] = &["pion", "neutron"];
 pub const ARCHWAY: &[&str] = &["constantine"];
 pub const LOCAL_CHAIN: &[&str] = &["cosmos-testnet"];
 /// Useful when deploying version control

--- a/integrations/astroport/packages/abstract-adapter/Cargo.toml
+++ b/integrations/astroport/packages/abstract-adapter/Cargo.toml
@@ -10,13 +10,7 @@ repository = "https://github.com/astroport-fi/astroport"
 [features]
 default = ["full_integration"]
 local = []
-full_integration = [
-  "dep:cw20",
-  "dep:cosmwasm-schema",
-  "dep:cw-asset",
-  "dep:cw-utils",
-  "dep:astroport",
-]
+full_integration = ["dep:cw20", "dep:cosmwasm-schema", "dep:cw-asset", "dep:cw-utils", "dep:astroport"]
 
 [dependencies]
 cosmwasm-std = { version = "1.1" }
@@ -31,6 +25,7 @@ cw-asset = { version = "3.0.0", optional = true }
 cw-utils = { version = "1.0.1", optional = true }
 
 astroport = { path = "../astroport/", optional = true }
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 abstract-dex-adapter-traits = { path = "../../../../framework/packages/dex", features = [

--- a/integrations/astroport/packages/abstract-adapter/src/lib.rs
+++ b/integrations/astroport/packages/abstract-adapter/src/lib.rs
@@ -2,7 +2,14 @@ pub const ASTROPORT: &str = "astroport";
 #[cfg(feature = "local")]
 pub const AVAILABLE_CHAINS: &[&str] = abstract_sdk::core::registry::LOCAL_CHAIN;
 #[cfg(not(feature = "local"))]
-pub const AVAILABLE_CHAINS: &[&str] = abstract_sdk::core::registry::TERRA;
+lazy_static::lazy_static! {
+    pub static ref AVAILABLE_CHAINS: Vec<&'static str> = {
+        let mut v = Vec::new();
+        v.extend_from_slice(abstract_sdk::core::registry::OSMOSIS);
+        v.extend_from_slice(abstract_sdk::core::registry::TERRA);
+        v
+    };
+}
 
 pub mod dex;
 pub mod staking;


### PR DESCRIPTION
This change adds neutron's mainnet and testnet as supported chains for Astroport.