### PR TITLE
Simple test for cw-orch full deploy

### DIFF
--- a/framework/Cargo.toml
+++ b/framework/Cargo.toml
@@ -53,7 +53,8 @@ protobuf = { version = "2", features = ["with-bytes"] }
 clap = { version = "4.0.32", features = ["derive"] }
 semver = "1.0"
 cw-semver = { version = "1.0" }
-cw-orch = { version = "0.16.1" }
+#cw-orch = { version = "0.16.1" }
+cw-orch = { git = "https://github.com/AbstractSDK/cw-orchestrator", branch = "update/add-full-deploy" }
 tokio = { version = "1.4", features = ["full"] }
 
 ## crates in order of publishing ## see docs/Publishing.md

--- a/framework/contracts/account/manager/src/commands.rs
+++ b/framework/contracts/account/manager/src/commands.rs
@@ -239,7 +239,7 @@ pub fn create_sub_account(
     assert_admin_right(deps.as_ref(), &msg_info.sender)?;
 
     let create_account_msg = &abstract_core::account_factory::ExecuteMsg::CreateAccount {
-        /// proxy of this manager will be the account owner
+        // proxy of this manager will be the account owner
         governance: GovernanceDetails::SubAccount {
             manager: env.contract.address.into_string(),
             proxy: ACCOUNT_MODULES.load(deps.storage, PROXY)?.into_string(),

--- a/framework/scripts/src/bin/full_deploy.rs
+++ b/framework/scripts/src/bin/full_deploy.rs
@@ -1,16 +1,10 @@
-use reqwest::Url;
-use std::{
-    fs::{self, File},
-    io::BufReader,
-    net::TcpStream,
-};
-
 use abstract_core::objects::gov_type::GovernanceDetails;
 use abstract_interface::Abstract;
 
-use abstract_interface_scripts::{assert_wallet_balance, DeploymentStatus, SUPPORTED_CHAINS};
+use abstract_interface_scripts::SUPPORTED_CHAINS;
 use clap::Parser;
 use cw_orch::{
+    daemon::DaemonError,
     deploy::Deploy,
     prelude::{
         networks::{parse_network, ChainInfo},
@@ -29,101 +23,37 @@ fn full_deploy(mut networks: Vec<ChainInfo>) -> anyhow::Result<()> {
         networks = SUPPORTED_CHAINS.to_vec();
     }
 
-    let deployment_status = read_deployment()?;
-    if deployment_status.success {
-        log::info!("Do you want to re-deploy to {:?}?", networks);
-        let mut input = String::new();
-        std::io::stdin().read_line(&mut input)?;
-        if input.to_lowercase().contains('n') {
-            return Ok(());
-        }
-    }
-    // let deployment_status = deployment_status.clone();
+    // We fill the variable with what we need
 
-    // If some chains need to be deployed, deploy them
-    // if !deployment_status.chain_ids.is_empty() {
-    //     networks = deployment_status.chain_ids.into_iter().map(|n| parse_network(&n)).collect();
-    // }
+    let networks = networks
+        .iter()
+        .map(|n| {
+            // let chain = DaemonBuilder::default()
+            //     .handle(rt.handle())
+            //     .chain(n.clone())
+            //     .build()?;
 
-    let networks = rt.block_on(assert_wallet_balance(&networks));
+            let chain = Mock::with_chain_id(&Addr::unchecked("sender"), n.chain_id);
+            Ok::<_, DaemonError>((chain.clone(), chain.sender().to_string()))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
 
-    // write_deployment(&deployment_status)?;
+    let _deployments = Abstract::full_deploy(
+        networks,
+        None,
+        Some(|abstr| {
+            abstr
+                .account_factory
+                .create_default_account(GovernanceDetails::Monarchy {
+                    monarch: abstr.account_factory.get_chain().sender().to_string(),
+                })?;
 
-    for network in networks {
-        let urls = network.grpc_urls.to_vec();
-        for url in urls {
-            rt.block_on(ping_grpc(url))?;
-        }
+            // anyhow::bail!("Artificial error for testing");
+            Ok(())
+        }),
+    )?;
 
-        let chain = DaemonBuilder::default()
-            .handle(rt.handle())
-            .chain(network.clone())
-            .build()?;
-
-        let sender = chain.sender();
-
-        let deployment = match Abstract::deploy_on(chain, sender.to_string()) {
-            Ok(deployment) => {
-                // write_deployment(&deployment_status)?;
-                deployment
-            }
-            Err(e) => {
-                // write_deployment(&deployment_status)?;
-                return Err(e.into());
-            }
-        };
-
-        // Create the Abstract Account because it's needed for the fees for the dex module
-        deployment
-            .account_factory
-            .create_default_account(GovernanceDetails::Monarchy {
-                monarch: sender.to_string(),
-            })?;
-    }
-
-    // fs::copy(Path::new("~/.cw-orchestrator/state.json"), to)
     Ok(())
-}
-
-async fn ping_grpc(url_str: &str) -> anyhow::Result<()> {
-    let parsed_url = Url::parse(url_str)?;
-
-    let host = parsed_url
-        .host_str()
-        .ok_or_else(|| anyhow::anyhow!("No host in url"))?;
-
-    let port = parsed_url.port_or_known_default().ok_or_else(|| {
-        anyhow::anyhow!(
-            "No port in url, and no default for scheme {:?}",
-            parsed_url.scheme()
-        )
-    })?;
-    let socket_addr = format!("{}:{}", host, port);
-
-    let _ = TcpStream::connect(socket_addr);
-    Ok(())
-}
-#[allow(dead_code)]
-fn write_deployment(status: &DeploymentStatus) -> anyhow::Result<()> {
-    let path = dirs::home_dir()
-        .unwrap()
-        .join(".cw-orchestrator")
-        .join("chains.json");
-    let status_str = serde_json::to_string_pretty(status)?;
-    fs::write(path, status_str)?;
-    Ok(())
-}
-
-fn read_deployment() -> anyhow::Result<DeploymentStatus> {
-    let path = dirs::home_dir()
-        .unwrap()
-        .join(".cw-orchestrator")
-        .join("chains.json");
-    let file = File::open(path)?;
-    let reader = BufReader::new(file);
-
-    // Read the JSON contents of the file as an instance of `DeploymentStatus`. If not present use default.
-    Ok(serde_json::from_reader(reader).unwrap_or_default())
 }
 
 #[derive(Parser, Default, Debug)]

--- a/framework/scripts/src/bin/full_deploy.rs
+++ b/framework/scripts/src/bin/full_deploy.rs
@@ -11,14 +11,11 @@ use cw_orch::{
         *,
     },
 };
-use tokio::runtime::Runtime;
 
 pub const ABSTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 // Run "cargo run --example download_wasms" in the `abstract-interfaces` package before deploying!
 fn full_deploy(mut networks: Vec<ChainInfo>) -> anyhow::Result<()> {
-    let rt = Runtime::new()?;
-
     if networks.is_empty() {
         networks = SUPPORTED_CHAINS.to_vec();
     }
@@ -48,7 +45,10 @@ fn full_deploy(mut networks: Vec<ChainInfo>) -> anyhow::Result<()> {
                     monarch: abstr.account_factory.get_chain().sender().to_string(),
                 })?;
 
-            // anyhow::bail!("Artificial error for testing");
+            if abstr.account_factory.get_chain().block_info()?.chain_id == "phoenix-1"{
+                anyhow::bail!("Test error to show what happens when a deployment fails does");
+            }
+
             Ok(())
         }),
     )?;

--- a/framework/scripts/src/bin/full_deploy.rs
+++ b/framework/scripts/src/bin/full_deploy.rs
@@ -45,7 +45,7 @@ fn full_deploy(mut networks: Vec<ChainInfo>) -> anyhow::Result<()> {
                     monarch: abstr.account_factory.get_chain().sender().to_string(),
                 })?;
 
-            if abstr.account_factory.get_chain().block_info()?.chain_id == "phoenix-1"{
+            if abstr.account_factory.get_chain().block_info()?.chain_id == "phoenix-1" {
                 anyhow::bail!("Test error to show what happens when a deployment fails does");
             }
 


### PR DESCRIPTION
DO NOT MERGE !!!!!!

This PR aims at showing how the full_deploy cw-orch method works.
It shows a test for : https://github.com/AbstractSDK/cw-orchestrator/pull/257

To run the test, use 
```bash
RUST_LOG=INFO cargo run --bin full_deploy
```

This test will try to full_deploy abstract on multiple `Mock` chains. 

It will deploy on all supported chains expect on `phoenix-1` on which we simulate an error.

inside the [framework/scripts](https://github.com/AbstractSDK/abstract/tree/test/cw-orch-full-deploy/framework/scripts) folder. 

For disabling interactions, you can use : 
```bash
CW_ORCH_DISABLE_MANUAL_INTERACTION=true RUST_LOG=INFO cargo run --bin full_deploy
```


### Checklist

- [ ] CI is green.
- [ ] Changelog updated.
