### PR TITLE
Bump to 0.17.2 to add neutron to abstract_sdk registry

### DIFF
--- a/app-template/Cargo.toml
+++ b/app-template/Cargo.toml
@@ -41,19 +41,19 @@ thiserror = { version = "1.0" }
 schemars = "0.8"
 cw-asset = { version = "3.0" }
 
-abstract-core = { version = "0.17.0" }
-abstract-app = { version = "0.17.0" }
-abstract-sdk = { version = "0.17.0" }
+abstract-core = { version = "0.17.2" }
+abstract-app = { version = "0.17.2" }
+abstract-sdk = { version = "0.17.2" }
 
 # Dependencies for interface
-abstract-interface = { version = "0.17.0", optional = true }
+abstract-interface = { version = "0.17.2", optional = true }
 cw-orch = { version = "0.13", optional = true }
 
 [dev-dependencies]
 app = { path = ".", features = ["interface"] }
-abstract-interface = { version = "0.17.0", features = ["daemon"] }
-abstract-testing = { version = "0.17.0" }
-abstract-sdk = { version = "0.17.0", features = ["test-utils"] }
+abstract-interface = { version = "0.17.2", features = ["daemon"] }
+abstract-testing = { version = "0.17.2" }
+abstract-sdk = { version = "0.17.2", features = ["test-utils"] }
 speculoos = "0.11.0"
 semver = "1.0"
 dotenv = "0.15.0"

--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+## [0.17.2] - 2023-07-27
+
+### Added
+- Neutron + Archway to registry
+
+### Changed
+
+### Fixed
+
 ## [0.17.0] - 2023-07-05
 
 ### Added

--- a/framework/Cargo.toml
+++ b/framework/Cargo.toml
@@ -12,7 +12,7 @@ members = ["packages/*", "contracts/native/*", "contracts/account/*", "scripts"]
 resolver = "2"
 
 [workspace.package]
-version = "0.17.0"
+version = "0.17.2"
 authors = [
   "CyberHoward <cyberhoward@protonmail.com>",
   "Riada <riada@abstract.money>",
@@ -52,8 +52,8 @@ tokio = { version = "1.4", features = ["full"] }
 
 ## crates in order of publishing ## see docs/Publishing.md
 
-abstract-adapter = { version = "0.17.0", path = "packages/abstract-adapter" }
-abstract-app = { version = "0.17.0", path = "packages/abstract-app" }
+abstract-adapter = { version = "0.17.2", path = "packages/abstract-adapter" }
+abstract-app = { version = "0.17.2", path = "packages/abstract-app" }
 
 # Keep these as path, creates cirular dependency otherwise
 # Only need to re-publish all contracts if a re-publish of abstract-interface is required
@@ -65,15 +65,15 @@ version-control = { package = "abstract-version-control", path = "contracts/nati
 proxy = { package = "abstract-proxy", path = "contracts/account/proxy" }
 manager = { package = "abstract-manager", path = "contracts/account/manager" }
 
-abstract-sdk = { version = "0.17.0", path = "packages/abstract-sdk" }
-abstract-testing = { version = "0.17.0", path = "packages/abstract-testing" }
-abstract-core = { version = "0.17.0", path = "packages/abstract-core" }
+abstract-sdk = { version = "0.17.2", path = "packages/abstract-sdk" }
+abstract-testing = { version = "0.17.2", path = "packages/abstract-testing" }
+abstract-core = { version = "0.17.2", path = "packages/abstract-core" }
 
 # These should remain fixed and don't need to be re-published (unless changes are made)
-abstract-macros = { version = "0.17.0", path = "packages/abstract-macros" }
-abstract-ica = { version = "0.17.0", path = "packages/abstract-ica" }
+abstract-macros = { version = "0.17.2", path = "packages/abstract-macros" }
+abstract-ica = { version = "0.17.2", path = "packages/abstract-ica" }
 
-abstract-adapter-utils = { version = "0.17.0", path = "packages/utils" }
+abstract-adapter-utils = { version = "0.17.2", path = "packages/utils" }
 abstract-dex-adapter-traits = { path = "packages/dex" }
 abstract-staking-adapter-traits = { path = "packages/staking" }
 

--- a/framework/packages/abstract-adapter/Cargo.toml
+++ b/framework/packages/abstract-adapter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "abstract-adapter"
-version = "0.17.0"
+version = "0.17.2"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
@@ -30,7 +30,7 @@ abstract-core = { workspace = true }
 abstract-testing = { workspace = true, optional = true }
 cw-orch = { workspace = true, optional = true }
 # Keep this as a version and update when publishing new versions
-abstract-interface = { path = "../../packages/abstract-interface", version = "0.17.0", optional = true }
+abstract-interface = { path = "../../packages/abstract-interface", version = "0.17.2", optional = true }
 
 [dev-dependencies]
 speculoos = { workspace = true }

--- a/framework/packages/abstract-app/Cargo.toml
+++ b/framework/packages/abstract-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "abstract-app"
-version = "0.17.0"
+version = "0.17.2"
 edition = { workspace = true }
 license = { workspace = true }
 description = "base app contract implementation"
@@ -30,7 +30,7 @@ abstract-core = { workspace = true }
 abstract-testing = { workspace = true, optional = true }
 cw-orch = { workspace = true, optional = true }
 # Keep this as a version and update when publishing new versions
-abstract-interface = { path = "../../packages/abstract-interface", version = "0.17.0", optional = true }
+abstract-interface = { path = "../../packages/abstract-interface", version = "0.17.2", optional = true }
 
 [dev-dependencies]
 cosmwasm-schema = { workspace = true }

--- a/framework/packages/abstract-core/src/registry.rs
+++ b/framework/packages/abstract-core/src/registry.rs
@@ -19,9 +19,10 @@ pub const ICS20: &str = "ics-20";
 
 // chain-id prefixes based on `https://cosmos.directory/`
 pub const JUNO: &[&str] = &["juno", "uni"];
-pub const OSMOSIS: &[&str] = &["osmosis", "osmo"];
+pub const OSMOSIS: &[&str] = &["osmosis", "osmo", "osmo-test"];
 pub const TERRA: &[&str] = &["phoenix", "pisco"];
 pub const KUJIRA: &[&str] = &["kaiyo", "harpoon"];
+pub const NEUTRON: &[&str] = &["pion", "neutron"];
 pub const ARCHWAY: &[&str] = &["constantine"];
 pub const LOCAL_CHAIN: &[&str] = &["cosmos-testnet"];
 /// Useful when deploying version control

--- a/framework/packages/abstract-core/src/registry.rs
+++ b/framework/packages/abstract-core/src/registry.rs
@@ -23,7 +23,7 @@ pub const OSMOSIS: &[&str] = &["osmosis", "osmo", "osmo-test"];
 pub const TERRA: &[&str] = &["phoenix", "pisco"];
 pub const KUJIRA: &[&str] = &["kaiyo", "harpoon"];
 pub const NEUTRON: &[&str] = &["pion", "neutron"];
-pub const ARCHWAY: &[&str] = &["constantine"];
+pub const ARCHWAY: &[&str] = &["constantine", "archway"];
 pub const LOCAL_CHAIN: &[&str] = &["cosmos-testnet"];
 /// Useful when deploying version control
 #[allow(unused)]

--- a/framework/packages/abstract-interface/Cargo.toml
+++ b/framework/packages/abstract-interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "abstract-interface"
-version = "0.17.0"
+version = "0.17.2"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Abstract deployment helpers with cw-orchestrator"
@@ -30,12 +30,12 @@ serde_json = "1.0.79"
 speculoos = { workspace = true }
 
 # Keep these here
-module-factory = { package = "abstract-module-factory", path = "../../contracts/native/module-factory", default-features = false, version = "0.17.0" }
-account-factory = { package = "abstract-account-factory", path = "../../contracts/native/account-factory", default-features = false, version = "0.17.0" }
-ans-host = { package = "abstract-ans-host", path = "../../contracts/native/ans-host", default-features = false, version = "0.17.0" }
-version-control = { package = "abstract-version-control", path = "../../contracts/native/version-control", default-features = false, version = "0.17.0" }
-proxy = { package = "abstract-proxy", path = "../../contracts/account/proxy", default-features = false, version = "0.17.0" }
-manager = { package = "abstract-manager", path = "../../contracts/account/manager", default-features = false, version = "0.17.0" }
+module-factory = { package = "abstract-module-factory", path = "../../contracts/native/module-factory", default-features = false, version = "0.17.2" }
+account-factory = { package = "abstract-account-factory", path = "../../contracts/native/account-factory", default-features = false, version = "0.17.2" }
+ans-host = { package = "abstract-ans-host", path = "../../contracts/native/ans-host", default-features = false, version = "0.17.2" }
+version-control = { package = "abstract-version-control", path = "../../contracts/native/version-control", default-features = false, version = "0.17.2" }
+proxy = { package = "abstract-proxy", path = "../../contracts/account/proxy", default-features = false, version = "0.17.2" }
+manager = { package = "abstract-manager", path = "../../contracts/account/manager", default-features = false, version = "0.17.2" }
 
 [build-dependencies]
 serde_json = "1.0.79"

--- a/framework/publish/packages.sh
+++ b/framework/publish/packages.sh
@@ -13,7 +13,9 @@ then
     exit 1
 fi
 
-ALL_PACKAGES="abstract-interface abstract-adapter abstract-app abstract-ibc-host"
+ALL_PACKAGES="abstract-interface abstract-adapter abstract-app abstract-ibc-host utils"
+# These need to update the dependency of abstract-interface to use the version
+OTHER_PACKAGES="dex staking"
 
 for pack in $ALL_PACKAGES; do
   (
@@ -23,7 +25,26 @@ for pack in $ALL_PACKAGES; do
   )
 done
 
-echo "Everything is published!"
+echo "Packages are published!"
+
+read -p "Please update the version of 'abstract-interface' to the published version and type 'yes' to continue: " input
+if [ "$input" != "yes" ]
+then
+  echo "The script will terminate now. Please run it again after updating the version."
+  exit 1
+fi
+
+echo "Continuing with the publication of other packages..."
+
+for pack in $OTHER_PACKAGES; do
+  (
+    cd "packages/$pack"
+    echo "Publishing $pack"
+    cargo publish --allow-dirty
+  )
+done
+
+echo "All packages have been published!"
 
 # VERSION=$(grep -A1 "\[workspace.package\]" Cargo.toml | awk -F'"' '/version/ {print $2}');
 # git tag v"$VERSION"

--- a/integrations/astroport/packages/abstract-adapter/Cargo.toml
+++ b/integrations/astroport/packages/abstract-adapter/Cargo.toml
@@ -10,13 +10,7 @@ repository = "https://github.com/astroport-fi/astroport"
 [features]
 default = ["full_integration"]
 local = []
-full_integration = [
-  "dep:cw20",
-  "dep:cosmwasm-schema",
-  "dep:cw-asset",
-  "dep:cw-utils",
-  "dep:astroport",
-]
+full_integration = ["dep:cw20", "dep:cosmwasm-schema", "dep:cw-asset", "dep:cw-utils", "dep:astroport"]
 
 [dependencies]
 cosmwasm-std = { version = "1.1" }
@@ -31,6 +25,7 @@ cw-asset = { version = "3.0.0", optional = true }
 cw-utils = { version = "1.0.1", optional = true }
 
 astroport = { path = "../astroport/", optional = true }
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 abstract-dex-adapter-traits = { version = "0.17.1", features = ["testing"] }

--- a/integrations/astroport/packages/abstract-adapter/Cargo.toml
+++ b/integrations/astroport/packages/abstract-adapter/Cargo.toml
@@ -14,9 +14,9 @@ full_integration = ["dep:cw20", "dep:cosmwasm-schema", "dep:cw-asset", "dep:cw-u
 
 [dependencies]
 cosmwasm-std = { version = "1.1" }
-abstract-staking-adapter-traits = { version = "0.17.1" }
-abstract-dex-adapter-traits = { version = "0.17.1" }
-abstract-sdk = { version = "0.17.0" }
+abstract-staking-adapter-traits = { version = "0.17.3" }
+abstract-dex-adapter-traits = { version = "0.17.3" }
+abstract-sdk = { version = "0.17.2" }
 
 
 cw20 = { version = "0.15", optional = true }
@@ -28,7 +28,7 @@ astroport = { path = "../astroport/", optional = true }
 lazy_static = "1.4.0"
 
 [dev-dependencies]
-abstract-dex-adapter-traits = { version = "0.17.1", features = ["testing"] }
+abstract-dex-adapter-traits = { version = "0.17.3", features = ["testing"] }
 cw-orch = { version = "0.13", features = ["daemon"] }
 ibc-chain-registry = "0.24.1"
 

--- a/integrations/astroport/packages/abstract-adapter/Cargo.toml
+++ b/integrations/astroport/packages/abstract-adapter/Cargo.toml
@@ -14,8 +14,8 @@ full_integration = ["dep:cw20", "dep:cosmwasm-schema", "dep:cw-asset", "dep:cw-u
 
 [dependencies]
 cosmwasm-std = { version = "1.1" }
-abstract-staking-adapter-traits = { version = "0.17.3" }
-abstract-dex-adapter-traits = { version = "0.17.3" }
+abstract-staking-adapter-traits = { version = "0.17.2" }
+abstract-dex-adapter-traits = { version = "0.17.2" }
 abstract-sdk = { version = "0.17.2" }
 
 
@@ -28,7 +28,7 @@ astroport = { path = "../astroport/", optional = true }
 lazy_static = "1.4.0"
 
 [dev-dependencies]
-abstract-dex-adapter-traits = { version = "0.17.3", features = ["testing"] }
+abstract-dex-adapter-traits = { version = "0.17.2", features = ["testing"] }
 cw-orch = { version = "0.13", features = ["daemon"] }
 ibc-chain-registry = "0.24.1"
 

--- a/integrations/astroport/packages/abstract-adapter/src/lib.rs
+++ b/integrations/astroport/packages/abstract-adapter/src/lib.rs
@@ -2,7 +2,14 @@ pub const ASTROPORT: &str = "astroport";
 #[cfg(feature = "local")]
 pub const AVAILABLE_CHAINS: &[&str] = abstract_sdk::core::registry::LOCAL_CHAIN;
 #[cfg(not(feature = "local"))]
-pub const AVAILABLE_CHAINS: &[&str] = abstract_sdk::core::registry::TERRA;
+lazy_static::lazy_static! {
+    pub static ref AVAILABLE_CHAINS: Vec<&'static str> = {
+        let mut v = Vec::new();
+        v.extend_from_slice(abstract_sdk::core::registry::NEUTRON);
+        v.extend_from_slice(abstract_sdk::core::registry::TERRA);
+        v
+    };
+}
 
 pub mod dex;
 pub mod staking;

--- a/integrations/osmosis/packages/abstract-adapter/Cargo.toml
+++ b/integrations/osmosis/packages/abstract-adapter/Cargo.toml
@@ -18,13 +18,13 @@ full_integration = [
 
 [dependencies]
 cosmwasm-std = { version = "1.1.2", features = ["stargate"] }
-abstract-core = { version = "0.17.0" }
-abstract-staking-adapter-traits = { version = "0.17.1" }
-abstract-dex-adapter-traits = { version = "0.17.1" }
+abstract-core = { version = "0.17.2" }
+abstract-staking-adapter-traits = { version = "0.17.3" }
+abstract-dex-adapter-traits = { version = "0.17.3" }
 
 #Abstract dependencies 
 cw20 = { version = "0.15", optional = true }
-abstract-sdk = { version = "0.17.0", optional = true }
+abstract-sdk = { version = "0.17.2", optional = true }
 cw-asset = { version = "3.0.0", optional = true }
 cw-utils = { version = "1.0.1", optional = true }
 osmosis-std = { path = "../osmosis-std/", optional = true }

--- a/integrations/osmosis/packages/abstract-adapter/Cargo.toml
+++ b/integrations/osmosis/packages/abstract-adapter/Cargo.toml
@@ -19,8 +19,8 @@ full_integration = [
 [dependencies]
 cosmwasm-std = { version = "1.1.2", features = ["stargate"] }
 abstract-core = { version = "0.17.2" }
-abstract-staking-adapter-traits = { version = "0.17.3" }
-abstract-dex-adapter-traits = { version = "0.17.3" }
+abstract-staking-adapter-traits = { version = "0.17.2" }
+abstract-dex-adapter-traits = { version = "0.17.2" }
 
 #Abstract dependencies 
 cw20 = { version = "0.15", optional = true }

--- a/integrations/wyndex/packages/wyndex-adapter/Cargo.toml
+++ b/integrations/wyndex/packages/wyndex-adapter/Cargo.toml
@@ -23,9 +23,9 @@ full_integration = [
 [dependencies]
 cosmwasm-std = { workspace = true }
 
-abstract-sdk = { version = "0.17.0" }
-abstract-staking-adapter-traits = { version = "0.17.0" }
-abstract-dex-adapter-traits = { version = "0.17.0" }
+abstract-sdk = { version = "0.17.2" }
+abstract-staking-adapter-traits = { version = "0.17.2" }
+abstract-dex-adapter-traits = { version = "0.17.2" }
 
 # Optional
 wyndex = { path = "../wyndex/", optional = true }

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -68,9 +68,9 @@ abstract-macros = { version = "0.17.2" }
 abstract-ica = { version = "0.17.2" }
 
 abstract-dex-adapter = { path = "./contracts/adapters/dex" }
-abstract-adapter-utils = { version = "0.17.3" }
-abstract-dex-adapter-traits = { version = "0.17.3" }
-abstract-staking-adapter-traits = { version = "0.17.3" }
+abstract-adapter-utils = { version = "0.17.2" }
+abstract-dex-adapter-traits = { version = "0.17.2" }
+abstract-staking-adapter-traits = { version = "0.17.2" }
 
 # Juno dexes #
 abstract-wyndex-adapter = { path = "../integrations/wyndex/packages/wyndex-adapter", default-features = false }

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.17.0"
+version = "0.17.2"
 authors = [
   "CyberHoward <cyberhoward@protonmail.com>",
   "Riada <riada@abstract.money>",
@@ -58,19 +58,19 @@ tokio = { version = "1.4", features = ["full"] }
 
 ## crates in order of publishing ## see docs/Publishing.md
 
-abstract-interface = { version = "0.17.0" }
-abstract-adapter = { version = "0.17.0" }
-abstract-app = { version = "0.17.0" }
-abstract-sdk = { version = "0.17.0" }
-abstract-testing = { version = "0.17.0" }
-abstract-core = { version = "0.17.0" }
-abstract-macros = { version = "0.17.0" }
-abstract-ica = { version = "0.17.0" }
+abstract-interface = { version = "0.17.2" }
+abstract-adapter = { version = "0.17.2" }
+abstract-app = { version = "0.17.2" }
+abstract-sdk = { version = "0.17.2" }
+abstract-testing = { version = "0.17.2" }
+abstract-core = { version = "0.17.2" }
+abstract-macros = { version = "0.17.2" }
+abstract-ica = { version = "0.17.2" }
 
 abstract-dex-adapter = { path = "./contracts/adapters/dex" }
-abstract-adapter-utils = { version = "0.17.1" }
-abstract-dex-adapter-traits = { version = "0.17.1" }
-abstract-staking-adapter-traits = { version = "0.17.1" }
+abstract-adapter-utils = { version = "0.17.3" }
+abstract-dex-adapter-traits = { version = "0.17.3" }
+abstract-staking-adapter-traits = { version = "0.17.3" }
 
 # Juno dexes #
 abstract-wyndex-adapter = { path = "../integrations/wyndex/packages/wyndex-adapter", default-features = false }

--- a/modules/contracts/adapters/cw-staking/tests/stake.rs
+++ b/modules/contracts/adapters/cw-staking/tests/stake.rs
@@ -21,7 +21,7 @@ use cw_orch::prelude::*;
 use speculoos::*;
 use wyndex_bundle::{EUR_USD_LP, WYNDEX as WYNDEX_WITHOUT_CHAIN, WYNDEX_OWNER, WYND_TOKEN};
 
-const WYNDEX: &str = "cosmos-testnet>wynd";
+const WYNDEX: &str = "cosmos-testnet>wyndex";
 
 use abstract_cw_staking::CW_STAKING;
 use common::create_default_account;

--- a/modules/contracts/adapters/dex/tests/swap.rs
+++ b/modules/contracts/adapters/dex/tests/swap.rs
@@ -17,7 +17,7 @@ use cw_orch::prelude::*;
 use speculoos::*;
 use wyndex_bundle::{EUR, RAW_TOKEN, USD, WYNDEX as WYNDEX_WITHOUT_CHAIN, WYNDEX_OWNER};
 
-const WYNDEX: &str = "cosmos-testnet>wynd";
+const WYNDEX: &str = "cosmos-testnet>wyndex";
 
 #[allow(clippy::type_complexity)]
 fn setup_mock() -> anyhow::Result<(

--- a/modules/contracts/apps/dca/tests/integration.rs
+++ b/modules/contracts/apps/dca/tests/integration.rs
@@ -315,7 +315,7 @@ fn create_dca_convert_negative() -> anyhow::Result<()> {
             offer_asset = OfferAsset::new(USD, 100_u128),
             target_asset = AssetEntry::new(USD),
             e = AbstractError::from(StdError::generic_err(
-                "asset pairing wynd/usd,usd not found in ans_host"
+                "asset pairing wyndex/usd,usd not found in ans_host"
             ))
         )),
     );
@@ -477,7 +477,7 @@ fn update_dca_negative() -> anyhow::Result<()> {
             offer_asset = OfferAsset::new(USD, 200_u128),
             target_asset = AssetEntry::new(USD),
             e = AbstractError::from(StdError::generic_err(
-                "asset pairing wynd/usd,usd not found in ans_host"
+                "asset pairing wyndex/usd,usd not found in ans_host"
             ))
         )),
     );

--- a/modules/packages/bundles/wyndex/src/lib.rs
+++ b/modules/packages/bundles/wyndex/src/lib.rs
@@ -23,23 +23,23 @@ use wyndex::{
 
 use cw20_base::contract::AbstractCw20Base;
 
-pub const STAKING: &str = "wynd:staking";
-pub const FACTORY: &str = "wynd:factory";
+pub const STAKING: &str = "wyndex:staking";
+pub const FACTORY: &str = "wyndex:factory";
 pub const WYND_TOKEN: &str = "wynd";
-const EUR_USD_PAIR: &str = "wynd:eur_usd_pair";
-pub const EUR_USD_STAKE: &str = "wynd:eur_usd_staking";
-pub const EUR_USD_LP: &str = "wynd/eur,usd";
-const WYND_EUR_PAIR: &str = "wynd:wynd_eur_pair";
-pub const WYND_EUR_LP: &str = "wynd/wynd,eur";
+const EUR_USD_PAIR: &str = "wyndex:eur_usd_pair";
+pub const EUR_USD_STAKE: &str = "wyndex:eur_usd_staking";
+pub const EUR_USD_LP: &str = "wyndex/eur,usd";
+const WYND_EUR_PAIR: &str = "wyndex:wynd_eur_pair";
+pub const WYND_EUR_LP: &str = "wyndex/wynd,eur";
 pub const EUR: &str = "eur";
 pub const USD: &str = "usd";
-pub const WYNDEX: &str = "wynd";
+pub const WYNDEX: &str = "wyndex";
 pub const WYNDEX_OWNER: &str = "wyndex_owner";
 pub const POOL_FACTORY: &str = "pool_factory";
 pub const MULTI_HOP: &str = "multi_hop";
 pub const RAW_TOKEN: &str = "raw";
-pub const RAW_EUR_LP: &str = "wynd/eur,raw";
-const RAW_EUR_PAIR: &str = "wynd:eur_raw_pair";
+pub const RAW_EUR_LP: &str = "wyndex/eur,raw";
+const RAW_EUR_PAIR: &str = "wyndex:eur_raw_pair";
 
 pub struct WynDex {
     /// Suite can be used to create new pools and register new rewards.


### PR DESCRIPTION
This change adds neutron (and archway) to the registry and publishes 0.17.2.