### PR TITLE
Fix abs 164

### DIFF
--- a/framework/contracts/account/manager/src/commands.rs
+++ b/framework/contracts/account/manager/src/commands.rs
@@ -40,7 +40,6 @@ use cosmwasm_std::{
     DepsMut, Empty, Env, MessageInfo, Response, StdError, StdResult, Storage, WasmMsg,
 };
 use cw2::{get_contract_version, ContractVersion};
-use cw_controllers::AdminError;
 use cw_ownable::Ownership;
 use cw_storage_plus::Item;
 use semver::Version;

--- a/framework/contracts/account/manager/src/contract.rs
+++ b/framework/contracts/account/manager/src/contract.rs
@@ -42,13 +42,13 @@ pub fn instantiate(
     msg: InstantiateMsg,
 ) -> ManagerResult {
     set_contract_version(deps.storage, MANAGER, CONTRACT_VERSION)?;
-
+    let module_factory_address = deps.api.addr_validate(&msg.module_factory_address)?;
     ACCOUNT_ID.save(deps.storage, &msg.account_id)?;
     CONFIG.save(
         deps.storage,
         &Config {
             version_control_address: deps.api.addr_validate(&msg.version_control_address)?,
-            module_factory_address: deps.api.addr_validate(&msg.module_factory_address)?,
+            module_factory_address: module_factory_address.clone(),
         },
     )?;
 
@@ -71,17 +71,42 @@ pub fn instantiate(
     INFO.save(deps.storage, &account_info)?;
     MIGRATE_CONTEXT.save(deps.storage, &vec![])?;
 
+    let installed_modules: Vec<String> = msg
+        .install_modules
+        .iter()
+        .map(|(module, _)| module.id_with_version())
+        .collect();
+    let install_modules_msgs = msg
+        .install_modules
+        .into_iter()
+        .map(|(module, init_msg)| {
+            install_module_internal(
+                deps.storage,
+                module,
+                module_factory_address.clone(),
+                init_msg,
+                vec![],
+            )
+        })
+        .collect::<ManagerResult<Vec<_>>>()?;
+
     // Set owner
     cw_ownable::initialize_owner(deps.storage, deps.api, Some(owner.as_str()))?;
     SUSPENSION_STATUS.save(deps.storage, &false)?;
     ACCOUNT_FACTORY.set(deps, Some(info.sender))?;
-    Ok(ManagerResponse::new(
+
+    let mut response = ManagerResponse::new(
         "instantiate",
         vec![
             ("account_id", msg.account_id.to_string()),
             ("owner", owner.to_string()),
         ],
-    ))
+    )
+    .add_messages(install_modules_msgs);
+    if !installed_modules.is_empty() {
+        response = response.add_attribute("installed_modules", format!("{installed_modules:?}"))
+    }
+    Ok(response)
 }
 
 #[cfg_attr(feature = "export", cosmwasm_std::entry_point)]

--- a/framework/contracts/account/manager/src/lib.rs
+++ b/framework/contracts/account/manager/src/lib.rs
@@ -30,6 +30,7 @@ mod test_common {
                 name: "test".to_string(),
                 description: None,
                 link: None,
+                install_modules: vec![],
             },
         )
     }

--- a/framework/contracts/account/manager/tests/upgrades.rs
+++ b/framework/contracts/account/manager/tests/upgrades.rs
@@ -493,43 +493,48 @@ fn create_account_with_installed_module() -> AResult {
     )?;
     deploy_modules(&chain);
 
-    let account = factory.create_new_account(
-        AccountDetails {
-            name: String::from("second_account"),
-            description: Some(String::from("account_description")),
-            link: Some(String::from("https://account_link_of_at_least_11_char")),
-            namespace: None,
-            base_asset: None,
-            install_modules: vec![
-                (
-                    ModuleInfo::from_id(
-                        adapter_1::MOCK_ADAPTER_ID,
-                        ModuleVersion::Version(V1.to_owned()),
-                    )?,
-                    None,
-                ),
-                (
-                    ModuleInfo::from_id(
-                        adapter_2::MOCK_ADAPTER_ID,
-                        ModuleVersion::Version(V1.to_owned()),
-                    )?,
-                    None,
-                ),
-                (
-                    ModuleInfo::from_id(app_1::MOCK_APP_ID, ModuleVersion::Version(V1.to_owned()))?,
-                    Some(to_binary(&app::InstantiateMsg {
-                        module: MockInitMsg,
-                        base: BaseInstantiateMsg {
-                            ans_host_address: deployment.ans_host.addr_str()?,
-                        },
-                    })?),
-                ),
-            ],
-        },
-        GovernanceDetails::Monarchy {
-            monarch: sender.to_string(),
-        },
-    ).unwrap();
+    let account = factory
+        .create_new_account(
+            AccountDetails {
+                name: String::from("second_account"),
+                description: Some(String::from("account_description")),
+                link: Some(String::from("https://account_link_of_at_least_11_char")),
+                namespace: None,
+                base_asset: None,
+                install_modules: vec![
+                    (
+                        ModuleInfo::from_id(
+                            adapter_1::MOCK_ADAPTER_ID,
+                            ModuleVersion::Version(V1.to_owned()),
+                        )?,
+                        None,
+                    ),
+                    (
+                        ModuleInfo::from_id(
+                            adapter_2::MOCK_ADAPTER_ID,
+                            ModuleVersion::Version(V1.to_owned()),
+                        )?,
+                        None,
+                    ),
+                    (
+                        ModuleInfo::from_id(
+                            app_1::MOCK_APP_ID,
+                            ModuleVersion::Version(V1.to_owned()),
+                        )?,
+                        Some(to_binary(&app::InstantiateMsg {
+                            module: MockInitMsg,
+                            base: BaseInstantiateMsg {
+                                ans_host_address: deployment.ans_host.addr_str()?,
+                            },
+                        })?),
+                    ),
+                ],
+            },
+            GovernanceDetails::Monarchy {
+                monarch: sender.to_string(),
+            },
+        )
+        .unwrap();
 
     // Make sure all installed
     let account_module_versions = account.manager.module_versions(vec![

--- a/framework/contracts/account/manager/tests/upgrades.rs
+++ b/framework/contracts/account/manager/tests/upgrades.rs
@@ -529,7 +529,7 @@ fn create_account_with_installed_module() -> AResult {
         GovernanceDetails::Monarchy {
             monarch: sender.to_string(),
         },
-    )?;
+    ).unwrap();
 
     // Make sure all installed
     let account_module_versions = account.manager.module_versions(vec![

--- a/framework/contracts/native/account-factory/src/commands.rs
+++ b/framework/contracts/native/account-factory/src/commands.rs
@@ -310,7 +310,7 @@ pub fn after_proxy_add_to_manager_and_set_admin(
         vec![],
     )?;
 
-    // The execution order here is important. 
+    // The execution order here is important.
     // Installing modules on the manager account requires that:
     // - The account is registered.
     // - The manager is the Admin of the proxy.

--- a/framework/contracts/native/account-factory/src/contract.rs
+++ b/framework/contracts/native/account-factory/src/contract.rs
@@ -89,14 +89,14 @@ pub fn execute(
 
 /// This just stores the result for future query
 #[cfg_attr(feature = "export", cosmwasm_std::entry_point)]
-pub fn reply(deps: DepsMut, _env: Env, msg: Reply) -> AccountFactoryResult {
+pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> AccountFactoryResult {
     match msg {
         Reply {
-            id: commands::CREATE_ACCOUNT_MANAGER_MSG_ID,
-            result,
-        } => commands::after_manager_create_proxy(deps, result),
-        Reply {
             id: commands::CREATE_ACCOUNT_PROXY_MSG_ID,
+            result,
+        } => commands::after_proxy_create_manager(deps, env, result),
+        Reply {
+            id: commands::CREATE_ACCOUNT_MANAGER_MSG_ID,
             result,
         } => commands::after_proxy_add_to_manager_and_set_admin(deps, result),
         _ => Err(AccountFactoryError::UnexpectedReply {}),

--- a/framework/packages/abstract-adapter/src/endpoints/instantiate.rs
+++ b/framework/packages/abstract-adapter/src/endpoints/instantiate.rs
@@ -43,7 +43,7 @@ impl<
         self.base_state.save(deps.storage, &state)?;
 
         let Some(handler) = self.maybe_instantiate_handler() else {
-            return Ok(Response::new())
+            return Ok(Response::new());
         };
         handler(deps, env, info, self, msg.module)
     }

--- a/framework/packages/abstract-app/src/endpoints/instantiate.rs
+++ b/framework/packages/abstract-app/src/endpoints/instantiate.rs
@@ -72,7 +72,7 @@ impl<
         self.admin.set(deps.branch(), Some(account_base.manager))?;
 
         let Some(handler) = self.maybe_instantiate_handler() else {
-            return Ok(Response::new())
+            return Ok(Response::new());
         };
         handler(deps, env, info, self, msg.module)
     }

--- a/framework/packages/abstract-core/src/core/manager.rs
+++ b/framework/packages/abstract-core/src/core/manager.rs
@@ -114,6 +114,7 @@ pub struct InstantiateMsg {
     pub name: String,
     pub description: Option<String>,
     pub link: Option<String>,
+    pub install_modules: Vec<(ModuleInfo, Option<Binary>)>,
 }
 
 /// Callback message to set the dependencies after module upgrades.

--- a/framework/packages/abstract-core/src/core/manager.rs
+++ b/framework/packages/abstract-core/src/core/manager.rs
@@ -19,8 +19,9 @@ pub mod state {
 
     pub use crate::objects::account_id::ACCOUNT_ID;
     use crate::objects::common_namespace::OWNERSHIP_STORAGE_KEY;
+    use crate::objects::module::ModuleInfo;
     use crate::objects::{gov_type::GovernanceDetails, module::ModuleId};
-    use cosmwasm_std::{Addr, Api};
+    use cosmwasm_std::{Addr, Api, Binary};
     use cw_address_like::AddressLike;
     use cw_controllers::Admin;
     use cw_ownable::Ownership;
@@ -86,6 +87,8 @@ pub mod state {
     /// Stores the dependency relationship between modules
     /// map module -> modules that depend on module.
     pub const DEPENDENTS: Map<ModuleId, HashSet<String>> = Map::new("dependents");
+    /// Stores a queue of modules to install on the account after creation.
+    pub const MODULE_QUEUE: Item<Vec<(ModuleInfo, Option<Binary>)>> = Item::new("mqueue");
 }
 
 use self::state::AccountInfo;
@@ -114,6 +117,7 @@ pub struct InstantiateMsg {
     pub name: String,
     pub description: Option<String>,
     pub link: Option<String>,
+    // Optionally modules can be provided. They will be installed after account registration.
     pub install_modules: Vec<(ModuleInfo, Option<Binary>)>,
 }
 

--- a/framework/packages/abstract-core/src/native/account_factory.rs
+++ b/framework/packages/abstract-core/src/native/account_factory.rs
@@ -14,8 +14,9 @@ pub mod state {
 
     use crate::objects::{
         account_id::AccountId,
+        gov_type::GovernanceDetails,
         module::{Module, ModuleInfo},
-        AssetEntry, gov_type::GovernanceDetails,
+        AssetEntry,
     };
 
     /// Account Factory configuration

--- a/framework/packages/abstract-core/src/native/account_factory.rs
+++ b/framework/packages/abstract-core/src/native/account_factory.rs
@@ -15,7 +15,7 @@ pub mod state {
     use crate::objects::{
         account_id::AccountId,
         module::{Module, ModuleInfo},
-        AssetEntry,
+        AssetEntry, gov_type::GovernanceDetails,
     };
 
     /// Account Factory configuration
@@ -30,7 +30,7 @@ pub mod state {
     /// Account Factory context for post-[`crate::abstract_manager`] [`crate::abstract_proxy`] creation
     #[derive(Serialize, Deserialize, Clone, Debug)]
     pub struct Context {
-        pub account_manager_address: Option<Addr>,
+        pub account_proxy_address: Option<Addr>,
         pub manager_module: Option<Module>,
         pub proxy_module: Option<Module>,
 
@@ -43,6 +43,10 @@ pub mod state {
     pub struct AdditionalContextConfig {
         pub namespace: Option<String>,
         pub base_asset: Option<AssetEntry>,
+        pub name: String,
+        pub description: Option<String>,
+        pub link: Option<String>,
+        pub owner: GovernanceDetails<String>,
     }
 
     pub const CONFIG: Item<Config> = Item::new("\u{0}{5}config");

--- a/framework/packages/abstract-core/src/objects/module.rs
+++ b/framework/packages/abstract-core/src/objects/module.rs
@@ -364,7 +364,7 @@ pub fn assert_module_data_validity(
             let Some(addr) = module_address else {
                 // if no addr provided and module doesn't have it, just return
                 // this will be the case when registering a code-id on VC
-                return Ok(())
+                return Ok(());
             };
             addr
         }
@@ -384,7 +384,7 @@ pub fn assert_module_data_validity(
     );
 
     let ModuleVersion::Version(version) = &module_claim.info.version else {
-    panic!("Module version is not versioned, context setting is wrong")
+        panic!("Module version is not versioned, context setting is wrong")
     };
 
     // Assert that the contract version is equal to the module version

--- a/framework/packages/abstract-ibc-host/src/endpoints/instantiate.rs
+++ b/framework/packages/abstract-ibc-host/src/endpoints/instantiate.rs
@@ -57,7 +57,7 @@ impl<
         self.base_state.save(deps.storage, &state)?;
 
         let Some(handler) = self.maybe_instantiate_handler() else {
-            return Ok(Response::new())
+            return Ok(Response::new());
         };
         self.admin.set(deps.branch(), Some(info.sender.clone()))?;
         handler(deps, env, info, self, msg.module)

--- a/framework/packages/abstract-sdk/src/apis/modules.rs
+++ b/framework/packages/abstract-sdk/src/apis/modules.rs
@@ -62,7 +62,9 @@ impl<'a, T: ModuleInterface> Modules<'a, T> {
         let maybe_module_addr =
             ACCOUNT_MODULES.query(&self.deps.querier, manager_addr, module_id)?;
         let Some(module_addr) = maybe_module_addr else {
-            return Err(crate::AbstractSdkError::MissingModule { module: module_id.to_string() });
+            return Err(crate::AbstractSdkError::MissingModule {
+                module: module_id.to_string(),
+            });
         };
         Ok(module_addr)
     }

--- a/framework/packages/abstract-sdk/src/base/handler.rs
+++ b/framework/packages/abstract-sdk/src/base/handler.rs
@@ -65,7 +65,9 @@ where
         &self,
     ) -> AbstractSdkResult<ExecuteHandlerFn<Self, Self::CustomExecMsg, Self::Error>> {
         let Some(handler) = self.maybe_execute_handler() else {
-            return Err(AbstractSdkError::MissingHandler { endpoint: "execution handler".to_string() })
+            return Err(AbstractSdkError::MissingHandler {
+                endpoint: "execution handler".to_string(),
+            });
         };
         Ok(handler)
     }
@@ -82,7 +84,9 @@ where
         &self,
     ) -> AbstractSdkResult<InstantiateHandlerFn<Self, Self::CustomInitMsg, Self::Error>> {
         let Some(handler) = self.maybe_instantiate_handler() else {
-            return Err(AbstractSdkError::MissingHandler { endpoint: "instantiate".to_string() })
+            return Err(AbstractSdkError::MissingHandler {
+                endpoint: "instantiate".to_string(),
+            });
         };
         Ok(handler)
     }
@@ -99,7 +103,9 @@ where
         &self,
     ) -> AbstractSdkResult<QueryHandlerFn<Self, Self::CustomQueryMsg, Self::Error>> {
         let Some(handler) = self.maybe_query_handler() else {
-            return Err(AbstractSdkError::MissingHandler { endpoint: "query".to_string() })
+            return Err(AbstractSdkError::MissingHandler {
+                endpoint: "query".to_string(),
+            });
         };
         Ok(handler)
     }
@@ -116,7 +122,9 @@ where
         &self,
     ) -> AbstractSdkResult<MigrateHandlerFn<Self, Self::CustomMigrateMsg, Self::Error>> {
         let Some(handler) = self.maybe_migrate_handler() else {
-            return Err(AbstractSdkError::MissingHandler { endpoint: "migrate".to_string() })
+            return Err(AbstractSdkError::MissingHandler {
+                endpoint: "migrate".to_string(),
+            });
         };
         Ok(handler)
     }
@@ -129,7 +137,9 @@ where
     /// Get a sudo handler or return an error.
     fn sudo_handler(&self) -> AbstractSdkResult<SudoHandlerFn<Self, Self::SudoMsg, Self::Error>> {
         let Some(handler) = self.maybe_sudo_handler() else {
-            return Err(AbstractSdkError::MissingHandler { endpoint: "sudo".to_string() })
+            return Err(AbstractSdkError::MissingHandler {
+                endpoint: "sudo".to_string(),
+            });
         };
         Ok(handler)
     }
@@ -146,7 +156,9 @@ where
         &self,
     ) -> AbstractSdkResult<ReceiveHandlerFn<Self, Self::ReceiveMsg, Self::Error>> {
         let Some(handler) = self.maybe_receive_handler() else {
-            return Err(AbstractSdkError::MissingHandler { endpoint: "receive".to_string() })
+            return Err(AbstractSdkError::MissingHandler {
+                endpoint: "receive".to_string(),
+            });
         };
         Ok(handler)
     }
@@ -178,7 +190,9 @@ where
     /// Get a reply handler or return an error.
     fn reply_handler(&self, id: u64) -> AbstractSdkResult<ReplyHandlerFn<Self, Self::Error>> {
         let Some(handler) = self.maybe_reply_handler(id) else {
-            return Err(AbstractSdkError::MissingHandler { endpoint: format! {"reply with id {id}"} })
+            return Err(AbstractSdkError::MissingHandler {
+                endpoint: format! {"reply with id {id}"},
+            });
         };
         Ok(handler)
     }


### PR DESCRIPTION
Update the account creation logic to:
- Save a module queue in the manager for later installation. 
- Update the message execution ordering in the account factory to unsure permissions are changed at the correct time.
- Update the internal config logic of the manager to only allow account factory calls when the account is being instantiated. After instantiation the module queue is loaded and any queued modules are installed. 

Question @Buckram123: How do we want to manage payments related to these module installations?

### Checklist

- [ ] CI is green.
- [ ] Changelog updated.
