### PR TITLE
Staking pair with no bonding period

### DIFF
--- a/modules/packages/bundles/wyndex/src/lib.rs
+++ b/modules/packages/bundles/wyndex/src/lib.rs
@@ -92,7 +92,9 @@ impl Debug for WynDex {
             .field("eur_usd_pair", &self.eur_usd_pair)
             .field("wynd_token", &self.wynd_token)
             .field("wynd_eur_pair", &self.wynd_eur_pair)
-            // TODO
+            .field("abstr_token", &self.abstr_token)
+            .field("abstr_usd_pair", &self.abstr_usd_pair)
+            .field("abstr_usd_staking", &self.abstr_usd_staking)
             .finish()
     }
 }

--- a/modules/packages/bundles/wyndex/src/lib.rs
+++ b/modules/packages/bundles/wyndex/src/lib.rs
@@ -459,6 +459,7 @@ impl WynDex {
     /// - Register the pair contracts
     ///   - wyndex/eur,usd
     ///   - wyndex/eur,wynd
+    ///   - wyndex/abstr,usd
     pub(crate) fn register_info_on_abstract(
         &self,
         abstrct: &Abstract<Mock>,


### PR DESCRIPTION
Adding no bonding staking pair to `wyndex-bundle`:
- Added abstr token
- Added abstr-usd pair and pool
- Added one small test of it

Closes https://github.com/AbstractSDK/integration-bundles/issues/27

Note: period is 0 instead of None, don't think we want to change this method https://github.com/AbstractSDK/abstract/blob/main/integrations/wyndex/packages/wyndex-adapter/src/staking.rs#L244-L253

# Checklist

- CI is green.
- Changelog updated.
