### PR TITLE
Added namespace and base asset definitions in account creation

### DIFF
--- a/framework/contracts/native/account-factory/src/contract.rs
+++ b/framework/contracts/native/account-factory/src/contract.rs
@@ -63,9 +63,21 @@ pub fn execute(
             link,
             name,
             description,
+            namespace,
+            base_asset,
         } => {
             let gov_details = governance.verify(deps.api)?;
-            commands::execute_create_account(deps, env, info, gov_details, name, description, link)
+            commands::execute_create_account(
+                deps,
+                env,
+                info,
+                gov_details,
+                name,
+                description,
+                link,
+                namespace,
+                base_asset,
+            )
         }
         ExecuteMsg::UpdateOwnership(action) => {
             execute_update_ownership!(AccountFactoryResponse, deps, env, info, action)

--- a/framework/contracts/native/account-factory/tests/create_account.rs
+++ b/framework/contracts/native/account-factory/tests/create_account.rs
@@ -1,5 +1,11 @@
 mod common;
 
+use abstract_core::ans_host::ExecuteMsgFns;
+use abstract_core::objects::namespace::Namespace;
+use abstract_core::objects::AssetEntry;
+use abstract_core::proxy::BaseAssetResponse;
+use abstract_core::version_control::NamespaceResponse;
+use abstract_core::PROXY;
 use abstract_core::{
     account_factory, objects::gov_type::GovernanceDetails, version_control::AccountBase,
     ABSTRACT_EVENT_TYPE,
@@ -10,6 +16,7 @@ use abstract_interface::{
 use abstract_testing::addresses::TEST_ACCOUNT_ID;
 use abstract_testing::prelude::TEST_OWNER;
 use cosmwasm_std::{Addr, Uint64};
+use cw_asset::{AssetInfo, AssetInfoBase};
 use cw_orch::deploy::Deploy;
 use cw_orch::prelude::Mock;
 use cw_orch::prelude::*;
@@ -49,8 +56,10 @@ fn create_one_account() -> AResult {
             monarch: sender.to_string(),
         },
         String::from("first_account"),
+        None,
         Some(String::from("account_description")),
         Some(String::from("https://account_link_of_at_least_11_char")),
+        None,
     )?;
 
     let manager = account_creation.event_attr_value(ABSTRACT_EVENT_TYPE, "manager_address")?;
@@ -97,8 +106,10 @@ fn create_two_account_s() -> AResult {
             monarch: sender.to_string(),
         },
         String::from("first_os"),
+        None,
         Some(String::from("account_description")),
         Some(String::from("https://account_link_of_at_least_11_char")),
+        None,
     )?;
     // second account
     let account_2 = factory.create_account(
@@ -106,8 +117,10 @@ fn create_two_account_s() -> AResult {
             monarch: sender.to_string(),
         },
         String::from("second_os"),
+        None,
         Some(String::from("account_description")),
         Some(String::from("https://account_link_of_at_least_11_char")),
+        None,
     )?;
 
     let manager1 = account_1.event_attr_value(ABSTRACT_EVENT_TYPE, "manager_address")?;
@@ -164,8 +177,10 @@ fn sender_is_not_admin_monarchy() -> AResult {
             monarch: TEST_OWNER.to_string(),
         },
         String::from("first_os"),
+        None,
         Some(String::from("account_description")),
         Some(String::from("https://account_link_of_at_least_11_char")),
+        None,
     )?;
 
     let manager = account_creation.event_attr_value(ABSTRACT_EVENT_TYPE, "manager_address")?;
@@ -212,8 +227,10 @@ fn sender_is_not_admin_external() -> AResult {
             governance_type: "some-gov-type".to_string(),
         },
         String::from("first_os"),
+        None,
         Some(String::from("account_description")),
         Some(String::from("http://account_link_of_at_least_11_char")),
+        None,
     )?;
 
     let account = AbstractAccount::new(&deployment, Some(TEST_ACCOUNT_ID));
@@ -224,6 +241,85 @@ fn sender_is_not_admin_external() -> AResult {
         is_suspended: false,
         version_control_address: version_control.address()?,
         module_factory_address: deployment.module_factory.address()?,
+    });
+
+    Ok(())
+}
+
+#[test]
+fn create_one_account_with_base_asset() -> AResult {
+    let sender = Addr::unchecked(common::OWNER);
+    let chain = Mock::new(&sender);
+    let deployment = Abstract::deploy_on(chain.clone(), sender.to_string())?;
+
+    let factory = &deployment.account_factory;
+    let ans_host = &deployment.ans_host;
+
+    // Register the "juno", test asset for usage with the account
+    let asset_name = "juno";
+    let asset = AssetInfoBase::Native("ujuno".to_string());
+    let checked_asset = AssetInfo::Native("ujuno".to_string());
+    ans_host.update_asset_addresses(vec![(asset_name.to_string(), asset)], vec![])?;
+
+    let account_creation = factory.create_account(
+        GovernanceDetails::Monarchy {
+            monarch: sender.to_string(),
+        },
+        String::from("first_account"),
+        Some(AssetEntry::new(asset_name)),
+        Some(String::from("account_description")),
+        Some(String::from("https://account_link_of_at_least_11_char")),
+        None,
+    )?;
+
+    let proxy_addr = account_creation.event_attr_value(ABSTRACT_EVENT_TYPE, "proxy_address")?;
+
+    let proxy = Proxy::new(PROXY, chain.clone());
+    proxy.set_address(&Addr::unchecked(proxy_addr));
+
+    let base_asset = proxy.base_asset()?;
+
+    assert_that!(&base_asset).is_equal_to(&BaseAssetResponse {
+        base_asset: checked_asset,
+    });
+
+    Ok(())
+}
+
+#[test]
+fn create_one_account_with_namespace() -> AResult {
+    let sender = Addr::unchecked(common::OWNER);
+    let chain = Mock::new(&sender);
+    let deployment = Abstract::deploy_on(chain.clone(), sender.to_string())?;
+
+    let factory = &deployment.account_factory;
+    let version_control = &deployment.version_control;
+
+    let namespace_to_claim = "namespace-to-claim";
+
+    let account_creation = factory.create_account(
+        GovernanceDetails::Monarchy {
+            monarch: sender.to_string(),
+        },
+        String::from("first_account"),
+        None,
+        Some(String::from("account_description")),
+        Some(String::from("https://account_link_of_at_least_11_char")),
+        Some(namespace_to_claim.to_string()),
+    )?;
+
+    let manager_addr = account_creation.event_attr_value(ABSTRACT_EVENT_TYPE, "manager_address")?;
+    let proxy_addr = account_creation.event_attr_value(ABSTRACT_EVENT_TYPE, "proxy_address")?;
+
+    // We need to check if the namespace is associated with this account
+    let namespace = version_control.namespace(Namespace::new(namespace_to_claim)?)?;
+
+    assert_that!(&namespace).is_equal_to(&NamespaceResponse {
+        account_id: TEST_ACCOUNT_ID,
+        account_base: AccountBase {
+            manager: Addr::unchecked(manager_addr),
+            proxy: Addr::unchecked(proxy_addr),
+        },
     });
 
     Ok(())

--- a/framework/contracts/native/version-control/src/commands.rs
+++ b/framework/contracts/native/version-control/src/commands.rs
@@ -1,9 +1,7 @@
-use abstract_core::{
-    objects::{
-        fee::FixedFee,
-        module::{self, Module, ModuleMetadata, Monetization},
-        validation::validate_link,
-    },
+use abstract_core::objects::{
+    fee::FixedFee,
+    module::{self, Module, ModuleMetadata, Monetization},
+    validation::validate_link,
 };
 use cosmwasm_std::{
     ensure, Addr, Attribute, BankMsg, Coin, CosmosMsg, Deps, DepsMut, MessageInfo, Order,

--- a/framework/contracts/native/version-control/src/commands.rs
+++ b/framework/contracts/native/version-control/src/commands.rs
@@ -1,7 +1,10 @@
-use abstract_core::objects::{
-    fee::FixedFee,
-    module::{self, Module, ModuleMetadata, Monetization},
-    validation::validate_link,
+use abstract_core::{
+    objects::{
+        fee::FixedFee,
+        module::{self, Module, ModuleMetadata, Monetization},
+        validation::validate_link,
+    },
+    ACCOUNT_FACTORY,
 };
 use cosmwasm_std::{
     ensure, Addr, Attribute, BankMsg, Coin, CosmosMsg, Deps, DepsMut, MessageInfo, Order,
@@ -296,7 +299,11 @@ pub fn claim_namespace(
     // verify account owner
     let account_base = ACCOUNT_ADDRESSES.load(deps.storage, account_id)?;
     let account_owner = query_account_owner(&deps.querier, &account_base.manager, account_id)?;
-    if msg_info.sender != account_owner {
+
+    let account_factory = FACTORY.get(deps.as_ref())?.unwrap();
+
+    // The account owner as well as the account factory contract are able to claim namespaces
+    if msg_info.sender != account_owner && msg_info.sender != account_factory {
         return Err(VCError::AccountOwnerMismatch {
             sender: msg_info.sender,
             owner: account_owner,

--- a/framework/contracts/native/version-control/src/commands.rs
+++ b/framework/contracts/native/version-control/src/commands.rs
@@ -4,7 +4,6 @@ use abstract_core::{
         module::{self, Module, ModuleMetadata, Monetization},
         validation::validate_link,
     },
-    ACCOUNT_FACTORY,
 };
 use cosmwasm_std::{
     ensure, Addr, Attribute, BankMsg, Coin, CosmosMsg, Deps, DepsMut, MessageInfo, Order,

--- a/framework/packages/abstract-core/src/native/account_factory.rs
+++ b/framework/packages/abstract-core/src/native/account_factory.rs
@@ -12,7 +12,7 @@ pub mod state {
     use cw_storage_plus::Item;
     use serde::{Deserialize, Serialize};
 
-    use crate::objects::{account_id::AccountId, module::Module};
+    use crate::objects::{account_id::AccountId, module::Module, AssetEntry};
 
     /// Account Factory configuration
     #[cosmwasm_schema::cw_serde]
@@ -29,6 +29,15 @@ pub mod state {
         pub account_manager_address: Option<Addr>,
         pub manager_module: Option<Module>,
         pub proxy_module: Option<Module>,
+
+        pub additional_config: AdditionalContextConfig,
+    }
+
+    /// Account Factory additional config context for post-[`crate::abstract_manager`] [`crate::abstract_proxy`] creation
+    #[derive(Serialize, Deserialize, Clone, Debug)]
+    pub struct AdditionalContextConfig {
+        pub namespace: Option<String>,
+        pub base_asset: Option<AssetEntry>,
     }
 
     pub const CONFIG: Item<Config> = Item::new("\u{0}{5}config");
@@ -38,7 +47,7 @@ pub mod state {
 use cosmwasm_schema::QueryResponses;
 use cosmwasm_std::Addr;
 
-use crate::objects::{account_id::AccountId, gov_type::GovernanceDetails};
+use crate::objects::{account_id::AccountId, gov_type::GovernanceDetails, AssetEntry};
 
 /// Msg used on instantiation
 #[cosmwasm_schema::cw_serde]
@@ -74,10 +83,14 @@ pub enum ExecuteMsg {
         governance: GovernanceDetails<String>,
         // Account name
         name: String,
+        // Optionally specify a base asset for the account
+        base_asset: Option<AssetEntry>,
         // Account description
         description: Option<String>,
         // Account link
         link: Option<String>,
+        // optionally specify a namespace for the account
+        namespace: Option<String>,
     },
 }
 

--- a/framework/packages/abstract-interface/src/native/account_factory.rs
+++ b/framework/packages/abstract-interface/src/native/account_factory.rs
@@ -3,7 +3,9 @@ pub use abstract_core::account_factory::{
     ExecuteMsgFns as AccountFactoryExecFns, QueryMsgFns as AccountFactoryQueryFns,
 };
 use abstract_core::{
-    account_factory::*, objects::gov_type::GovernanceDetails, ABSTRACT_EVENT_TYPE, MANAGER, PROXY,
+    account_factory::*,
+    objects::{gov_type::GovernanceDetails, AssetEntry},
+    ABSTRACT_EVENT_TYPE, MANAGER, PROXY,
 };
 use cosmwasm_std::Addr;
 use cw_orch::{interface, prelude::*};
@@ -14,6 +16,8 @@ pub struct AccountDetails {
     pub name: String,
     pub description: Option<String>,
     pub link: Option<String>,
+    pub namespace: Option<String>,
+    pub base_asset: Option<AssetEntry>,
 }
 
 #[interface(InstantiateMsg, ExecuteMsg, QueryMsg, MigrateMsg)]
@@ -50,6 +54,8 @@ impl<Chain: CwEnv> AccountFactory<Chain> {
             name,
             link,
             description,
+            namespace,
+            base_asset,
         } = account_details;
 
         let result = self.execute(
@@ -58,6 +64,8 @@ impl<Chain: CwEnv> AccountFactory<Chain> {
                 name,
                 link,
                 description,
+                namespace,
+                base_asset,
             },
             None,
         )?;

--- a/integrations/astroport/packages/abstract-adapter/Cargo.toml
+++ b/integrations/astroport/packages/abstract-adapter/Cargo.toml
@@ -10,7 +10,13 @@ repository = "https://github.com/astroport-fi/astroport"
 [features]
 default = ["full_integration"]
 local = []
-full_integration = ["dep:cw20", "dep:cosmwasm-schema", "dep:cw-asset", "dep:cw-utils", "dep:astroport"]
+full_integration = [
+  "dep:cw20",
+  "dep:cosmwasm-schema",
+  "dep:cw-asset",
+  "dep:cw-utils",
+  "dep:astroport",
+]
 
 [dependencies]
 cosmwasm-std = { version = "1.1" }


### PR DESCRIPTION
This PR aims at allowing users to claim their namespace and add their base asset directly from the create account message.

# Checklist

- CI is green.
- Changelog updated.


