### PR TITLE
add payable attr to create_subaccount

### DIFF
--- a/framework/contracts/account/manager/tests/subaccount.rs
+++ b/framework/contracts/account/manager/tests/subaccount.rs
@@ -23,6 +23,7 @@ fn creating_on_subaccount_should_succeed() -> AResult {
         None,
         None,
         None,
+        &[],
     )?;
     let sub_accounts = account.manager.sub_account_ids(None, None)?;
     assert_eq!(
@@ -48,6 +49,7 @@ fn updating_on_subaccount_should_succeed() -> AResult {
         None,
         None,
         None,
+        &[],
     )?;
 
     // Subaccount should have id 2 in this test, we try to update the config of this module
@@ -80,6 +82,7 @@ fn proxy_updating_on_subaccount_should_succeed() -> AResult {
         None,
         None,
         None,
+        &[],
     )?;
 
     // Subaccount should have id 2 in this test, we try to update the config of this module
@@ -113,6 +116,7 @@ fn recursive_updating_on_subaccount_should_succeed() -> AResult {
         None,
         None,
         None,
+        &[],
     )?;
 
     // Subaccount should have id 2 in this test, we try to update the config of this module
@@ -127,6 +131,7 @@ fn recursive_updating_on_subaccount_should_succeed() -> AResult {
         None,
         None,
         None,
+        &[],
     )?;
     let account_contracts =
         get_account_contracts(&deployment.version_control, Some(AccountId::local(3)));
@@ -158,6 +163,7 @@ fn installed_app_updating_on_subaccount_should_succeed() -> AResult {
         None,
         None,
         None,
+        &[],
     )?;
     let first_proxy_addr = account.proxy.address()?;
 
@@ -215,6 +221,7 @@ fn sub_account_move_ownership() -> AResult {
         None,
         None,
         None,
+        &[],
     )?;
     let sub_accounts = account.manager.sub_account_ids(None, None)?;
     assert_eq!(
@@ -278,6 +285,7 @@ fn account_move_ownership_to_sub_account() -> AResult {
         None,
         None,
         None,
+        &[],
     )?;
     let sub_account = AbstractAccount::new(&deployment, Some(AccountId::local(2)));
     let sub_manager_addr = sub_account.manager.address()?;
@@ -335,6 +343,7 @@ fn sub_account_move_ownership_to_sub_account() -> AResult {
         None,
         None,
         None,
+        &[],
     )?;
     let sub_account = AbstractAccount::new(&deployment, Some(AccountId::local(2)));
     let sub_manager_addr = sub_account.manager.address()?;
@@ -348,6 +357,7 @@ fn sub_account_move_ownership_to_sub_account() -> AResult {
         None,
         None,
         None,
+        &[],
     )?;
 
     // sub-accounts state updated
@@ -411,6 +421,7 @@ fn account_move_ownership_to_falsy_sub_account() -> AResult {
         None,
         None,
         None,
+        &[],
     )?;
     let sub_account = AbstractAccount::new(&deployment, Some(AccountId::local(2)));
     let sub_manager_addr = sub_account.manager.address()?;

--- a/framework/contracts/account/manager/tests/upgrades.rs
+++ b/framework/contracts/account/manager/tests/upgrades.rs
@@ -631,6 +631,7 @@ fn create_sub_account_with_installed_module() -> AResult {
         Some(String::from("account_description")),
         None,
         None,
+        &[],
     )?;
 
     let account = AbstractAccount::new(&deployment, Some(AccountId::local(2)));

--- a/framework/packages/abstract-core/src/core/manager.rs
+++ b/framework/packages/abstract-core/src/core/manager.rs
@@ -193,6 +193,7 @@ pub enum ExecuteMsg {
         modules: Vec<(ModuleInfo, Option<Binary>)>,
     },
     /// Creates a sub-account on the account
+    #[cfg_attr(feature = "interface", payable)]
     CreateSubAccount {
         // Name of the sub-account
         name: String,

--- a/framework/packages/abstract-interface/build.rs
+++ b/framework/packages/abstract-interface/build.rs
@@ -7,7 +7,7 @@ fn main() {
         .display()
         .to_string();
     // This is where the compiled wasm come from, not possible to change that for now
-    let _artifacts_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+    let artifacts_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("artifacts")
         .display()
         .to_string();
@@ -39,7 +39,7 @@ fn main() {
     // .unwrap();
 
     // We also verify that the local artifacts fir exists
-    // assert!(std::fs::metadata(artifacts_path).is_ok(), "You should create an artifacts dir in your crate to export the wasm files along with the cw-orch library");
+    assert!(std::fs::metadata(artifacts_path).is_ok(), "You should create an artifacts dir in your crate to export the wasm files along with the cw-orch library");
 
     println!("cargo:rerun-if-changed=build.rs");
     // println!("cargo:rerun-if-changed={}", absolute_state_path.display());

--- a/framework/packages/abstract-interface/build.rs
+++ b/framework/packages/abstract-interface/build.rs
@@ -7,7 +7,7 @@ fn main() {
         .display()
         .to_string();
     // This is where the compiled wasm come from, not possible to change that for now
-    let artifacts_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+    let _artifacts_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("artifacts")
         .display()
         .to_string();
@@ -39,7 +39,7 @@ fn main() {
     // .unwrap();
 
     // We also verify that the local artifacts fir exists
-    assert!(std::fs::metadata(artifacts_path).is_ok(), "You should create an artifacts dir in your crate to export the wasm files along with the cw-orch library");
+    // assert!(std::fs::metadata(artifacts_path).is_ok(), "You should create an artifacts dir in your crate to export the wasm files along with the cw-orch library");
 
     println!("cargo:rerun-if-changed=build.rs");
     // println!("cargo:rerun-if-changed={}", absolute_state_path.display());


### PR DESCRIPTION
Adds the payable attribute to the create_subaccount variant of the manager execute message.

### Checklist

- [x] CI is green.
- [x] Changelog updated.
