### PR TITLE
Integrate orchestrator cli

### DIFF
--- a/framework/Cargo.toml
+++ b/framework/Cargo.toml
@@ -47,7 +47,7 @@ protobuf = { version = "2", features = ["with-bytes"] }
 clap = { version = "4.0.32", features = ["derive"] }
 semver = "1.0"
 cw-semver = { version = "1.0" }
-cw-orch = { version = "~0.13" }
+cw-orch = { version = "~0.15" }
 tokio = { version = "1.4", features = ["full"] }
 
 ## crates in order of publishing ## see docs/Publishing.md
@@ -84,7 +84,7 @@ speculoos = "0.11.0"
 anyhow = "1"
 
 [patch.crates-io]
-cw-orch = { git = "https://github.com/AbstractSDK/cw-orchestrator.git", rev = "ed0894c" }
+cw-orch = { git = "https://github.com/AbstractSDK/cw-orchestrator.git", rev = "2376c5e" }
 
 # Backup release profile, will result in warnings during optimization
 [profile.release]

--- a/framework/Cargo.toml
+++ b/framework/Cargo.toml
@@ -84,7 +84,7 @@ speculoos = "0.11.0"
 anyhow = "1"
 
 [patch.crates-io]
-cw-orch = { git = "https://github.com/AbstractSDK/cw-orchestrator.git" }
+cw-orch = { git = "https://github.com/AbstractSDK/cw-orchestrator.git", rev = "ed0894c" }
 
 # Backup release profile, will result in warnings during optimization
 [profile.release]

--- a/framework/packages/abstract-adapter/Cargo.toml
+++ b/framework/packages/abstract-adapter/Cargo.toml
@@ -15,6 +15,7 @@ resolver = "2"
 [features]
 test-utils = ["dep:abstract-testing", "dep:abstract-interface", "dep:cw-orch"]
 schema = []
+cli = ["dep:semver"]
 
 [dependencies]
 cosmwasm-std = { workspace = true }
@@ -31,6 +32,8 @@ abstract-testing = { workspace = true, optional = true }
 cw-orch = { workspace = true, optional = true }
 # Keep this as a version and update when publishing new versions
 abstract-interface = { path = "../../packages/abstract-interface", version = "0.18.0", optional = true }
+
+semver = { workspace = true, optional = true}
 
 [dev-dependencies]
 speculoos = { workspace = true }

--- a/framework/packages/abstract-adapter/src/cli.rs
+++ b/framework/packages/abstract-adapter/src/cli.rs
@@ -1,0 +1,49 @@
+pub enum AdapterOptions {
+    Deploy,
+    // TODO add other useful options for adapters
+    // and ability to add customs as wel
+}
+
+impl std::fmt::Display for AdapterOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AdapterOptions::Deploy => f.pad("Deploy"),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct AdapterContext<CustomInitMsg: serde::Serialize> {
+    pub version: semver::Version,
+    pub init_msg: CustomInitMsg
+}
+
+#[macro_export]
+macro_rules! cw_cli {
+    ($adapter_type:ident, $init_msg: ty) => {
+        mod implement_addons {
+            impl ::cw_orch_cli::CwCliAddons<::abstract_adapter::cli::AdapterContext<$init_msg>>
+                for super::interface::$adapter_type<::cw_orch::daemon::Daemon>
+            {
+                fn addons(
+                    &mut self,
+                    context: ::abstract_adapter::cli::AdapterContext<$init_msg>,
+                ) -> ::cw_orch_cli::OrchCliResult<()>
+                where
+                    Self: ::cw_orch::prelude::ContractInstance<::cw_orch::daemon::Daemon>,
+                {
+                    let option =
+                        ::cw_orch_cli::select_msg(vec![::abstract_adapter::cli::AdapterOptions::Deploy])?;
+                    match option {
+                        ::abstract_adapter::cli::AdapterOptions::Deploy => {
+                            ::abstract_interface::AdapterDeployer::deploy(self, context.version, context.init_msg)
+                                .map_err(|e| ::cw_orch_cli::OrchCliError::CustomError {
+                                    val: e.to_string(),
+                                })
+                        }
+                    }
+                }
+            }
+        }
+    };
+}

--- a/framework/packages/abstract-adapter/src/lib.rs
+++ b/framework/packages/abstract-adapter/src/lib.rs
@@ -18,6 +18,9 @@ mod handler;
 pub mod schema;
 pub mod state;
 
+#[cfg(feature = "cli")]
+pub mod cli;
+
 #[cfg(feature = "test-utils")]
 pub mod mock {
     use crate::{AdapterContract, AdapterError};

--- a/framework/packages/abstract-app/Cargo.toml
+++ b/framework/packages/abstract-app/Cargo.toml
@@ -13,6 +13,7 @@ resolver = "2"
 [features]
 test-utils = ["dep:abstract-testing", "dep:abstract-interface", "dep:cw-orch"]
 schema = []
+cli = []
 
 [dependencies]
 cosmwasm-std = { workspace = true }

--- a/framework/packages/abstract-app/src/cli.rs
+++ b/framework/packages/abstract-app/src/cli.rs
@@ -1,0 +1,45 @@
+pub enum AppOptions {
+    Deploy,
+    // TODO add other useful options for apps
+    // and ability to add customs as wel
+}
+
+impl std::fmt::Display for AppOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AppOptions::Deploy => f.pad("Deploy"),
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! cw_cli {
+    ($app_type:ident) => {
+        pub mod app_cli {
+            #[derive(Clone)]
+            pub struct AppContext {
+                pub version: semver::Version,
+            }
+
+            impl ::cw_orch_cli::CwCliAddons<AppContext>
+                for super::$app_type<::cw_orch::daemon::Daemon>
+            {
+                fn addons(&mut self, context: AppContext) -> ::cw_orch_cli::OrchCliResult<()>
+                where
+                    Self: ::cw_orch::prelude::ContractInstance<::cw_orch::daemon::Daemon>,
+                {
+                    let option =
+                        ::cw_orch_cli::select_msg(vec![::abstract_app::cli::AppOptions::Deploy])?;
+                    match option {
+                        ::abstract_app::cli::AppOptions::Deploy => {
+                            ::abstract_interface::AppDeployer::deploy(self, context.version)
+                                .map_err(|e| ::cw_orch_cli::OrchCliError::CustomError {
+                                    val: e.to_string(),
+                                })
+                        }
+                    }
+                }
+            }
+        }
+    };
+}

--- a/framework/packages/abstract-app/src/cli.rs
+++ b/framework/packages/abstract-app/src/cli.rs
@@ -12,19 +12,22 @@ impl std::fmt::Display for AppOptions {
     }
 }
 
+#[derive(Clone)]
+pub struct AppContext {
+    pub version: semver::Version,
+}
+
 #[macro_export]
 macro_rules! cw_cli {
     ($app_type:ident) => {
-        pub mod app_cli {
-            #[derive(Clone)]
-            pub struct AppContext {
-                pub version: semver::Version,
-            }
-
-            impl ::cw_orch_cli::CwCliAddons<AppContext>
-                for super::$app_type<::cw_orch::daemon::Daemon>
+        mod implement_addons {
+            impl ::cw_orch_cli::CwCliAddons<::abstract_app::cli::AppContext>
+                for super::interface::$app_type<::cw_orch::daemon::Daemon>
             {
-                fn addons(&mut self, context: AppContext) -> ::cw_orch_cli::OrchCliResult<()>
+                fn addons(
+                    &mut self,
+                    context: ::abstract_app::cli::AppContext,
+                ) -> ::cw_orch_cli::OrchCliResult<()>
                 where
                     Self: ::cw_orch::prelude::ContractInstance<::cw_orch::daemon::Daemon>,
                 {

--- a/framework/packages/abstract-app/src/lib.rs
+++ b/framework/packages/abstract-app/src/lib.rs
@@ -13,6 +13,9 @@ pub use error::AppError;
 pub type AppResult<C = Empty> = Result<Response<C>, AppError>;
 mod interface;
 
+#[cfg(feature = "cli")]
+pub mod cli;
+
 use cosmwasm_std::{Empty, Response};
 #[cfg(feature = "test-utils")]
 pub mod mock {

--- a/framework/packages/abstract-core/Cargo.toml
+++ b/framework/packages/abstract-core/Cargo.toml
@@ -30,7 +30,7 @@ cw2 = { workspace = true }
 cw20 = { workspace = true }
 abstract-ica = { workspace = true }
 cw-orch = { workspace = true, optional = true }
-cw-orch-cli = { git = "https://github.com/AbstractSDK/cw-orchestrator.git", rev = "ed0894c", optional = true}
+cw-orch-cli = { git = "https://github.com/AbstractSDK/cw-orchestrator.git", rev = "2376c5e", optional = true}
 cw-ownable = { workspace = true }
 
 [dev-dependencies]

--- a/framework/packages/abstract-core/Cargo.toml
+++ b/framework/packages/abstract-core/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/AbstractSDK/contracts"
 
 
 [features]
-interface = ["dep:cw-orch"]
+interface = ["dep:cw-orch", "dep:cw-orch-cli"]
 # for quicker tests, cargo test --lib
 
 [dependencies]
@@ -30,6 +30,7 @@ cw2 = { workspace = true }
 cw20 = { workspace = true }
 abstract-ica = { workspace = true }
 cw-orch = { workspace = true, optional = true }
+cw-orch-cli = { git = "https://github.com/AbstractSDK/cw-orchestrator.git", rev = "428b136", optional = true}
 cw-ownable = { workspace = true }
 
 [dev-dependencies]

--- a/framework/packages/abstract-core/Cargo.toml
+++ b/framework/packages/abstract-core/Cargo.toml
@@ -30,8 +30,9 @@ cw2 = { workspace = true }
 cw20 = { workspace = true }
 abstract-ica = { workspace = true }
 cw-orch = { workspace = true, optional = true }
-cw-orch-cli = { git = "https://github.com/AbstractSDK/cw-orchestrator.git", rev = "2376c5e", optional = true}
 cw-ownable = { workspace = true }
+# TODO: publish
+cw-orch-cli = { git = "https://github.com/AbstractSDK/cw-orchestrator.git", rev = "2376c5e", optional = true }
 
 [dev-dependencies]
 speculoos = { workspace = true }

--- a/framework/packages/abstract-core/Cargo.toml
+++ b/framework/packages/abstract-core/Cargo.toml
@@ -30,7 +30,7 @@ cw2 = { workspace = true }
 cw20 = { workspace = true }
 abstract-ica = { workspace = true }
 cw-orch = { workspace = true, optional = true }
-cw-orch-cli = { git = "https://github.com/AbstractSDK/cw-orchestrator.git", rev = "428b136", optional = true}
+cw-orch-cli = { git = "https://github.com/AbstractSDK/cw-orchestrator.git", rev = "ed0894c", optional = true}
 cw-ownable = { workspace = true }
 
 [dev-dependencies]

--- a/framework/packages/abstract-core/src/adapter.rs
+++ b/framework/packages/abstract-core/src/adapter.rs
@@ -42,7 +42,7 @@ impl<T: AdapterExecuteMsg + cw_orch_cli::ParseCwMsg, R: Serialize> cw_orch_cli::
 {
     fn cw_parse(
         state_interface: &impl cw_orch::state::StateInterface,
-    ) -> cw_orch::anyhow::Result<Self> {
+    ) -> cw_orch_cli::OrchCliResult<Self> {
         Ok(Self::Module(AdapterRequestMsg {
             proxy_address: None,
             request: T::cw_parse(state_interface)?,
@@ -68,7 +68,7 @@ impl<T: AdapterQueryMsg> From<T> for QueryMsg<T> {
 impl<T: AdapterQueryMsg + cw_orch_cli::ParseCwMsg> cw_orch_cli::ParseCwMsg for QueryMsg<T> {
     fn cw_parse(
         state_interface: &impl cw_orch::state::StateInterface,
-    ) -> cw_orch::anyhow::Result<Self> {
+    ) -> cw_orch_cli::OrchCliResult<Self> {
         Ok(Self::Module(T::cw_parse(state_interface)?))
     }
 }
@@ -80,7 +80,7 @@ impl AdapterQueryMsg for Empty {}
 impl<T: cw_orch_cli::ParseCwMsg> cw_orch_cli::ParseCwMsg for InstantiateMsg<T> {
     fn cw_parse(
         state_interface: &impl cw_orch::state::StateInterface,
-    ) -> cw_orch::anyhow::Result<Self> {
+    ) -> cw_orch_cli::OrchCliResult<Self> {
         Ok(Self {
             base: BaseInstantiateMsg {
                 ans_host_address: state_interface.get_address(crate::ANS_HOST)?.into_string(),

--- a/framework/packages/abstract-core/src/app.rs
+++ b/framework/packages/abstract-core/src/app.rs
@@ -38,7 +38,7 @@ impl<T: AppExecuteMsg + cw_orch_cli::ParseCwMsg, R: Serialize> cw_orch_cli::Pars
 {
     fn cw_parse(
         state_interface: &impl cw_orch::state::StateInterface,
-    ) -> cw_orch::anyhow::Result<Self> {
+    ) -> cw_orch_cli::OrchCliResult<Self> {
         Ok(Self::Module(T::cw_parse(state_interface)?))
     }
 }
@@ -60,7 +60,7 @@ impl<T: AppQueryMsg> From<T> for QueryMsg<T> {
 impl<T: AppQueryMsg + cw_orch_cli::ParseCwMsg> cw_orch_cli::ParseCwMsg for QueryMsg<T> {
     fn cw_parse(
         state_interface: &impl cw_orch::state::StateInterface,
-    ) -> cw_orch::anyhow::Result<Self> {
+    ) -> cw_orch_cli::OrchCliResult<Self> {
         Ok(Self::Module(T::cw_parse(state_interface)?))
     }
 }
@@ -72,7 +72,7 @@ impl AppQueryMsg for Empty {}
 impl<T: cw_orch_cli::ParseCwMsg> cw_orch_cli::ParseCwMsg for InstantiateMsg<T> {
     fn cw_parse(
         state_interface: &impl cw_orch::state::StateInterface,
-    ) -> cw_orch::anyhow::Result<Self> {
+    ) -> cw_orch_cli::OrchCliResult<Self> {
         Ok(Self {
             base: BaseInstantiateMsg {
                 ans_host_address: state_interface.get_address(crate::ANS_HOST)?.into_string(),
@@ -87,7 +87,7 @@ impl<T: cw_orch_cli::ParseCwMsg> cw_orch_cli::ParseCwMsg for InstantiateMsg<T> {
 impl<T: cw_orch_cli::ParseCwMsg> cw_orch_cli::ParseCwMsg for MigrateMsg<T> {
     fn cw_parse(
         state_interface: &impl cw_orch::state::StateInterface,
-    ) -> cw_orch::anyhow::Result<Self> {
+    ) -> cw_orch_cli::OrchCliResult<Self> {
         Ok(Self {
             base: BaseMigrateMsg {},
             module: T::cw_parse(state_interface)?,

--- a/framework/packages/abstract-core/src/app.rs
+++ b/framework/packages/abstract-core/src/app.rs
@@ -19,6 +19,7 @@ use cosmwasm_schema::QueryResponses;
 use cosmwasm_std::{Addr, Empty};
 #[allow(unused_imports)]
 use cw_controllers::AdminResponse;
+use cw_orch_cli::ParseCwMsg;
 use serde::Serialize;
 
 /// Trait indicates that the type is used as an app message
@@ -28,6 +29,13 @@ pub trait AppExecuteMsg: Serialize {}
 impl<T: AppExecuteMsg, R: Serialize> From<T> for ExecuteMsg<T, R> {
     fn from(app: T) -> Self {
         Self::Module(app)
+    }
+}
+
+#[cfg(feature = "interface")]
+impl<T: AppExecuteMsg + ParseCwMsg, R: Serialize> ParseCwMsg for ExecuteMsg<T, R> {
+    fn cw_parse() -> cw_orch::anyhow::Result<Self> {
+        Ok(Self::Module(T::cw_parse()?))
     }
 }
 

--- a/framework/packages/abstract-interface/src/error.rs
+++ b/framework/packages/abstract-interface/src/error.rs
@@ -8,6 +8,10 @@ pub enum AbstractInterfaceError {
     #[error(transparent)]
     Abstract(#[from] AbstractError),
 
+    #[cfg(feature = "daemon")]
+    #[error(transparent)]
+    DaemonError(#[from] cw_orch::daemon::DaemonError),
+
     #[error(transparent)]
     Orch(#[from] CwOrchError),
 

--- a/framework/packages/dex/Cargo.toml
+++ b/framework/packages/dex/Cargo.toml
@@ -38,7 +38,7 @@ abstract-adapter = { workspace = true }
 abstract-adapter-utils = { workspace = true }
 cw-orch = { workspace = true, optional = true, features = ["daemon"] }
 abstract-interface = { workspace = true, optional = true }
-ibc-chain-registry = { version = "0.24.1", optional = true }
+ibc-chain-registry = { version = "0.25", optional = true }
 
 [dev-dependencies]
 abstract-interface = { workspace = true, features = ["daemon"] }

--- a/framework/packages/dex/src/tests.rs
+++ b/framework/packages/dex/src/tests.rs
@@ -6,7 +6,7 @@ use cosmwasm_std::Decimal;
 use cosmwasm_std::StdError;
 use cw_asset::Asset;
 use cw_asset::AssetInfo;
-use cw_orch::live_mock::mock_dependencies;
+use cw_orch::prelude::live_mock::mock_dependencies;
 use ibc_chain_registry::chain::ChainData;
 use std::fmt::Debug;
 

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -87,6 +87,10 @@ rstest = "0.17.0"
 speculoos = "0.11.0"
 anyhow = "1"
 
+# Cli
+# TODO: publish
+cw-orch-cli = { git = "https://github.com/AbstractSDK/cw-orchestrator.git", rev = "2376c5e"}
+
 # this ensures local compatability when compiling locally
 [patch.crates-io]
 abstract-adapter = { path = "../framework/packages/abstract-adapter" }

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -53,7 +53,7 @@ protobuf = { version = "2", features = ["with-bytes"] }
 clap = { version = "4.0.32", features = ["derive"] }
 semver = "1.0"
 cw-semver = { version = "1.0" }
-cw-orch = { version = "~0.13" }
+cw-orch = { version = "~0.15" }
 tokio = { version = "1.4", features = ["full"] }
 
 ## crates in order of publishing ## see docs/Publishing.md
@@ -101,7 +101,7 @@ abstract-adapter-utils = { path = "../framework/packages/utils" }
 abstract-dex-adapter-traits = { path = "../framework/packages/dex" }
 abstract-staking-adapter-traits = { path = "../framework/packages/staking" }
 # TODO: remove after new version with osmosis-test-tube deployed
-cw-orch = { git = "https://github.com/AbstractSDK/cw-orchestrator.git", rev = "ed0894c" }
+cw-orch = { git = "https://github.com/AbstractSDK/cw-orchestrator.git", rev = "2376c5e" }
 
 # Backup release profile, will result in warnings during optimization
 [profile.release]

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -101,7 +101,7 @@ abstract-adapter-utils = { path = "../framework/packages/utils" }
 abstract-dex-adapter-traits = { path = "../framework/packages/dex" }
 abstract-staking-adapter-traits = { path = "../framework/packages/staking" }
 # TODO: remove after new version with osmosis-test-tube deployed
-cw-orch = { git = "https://github.com/AbstractSDK/cw-orchestrator.git", rev = "13c11e4" }
+cw-orch = { git = "https://github.com/AbstractSDK/cw-orchestrator.git", rev = "ed0894c" }
 
 # Backup release profile, will result in warnings during optimization
 [profile.release]

--- a/modules/contracts/adapters/dex/Cargo.toml
+++ b/modules/contracts/adapters/dex/Cargo.toml
@@ -25,7 +25,7 @@ required-features = ["schema"]
 [features]
 default = ["export"]
 export = []
-interface = ["dep:abstract-interface", "dep:cw-orch", "export"]
+interface = ["dep:abstract-interface", "dep:cw-orch", "dep:cw-orch-cli", "export"]
 juno = [
   "dep:wasmswap",
   "dep:cw20_junoswap",
@@ -83,6 +83,8 @@ terraswap = { version = "2.8.0", optional = true }
 # Kujira #
 kujira = { version = "0.8.2", optional = true }
 
+cw-orch-cli = { git = "https://github.com/AbstractSDK/cw-orchestrator.git", rev = "2376c5e", optional = true }
+
 [dev-dependencies]
 abstract-interface = { workspace = true, features = ["daemon"] }
 tokio = { workspace = true }
@@ -101,6 +103,7 @@ dex = { path = ".", features = [
 ], package = "abstract-dex-adapter" }
 
 abstract-wyndex-adapter = { workspace = true, features = ["local"] }
+abstract-adapter = { workspace = true, features = ["cli"]}
 
 cw20 = { workspace = true, features = ["interface"] }
 cw20-base = { workspace = true, features = ["interface"] }

--- a/modules/contracts/adapters/dex/Cargo.toml
+++ b/modules/contracts/adapters/dex/Cargo.toml
@@ -25,7 +25,12 @@ required-features = ["schema"]
 [features]
 default = ["export"]
 export = []
-interface = ["dep:abstract-interface", "dep:cw-orch", "dep:cw-orch-cli", "export"]
+interface = [
+  "dep:abstract-interface",
+  "dep:cw-orch",
+  "dep:cw-orch-cli",
+  "export",
+]
 juno = [
   "dep:wasmswap",
   "dep:cw20_junoswap",
@@ -83,7 +88,7 @@ terraswap = { version = "2.8.0", optional = true }
 # Kujira #
 kujira = { version = "0.8.2", optional = true }
 
-cw-orch-cli = { git = "https://github.com/AbstractSDK/cw-orchestrator.git", rev = "2376c5e", optional = true }
+cw-orch-cli = { workspace = true, optional = true }
 
 [dev-dependencies]
 abstract-interface = { workspace = true, features = ["daemon"] }
@@ -103,7 +108,7 @@ dex = { path = ".", features = [
 ], package = "abstract-dex-adapter" }
 
 abstract-wyndex-adapter = { workspace = true, features = ["local"] }
-abstract-adapter = { workspace = true, features = ["cli"]}
+abstract-adapter = { workspace = true, features = ["cli"] }
 
 cw20 = { workspace = true, features = ["interface"] }
 cw20-base = { workspace = true, features = ["interface"] }

--- a/modules/contracts/adapters/dex/examples/cli.rs
+++ b/modules/contracts/adapters/dex/examples/cli.rs
@@ -1,7 +1,7 @@
-use abstract_app::cli::AppContext;
-use croncat_app::{contract::CRONCAT_ID, CroncatApp};
+use abstract_adapter::cli::AdapterContext;
 use cw_orch::{anyhow, prelude::Daemon, tokio::runtime::Runtime};
 use cw_orch_cli::{ContractCli, DaemonFromCli};
+use dex_adapter::{contract::DEX_ID, DexAdapter};
 use semver::Version;
 
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -12,10 +12,16 @@ pub fn main() -> anyhow::Result<()> {
     let rt = Runtime::new()?;
     let chain = Daemon::from_cli(rt.handle())?;
 
-    let croncat = CroncatApp::new(CRONCAT_ID, chain);
+    let dex = DexAdapter::new(CRONCAT_ID, chain);
 
     let version: Version = CONTRACT_VERSION.parse().unwrap();
-    croncat.select_action(AppContext { version })?;
+    dex.select_action(AdapterContext {
+        version,
+        init_msg: DexInstantiateMsg {
+            swap_fee: Decimal::percent(1),
+            recipient_account: 0,
+        },
+    })?;
 
     Ok(())
 }

--- a/modules/contracts/adapters/dex/src/lib.rs
+++ b/modules/contracts/adapters/dex/src/lib.rs
@@ -83,4 +83,5 @@ pub mod interface {
     }
 }
 
+#[cfg(feature = "interface")]
 abstract_adapter::cw_cli!(DexAdapter, abstract_dex_adapter_traits::msg::DexInstantiateMsg);

--- a/modules/contracts/adapters/dex/src/lib.rs
+++ b/modules/contracts/adapters/dex/src/lib.rs
@@ -82,3 +82,5 @@ pub mod interface {
         }
     }
 }
+
+abstract_adapter::cw_cli!(DexAdapter, abstract_dex_adapter_traits::msg::DexInstantiateMsg);

--- a/modules/contracts/apps/croncat/Cargo.toml
+++ b/modules/contracts/apps/croncat/Cargo.toml
@@ -66,7 +66,7 @@ croncat-integration-utils = "1.1.0"
 # TODO: avoid using contract dep
 croncat-factory = { version = "1.0.3", features = ["library"] }
 croncat-manager = { version = "1.0.3", features = ["library"] }
-cw-orch-cli = { git = "https://github.com/AbstractSDK/cw-orchestrator.git", rev = "428b136", optional = true}
+cw-orch-cli = { git = "https://github.com/AbstractSDK/cw-orchestrator.git", rev = "ed0894c", optional = true}
 
 [dev-dependencies]
 croncat-app = { path = ".", features = ["interface"] }

--- a/modules/contracts/apps/croncat/Cargo.toml
+++ b/modules/contracts/apps/croncat/Cargo.toml
@@ -35,7 +35,7 @@ required-features = ["schema"]
 [features]
 default = ["export"]
 export = []
-interface = ["export", "dep:abstract-interface", "dep:cw-orch"]
+interface = ["export", "dep:abstract-interface", "dep:cw-orch", "dep:cw-orch-cli"]
 schema = ["abstract-app/schema"]
 
 [dependencies]
@@ -66,6 +66,7 @@ croncat-integration-utils = "1.1.0"
 # TODO: avoid using contract dep
 croncat-factory = { version = "1.0.3", features = ["library"] }
 croncat-manager = { version = "1.0.3", features = ["library"] }
+cw-orch-cli = { git = "https://github.com/AbstractSDK/cw-orchestrator.git", rev = "428b136", optional = true}
 
 [dev-dependencies]
 croncat-app = { path = ".", features = ["interface"] }

--- a/modules/contracts/apps/croncat/Cargo.toml
+++ b/modules/contracts/apps/croncat/Cargo.toml
@@ -91,3 +91,6 @@ croncat-integration-testing = "1.1.0"
 
 # Testing cw20
 cw20-base = "0.16.0"
+
+# Enable cli on abstract-app
+abstract-app = { workspace = true, features = ["cli"] }

--- a/modules/contracts/apps/croncat/Cargo.toml
+++ b/modules/contracts/apps/croncat/Cargo.toml
@@ -66,7 +66,7 @@ croncat-integration-utils = "1.1.0"
 # TODO: avoid using contract dep
 croncat-factory = { version = "1.0.3", features = ["library"] }
 croncat-manager = { version = "1.0.3", features = ["library"] }
-cw-orch-cli = { git = "https://github.com/AbstractSDK/cw-orchestrator.git", rev = "2376c5e", optional = true}
+cw-orch-cli = { workspace = true, optional = true}
 
 [dev-dependencies]
 croncat-app = { path = ".", features = ["interface"] }

--- a/modules/contracts/apps/croncat/Cargo.toml
+++ b/modules/contracts/apps/croncat/Cargo.toml
@@ -66,7 +66,7 @@ croncat-integration-utils = "1.1.0"
 # TODO: avoid using contract dep
 croncat-factory = { version = "1.0.3", features = ["library"] }
 croncat-manager = { version = "1.0.3", features = ["library"] }
-cw-orch-cli = { git = "https://github.com/AbstractSDK/cw-orchestrator.git", rev = "ed0894c", optional = true}
+cw-orch-cli = { git = "https://github.com/AbstractSDK/cw-orchestrator.git", rev = "2376c5e", optional = true}
 
 [dev-dependencies]
 croncat-app = { path = ".", features = ["interface"] }

--- a/modules/contracts/apps/croncat/examples/cli.rs
+++ b/modules/contracts/apps/croncat/examples/cli.rs
@@ -1,60 +1,21 @@
 use croncat_app::{contract::CRONCAT_ID, CroncatApp};
-use cw_orch::{
-    anyhow,
-    prelude::{networks, Daemon, DaemonBuilder},
-    tokio::runtime::Runtime,
-};
-use cw_orch_cli::{ContractCli, OrchCliError};
-
-pub enum AppOptions {
-    Deploy,
-}
-
-impl ::std::fmt::Display for AppOptions {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            AppOptions::Deploy => f.pad("Deploy"),
-        }
-    }
-}
-
-#[derive(Clone)]
-pub struct AppContext {
-    pub version: semver::Version,
-}
-
-use cw_orch_cli::CwCliAddons;
+use cw_orch::{anyhow, prelude::Daemon, tokio::runtime::Runtime};
+use cw_orch_cli::{ContractCli, DaemonFromCli};
 use semver::Version;
 
-impl CwCliAddons<AppContext> for CroncatApp<Daemon> {
-    fn addons(&mut self, context: AppContext) -> cw_orch_cli::OrchCliResult<()>
-    where
-        Self: cw_orch::prelude::ContractInstance<cw_orch::prelude::Daemon>,
-    {
-        let option = ::cw_orch_cli::select_msg(vec![AppOptions::Deploy])?;
-        match option {
-            AppOptions::Deploy => ::abstract_interface::AppDeployer::deploy(self, context.version)
-                .map_err(|e| OrchCliError::CustomError { val: e.to_string() }),
-        }
-    }
-}
+abstract_app::cw_cli!(CroncatApp);
 
-const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");   
+const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub fn main() -> anyhow::Result<()> {
     dotenv::dotenv().ok();
 
     let rt = Runtime::new()?;
-    let network = networks::UNI_6;
-    let version: Version = CONTRACT_VERSION.parse().unwrap();
-    let chain = DaemonBuilder::default()
-        .handle(rt.handle())
-        .chain(network)
-        .build()?;
+    let chain = Daemon::from_cli(rt.handle())?;
 
     let croncat = CroncatApp::new(CRONCAT_ID, chain);
-
-    croncat.select_action(AppContext { version })?;
+    let version: Version = CONTRACT_VERSION.parse().unwrap();
+    croncat.select_action(app_cli::AppContext { version })?;
 
     Ok(())
 }

--- a/modules/contracts/apps/croncat/examples/cli.rs
+++ b/modules/contracts/apps/croncat/examples/cli.rs
@@ -1,0 +1,25 @@
+use croncat_app::{CroncatApp, contract::CRONCAT_ID};
+use cw_orch::{
+    anyhow,
+    prelude::{networks, DaemonBuilder},
+    tokio::runtime::Runtime,
+};
+use cw_orch_cli::ContractCli;
+
+pub fn main() -> anyhow::Result<()> {
+    dotenv::dotenv().ok();
+
+    let rt = Runtime::new()?;
+    let network = networks::UNI_6;
+    // let version: Version = CONTRACT_VERSION.parse().unwrap();
+    let chain = DaemonBuilder::default()
+        .handle(rt.handle())
+        .chain(network)
+        .build()?;
+
+    let croncat = CroncatApp::new(CRONCAT_ID, chain);
+
+    ContractCli::select_action(croncat)?;
+
+    Ok(())
+}

--- a/modules/contracts/apps/croncat/examples/cli.rs
+++ b/modules/contracts/apps/croncat/examples/cli.rs
@@ -1,17 +1,52 @@
-use croncat_app::{CroncatApp, contract::CRONCAT_ID};
+use croncat_app::{contract::CRONCAT_ID, CroncatApp};
 use cw_orch::{
     anyhow,
-    prelude::{networks, DaemonBuilder},
+    prelude::{networks, Daemon, DaemonBuilder},
     tokio::runtime::Runtime,
 };
-use cw_orch_cli::ContractCli;
+use cw_orch_cli::{ContractCli, OrchCliError};
+
+pub enum AppOptions {
+    Deploy,
+}
+
+impl ::std::fmt::Display for AppOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AppOptions::Deploy => f.pad("Deploy"),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct AppContext {
+    pub version: semver::Version,
+}
+
+use cw_orch_cli::CwCliAddons;
+use semver::Version;
+
+impl CwCliAddons<AppContext> for CroncatApp<Daemon> {
+    fn addons(&mut self, context: AppContext) -> cw_orch_cli::OrchCliResult<()>
+    where
+        Self: cw_orch::prelude::ContractInstance<cw_orch::prelude::Daemon>,
+    {
+        let option = ::cw_orch_cli::select_msg(vec![AppOptions::Deploy])?;
+        match option {
+            AppOptions::Deploy => ::abstract_interface::AppDeployer::deploy(self, context.version)
+                .map_err(|e| OrchCliError::CustomError { val: e.to_string() }),
+        }
+    }
+}
+
+const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");   
 
 pub fn main() -> anyhow::Result<()> {
     dotenv::dotenv().ok();
 
     let rt = Runtime::new()?;
     let network = networks::UNI_6;
-    // let version: Version = CONTRACT_VERSION.parse().unwrap();
+    let version: Version = CONTRACT_VERSION.parse().unwrap();
     let chain = DaemonBuilder::default()
         .handle(rt.handle())
         .chain(network)
@@ -19,7 +54,7 @@ pub fn main() -> anyhow::Result<()> {
 
     let croncat = CroncatApp::new(CRONCAT_ID, chain);
 
-    ContractCli::select_action(croncat)?;
+    croncat.select_action(AppContext { version })?;
 
     Ok(())
 }

--- a/modules/contracts/apps/croncat/examples/cli.rs
+++ b/modules/contracts/apps/croncat/examples/cli.rs
@@ -1,9 +1,8 @@
+use abstract_app::cli::AppContext;
 use croncat_app::{contract::CRONCAT_ID, CroncatApp};
-use cw_orch::{anyhow, prelude::Daemon, tokio::runtime::Runtime};
+use cw_orch::{anyhow, prelude::Daemon, tokio::runtime::Runtime, deploy::Deploy};
 use cw_orch_cli::{ContractCli, DaemonFromCli};
 use semver::Version;
-
-abstract_app::cw_cli!(CroncatApp);
 
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -14,8 +13,9 @@ pub fn main() -> anyhow::Result<()> {
     let chain = Daemon::from_cli(rt.handle())?;
 
     let croncat = CroncatApp::new(CRONCAT_ID, chain);
+    
     let version: Version = CONTRACT_VERSION.parse().unwrap();
-    croncat.select_action(app_cli::AppContext { version })?;
+    croncat.select_action(AppContext { version })?;
 
     Ok(())
 }

--- a/modules/contracts/apps/croncat/src/contract.rs
+++ b/modules/contracts/apps/croncat/src/contract.rs
@@ -34,3 +34,6 @@ abstract_app::export_endpoints!(CRONCAT_APP, CroncatApp);
 
 #[cfg(feature = "interface")]
 abstract_app::cw_orch_interface!(CRONCAT_APP, CroncatApp, CroncatApp);
+
+#[cfg(feature = "interface")]
+abstract_app::cw_cli!(CroncatApp);

--- a/modules/contracts/apps/croncat/src/msg.rs
+++ b/modules/contracts/apps/croncat/src/msg.rs
@@ -14,7 +14,7 @@ pub struct AppInstantiateMsg {}
 
 /// App execute messages
 #[cosmwasm_schema::cw_serde]
-#[cfg_attr(feature = "interface", derive(cw_orch::ExecuteFns))]
+#[cfg_attr(feature = "interface", derive(cw_orch::ExecuteFns, cw_orch_cli::ParseCwMsg))]
 #[cfg_attr(feature = "interface", impl_into(ExecuteMsg))]
 pub enum AppExecuteMsg {
     UpdateConfig {},

--- a/modules/contracts/apps/croncat/src/msg.rs
+++ b/modules/contracts/apps/croncat/src/msg.rs
@@ -10,6 +10,7 @@ abstract_app::app_msg_types!(CroncatApp, AppExecuteMsg, AppQueryMsg);
 
 /// App instantiate message
 #[cosmwasm_schema::cw_serde]
+#[cfg_attr(feature = "interface", derive(cw_orch_cli::ParseCwMsg))]
 pub struct AppInstantiateMsg {}
 
 /// App execute messages
@@ -36,7 +37,7 @@ pub enum AppExecuteMsg {
 }
 
 #[cosmwasm_schema::cw_serde]
-#[cfg_attr(feature = "interface", derive(cw_orch::QueryFns))]
+#[cfg_attr(feature = "interface", derive(cw_orch::QueryFns, cw_orch_cli::ParseCwMsg))]
 #[cfg_attr(feature = "interface", impl_into(QueryMsg))]
 #[derive(QueryResponses)]
 pub enum AppQueryMsg {


### PR DESCRIPTION
Making an easy way to integrate interactive cli for apps and adapters 
- [x] Add blanket impl of `ParseCwMessage` for Module Messages that implements it
- [x] Create macro to reduce boilerplate for apps
- [x] Create macro to reduce boilerplate for adapters
- [ ] Add README to guide how to activate it
# Checklist

- [ ] CI is green.
- [ ] Changelog updated.
