### PR TITLE
Update/Must use on abstract sdk methods

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Modified the account id structure. Each account is now identified with a unique ID and a trace. This is a requirement for Abstract IBC.
 - Register Module(and Add Module) will now accept list of items, which reduces gas for multi-module install
 - Stake methods on cw-staking adapter now accept list, allowing users to do multi-stake/unstake/etc.
+- Added must_use attribute on abstract sdk methods
 
 ### Fixed
 

--- a/framework/packages/abstract-sdk/src/account_action.rs
+++ b/framework/packages/abstract-sdk/src/account_action.rs
@@ -5,6 +5,7 @@ use cosmwasm_std::CosmosMsg;
 ///
 /// If required you can create an AccountAction from a CosmosMsg using `AccountAction::from(msg)`.
 #[derive(Debug, PartialEq, Clone, Default)]
+#[must_use = "Pass AccountAction to the Executor"]
 pub struct AccountAction(Vec<CosmosMsg>);
 
 impl AccountAction {

--- a/framework/packages/abstract-sdk/src/account_action.rs
+++ b/framework/packages/abstract-sdk/src/account_action.rs
@@ -1,11 +1,11 @@
 use cosmwasm_std::CosmosMsg;
 
 /// Encapsulates an action on the account.
-/// When a method returns an AccountAction, this means this message needs to be dispatched to the account using the [`Execution`] api.
+/// When a method returns an AccountAction, this means this message needs to be dispatched to the account using the [`crate::Execution`] api.
 ///
 /// If required you can create an AccountAction from a CosmosMsg using `AccountAction::from(msg)`.
 #[derive(Debug, PartialEq, Clone, Default)]
-#[must_use = "Pass AccountAction to the Executor"]
+#[must_use = "Pass AccountAction to the Executor, see the docs"]
 pub struct AccountAction(Vec<CosmosMsg>);
 
 impl AccountAction {

--- a/framework/packages/abstract-sdk/src/account_action.rs
+++ b/framework/packages/abstract-sdk/src/account_action.rs
@@ -1,7 +1,7 @@
 use cosmwasm_std::CosmosMsg;
 
 /// Encapsulates an action on the account.
-/// When a method returns an AccountAction, this means this message needs to be dispatched to the account using the [`crate::Execution`] api.
+/// When a method returns an AccountAction, this means this message needs to be dispatched to the account using the [`Execution`](crate::Execution) api.
 ///
 /// If required you can create an AccountAction from a CosmosMsg using `AccountAction::from(msg)`.
 #[derive(Debug, PartialEq, Clone, Default)]

--- a/framework/packages/abstract-sdk/src/apis/bank.rs
+++ b/framework/packages/abstract-sdk/src/apis/bank.rs
@@ -138,7 +138,7 @@ impl<'a, T: TransferInterface> Bank<'a, T> {
             .map(|asset| asset.transfer_msg(recipient.clone()))
             .collect::<Result<Vec<_>, _>>()
             .map_err(Into::into)
-            .map(|msgs| DepositMsgs(msgs))
+            .map(DepositMsgs)
     }
 
     /// Withdraw funds from the Account to this contract.

--- a/framework/packages/abstract-sdk/src/apis/bank.rs
+++ b/framework/packages/abstract-sdk/src/apis/bank.rs
@@ -252,7 +252,7 @@ mod test {
     mod transfer_coins {
         use abstract_core::proxy::ExecuteMsg;
 
-        use crate::{Execution, Executor, UnusedExecutorMsg};
+        use crate::{Execution, Executor, ExecutorMsg};
 
         use super::*;
 
@@ -268,7 +268,7 @@ mod test {
             let bank_transfer: AccountAction = bank.transfer(coins.clone(), &recipient).unwrap();
 
             let executor: Executor<'_, MockModule> = app.executor(deps.as_ref());
-            let account_message: UnusedExecutorMsg = executor.execute(vec![bank_transfer]).unwrap();
+            let account_message: ExecutorMsg = executor.execute(vec![bank_transfer]).unwrap();
             let response: Response = Response::new().add_message(account_message);
             // ANCHOR_END: transfer
 

--- a/framework/packages/abstract-sdk/src/apis/bank.rs
+++ b/framework/packages/abstract-sdk/src/apis/bank.rs
@@ -231,7 +231,7 @@ mod test {
     mod transfer_coins {
         use abstract_core::proxy::ExecuteMsg;
 
-        use crate::{Execution, Executor};
+        use crate::{Execution, Executor, UnusedExecutorMsg};
 
         use super::*;
 
@@ -247,7 +247,7 @@ mod test {
             let bank_transfer: AccountAction = bank.transfer(coins.clone(), &recipient).unwrap();
 
             let executor: Executor<'_, MockModule> = app.executor(deps.as_ref());
-            let account_message: CosmosMsg = executor.execute(vec![bank_transfer]).unwrap();
+            let account_message: UnusedExecutorMsg = executor.execute(vec![bank_transfer]).unwrap();
             let response: Response = Response::new().add_message(account_message);
             // ANCHOR_END: transfer
 

--- a/framework/packages/abstract-sdk/src/apis/execution.rs
+++ b/framework/packages/abstract-sdk/src/apis/execution.rs
@@ -138,7 +138,7 @@ impl<'a, T: Execution> Executor<'a, T> {
 }
 
 /// CosmosMsg from the executor methods
-#[must_use = "Pass it to the response"]
+#[must_use = "Pass it to the Response::add_message"]
 #[cfg_attr(not(target_arch = "wasm32"), derive(Debug, PartialEq, Eq))]
 pub struct UnusedExecutorMsg(CosmosMsg);
 

--- a/framework/packages/abstract-sdk/src/apis/execution.rs
+++ b/framework/packages/abstract-sdk/src/apis/execution.rs
@@ -61,25 +61,27 @@ pub struct Executor<'a, T: Execution> {
 
 impl<'a, T: Execution> Executor<'a, T> {
     /// Execute a single message on the `ModuleActionWithData` endpoint.
-    fn execute_with_data(&self, msg: CosmosMsg) -> AbstractSdkResult<CosmosMsg> {
-        Ok(wasm_execute(
+    fn execute_with_data(&self, msg: CosmosMsg) -> AbstractSdkResult<UnusedExecutorMsg> {
+        let msg = wasm_execute(
             self.base.proxy_address(self.deps)?.to_string(),
             &ExecuteMsg::ModuleActionWithData { msg },
             vec![],
         )?
-        .into())
+        .into();
+        Ok(UnusedExecutorMsg(msg))
     }
 
     /// Execute the msgs on the Account.
     /// These messages will be executed on the proxy contract and the sending module must be whitelisted.
-    pub fn execute(&self, actions: Vec<AccountAction>) -> AbstractSdkResult<CosmosMsg> {
+    pub fn execute(&self, actions: Vec<AccountAction>) -> AbstractSdkResult<UnusedExecutorMsg> {
         let msgs = actions.into_iter().flat_map(|a| a.messages()).collect();
-        Ok(wasm_execute(
+        let msg: CosmosMsg = wasm_execute(
             self.base.proxy_address(self.deps)?.to_string(),
             &ExecuteMsg::ModuleAction { msgs },
             vec![],
         )?
-        .into())
+        .into();
+        Ok(UnusedExecutorMsg(msg))
     }
 
     /// Execute the msgs on the Account.
@@ -94,7 +96,7 @@ impl<'a, T: Execution> Executor<'a, T> {
         let msg = self.execute(actions)?;
         let sub_msg = SubMsg {
             id,
-            msg,
+            msg: msg.into(),
             gas_limit: None,
             reply_on,
         };
@@ -113,7 +115,7 @@ impl<'a, T: Execution> Executor<'a, T> {
         let msg = self.execute_with_data(actions)?;
         let sub_msg = SubMsg {
             id,
-            msg,
+            msg: msg.into(),
             gas_limit: None,
             reply_on,
         };
@@ -132,6 +134,17 @@ impl<'a, T: Execution> Executor<'a, T> {
         let resp = Response::default();
 
         Ok(with_abstract_event!(resp, self.base.module_id(), action).add_message(msg))
+    }
+}
+
+/// CosmosMsg from the executor methods
+#[must_use = "Pass it to the response"]
+#[cfg_attr(not(target_arch = "wasm32"), derive(Debug, PartialEq, Eq))]
+pub struct UnusedExecutorMsg(CosmosMsg);
+
+impl From<UnusedExecutorMsg> for CosmosMsg {
+    fn from(val: UnusedExecutorMsg) -> Self {
+        val.0
     }
 }
 
@@ -171,14 +184,14 @@ mod test {
             let actual_res = executor.execute(messages.clone());
             assert_that!(actual_res).is_ok();
 
-            let expected = CosmosMsg::Wasm(WasmMsg::Execute {
+            let expected = UnusedExecutorMsg(CosmosMsg::Wasm(WasmMsg::Execute {
                 contract_addr: TEST_PROXY.to_string(),
                 msg: to_binary(&ExecuteMsg::ModuleAction {
                     msgs: flatten_actions(messages),
                 })
                 .unwrap(),
                 funds: vec![],
-            });
+            }));
             assert_that!(actual_res.unwrap()).is_equal_to(expected);
         }
 
@@ -194,7 +207,7 @@ mod test {
             let actual_res = executor.execute(messages.clone());
             assert_that!(actual_res).is_ok();
 
-            let expected = CosmosMsg::Wasm(WasmMsg::Execute {
+            let expected = UnusedExecutorMsg(CosmosMsg::Wasm(WasmMsg::Execute {
                 contract_addr: TEST_PROXY.to_string(),
                 msg: to_binary(&ExecuteMsg::ModuleAction {
                     msgs: flatten_actions(messages),
@@ -202,7 +215,7 @@ mod test {
                 .unwrap(),
                 // funds should be empty
                 funds: vec![],
-            });
+            }));
             assert_that!(actual_res.unwrap()).is_equal_to(expected);
         }
     }

--- a/framework/packages/abstract-sdk/src/apis/execution.rs
+++ b/framework/packages/abstract-sdk/src/apis/execution.rs
@@ -61,19 +61,19 @@ pub struct Executor<'a, T: Execution> {
 
 impl<'a, T: Execution> Executor<'a, T> {
     /// Execute a single message on the `ModuleActionWithData` endpoint.
-    fn execute_with_data(&self, msg: CosmosMsg) -> AbstractSdkResult<UnusedExecutorMsg> {
+    fn execute_with_data(&self, msg: CosmosMsg) -> AbstractSdkResult<ExecutorMsg> {
         let msg = wasm_execute(
             self.base.proxy_address(self.deps)?.to_string(),
             &ExecuteMsg::ModuleActionWithData { msg },
             vec![],
         )?
         .into();
-        Ok(UnusedExecutorMsg(msg))
+        Ok(ExecutorMsg(msg))
     }
 
     /// Execute the msgs on the Account.
     /// These messages will be executed on the proxy contract and the sending module must be whitelisted.
-    pub fn execute(&self, actions: Vec<AccountAction>) -> AbstractSdkResult<UnusedExecutorMsg> {
+    pub fn execute(&self, actions: Vec<AccountAction>) -> AbstractSdkResult<ExecutorMsg> {
         let msgs = actions.into_iter().flat_map(|a| a.messages()).collect();
         let msg: CosmosMsg = wasm_execute(
             self.base.proxy_address(self.deps)?.to_string(),
@@ -81,7 +81,7 @@ impl<'a, T: Execution> Executor<'a, T> {
             vec![],
         )?
         .into();
-        Ok(UnusedExecutorMsg(msg))
+        Ok(ExecutorMsg(msg))
     }
 
     /// Execute the msgs on the Account.
@@ -138,12 +138,12 @@ impl<'a, T: Execution> Executor<'a, T> {
 }
 
 /// CosmosMsg from the executor methods
-#[must_use = "Pass it to the Response::add_message"]
+#[must_use = "ExecutorMsg should be provided to Response::add_message"]
 #[cfg_attr(not(target_arch = "wasm32"), derive(Debug, PartialEq, Eq))]
-pub struct UnusedExecutorMsg(CosmosMsg);
+pub struct ExecutorMsg(CosmosMsg);
 
-impl From<UnusedExecutorMsg> for CosmosMsg {
-    fn from(val: UnusedExecutorMsg) -> Self {
+impl From<ExecutorMsg> for CosmosMsg {
+    fn from(val: ExecutorMsg) -> Self {
         val.0
     }
 }
@@ -184,7 +184,7 @@ mod test {
             let actual_res = executor.execute(messages.clone());
             assert_that!(actual_res).is_ok();
 
-            let expected = UnusedExecutorMsg(CosmosMsg::Wasm(WasmMsg::Execute {
+            let expected = ExecutorMsg(CosmosMsg::Wasm(WasmMsg::Execute {
                 contract_addr: TEST_PROXY.to_string(),
                 msg: to_binary(&ExecuteMsg::ModuleAction {
                     msgs: flatten_actions(messages),
@@ -207,7 +207,7 @@ mod test {
             let actual_res = executor.execute(messages.clone());
             assert_that!(actual_res).is_ok();
 
-            let expected = UnusedExecutorMsg(CosmosMsg::Wasm(WasmMsg::Execute {
+            let expected = ExecutorMsg(CosmosMsg::Wasm(WasmMsg::Execute {
                 contract_addr: TEST_PROXY.to_string(),
                 msg: to_binary(&ExecuteMsg::ModuleAction {
                     msgs: flatten_actions(messages),

--- a/framework/packages/abstract-sdk/src/apis/splitter.rs
+++ b/framework/packages/abstract-sdk/src/apis/splitter.rs
@@ -59,6 +59,7 @@ mod test {
 
     use crate::{
         apis::splitter::SplitterInterface, mock_module::MockModule, AbstractSdkError, Execution,
+        UnusedExecutorMsg,
     };
 
     fn split() -> Result<Response, AbstractSdkError> {
@@ -79,7 +80,7 @@ mod test {
         let split_funds = module.splitter(deps.as_ref()).split(asset, &receivers)?;
         assert_eq!(split_funds.messages().len(), 3);
 
-        let msg: CosmosMsg = module.executor(deps.as_ref()).execute(vec![split_funds])?;
+        let msg: UnusedExecutorMsg = module.executor(deps.as_ref()).execute(vec![split_funds])?;
 
         Ok(Response::new().add_message(msg))
         // ANCHOR_END: usage

--- a/framework/packages/abstract-sdk/src/apis/splitter.rs
+++ b/framework/packages/abstract-sdk/src/apis/splitter.rs
@@ -59,7 +59,7 @@ mod test {
 
     use crate::{
         apis::splitter::SplitterInterface, mock_module::MockModule, AbstractSdkError, Execution,
-        UnusedExecutorMsg,
+        ExecutorMsg,
     };
 
     fn split() -> Result<Response, AbstractSdkError> {
@@ -80,7 +80,7 @@ mod test {
         let split_funds = module.splitter(deps.as_ref()).split(asset, &receivers)?;
         assert_eq!(split_funds.messages().len(), 3);
 
-        let msg: UnusedExecutorMsg = module.executor(deps.as_ref()).execute(vec![split_funds])?;
+        let msg: ExecutorMsg = module.executor(deps.as_ref()).execute(vec![split_funds])?;
 
         Ok(Response::new().add_message(msg))
         // ANCHOR_END: usage


### PR DESCRIPTION
This adds warnings on unused `AccountAction` and unused `CosmosMsg` from the `Executor`

- Helpfully `add_message` and `add_messages` takes `impl Into<CosmosMsg<T>>`, so it shouldn't affect users.
- Unfortunately `add_submessage` takes raw `SubMsg<T>`.  

So we still have an issue: we can't implement message wrapper with unused warning for unused SubMsg, because it will require users to cast it using "into" every time

### Checklist

- [x] CI is green.
- [x] Changelog updated.
