### PR TITLE
Replace to_binary with to_json_binary and from_binary with from_json

### DIFF
--- a/framework/contracts/account/manager/src/commands.rs
+++ b/framework/contracts/account/manager/src/commands.rs
@@ -40,8 +40,8 @@ use abstract_sdk::{
     ModuleRegistryInterface,
 };
 use cosmwasm_std::{
-    ensure, from_json, to_json_binary, wasm_execute, Addr, Attribute, Binary, Coin, CosmosMsg, Deps,
-    DepsMut, Empty, Env, MessageInfo, Response, StdError, StdResult, Storage, WasmMsg,
+    ensure, from_json, to_json_binary, wasm_execute, Addr, Attribute, Binary, Coin, CosmosMsg,
+    Deps, DepsMut, Empty, Env, MessageInfo, Response, StdError, StdResult, Storage, WasmMsg,
 };
 use cw2::{get_contract_version, ContractVersion};
 use cw_ownable::OwnershipError;
@@ -924,7 +924,7 @@ pub fn update_internal_config(
 ) -> ManagerResult {
     // deserialize the config action
     let action: InternalConfigAction =
-        from_json(&config).map_err(|error| ManagerError::InvalidConfigAction { error })?;
+        from_json(config).map_err(|error| ManagerError::InvalidConfigAction { error })?;
 
     let (add, remove) = match action {
         InternalConfigAction::UpdateModuleAddresses { to_add, to_remove } => (to_add, to_remove),
@@ -1981,7 +1981,8 @@ mod tests {
             let mut deps = mock_dependencies();
             mock_init(deps.as_mut())?;
 
-            let msg = ExecuteMsg::UpdateInternalConfig(to_json_binary(&QueryMsg::Config {}).unwrap());
+            let msg =
+                ExecuteMsg::UpdateInternalConfig(to_json_binary(&QueryMsg::Config {}).unwrap());
 
             let res = execute_as(deps.as_mut(), TEST_ACCOUNT_FACTORY, msg);
 

--- a/framework/contracts/account/manager/src/queries.rs
+++ b/framework/contracts/account/manager/src/queries.rs
@@ -8,7 +8,7 @@ use abstract_sdk::core::manager::{
 };
 use abstract_sdk::feature_objects::VersionControlContract;
 use abstract_sdk::ModuleRegistryInterface;
-use cosmwasm_std::{to_binary, Addr, Binary, Deps, Env, Order, StdError, StdResult};
+use cosmwasm_std::{to_json_binary, Addr, Binary, Deps, Env, Order, StdError, StdResult};
 use cw2::ContractVersion;
 use cw_storage_plus::Bound;
 use std::collections::BTreeMap;
@@ -19,18 +19,18 @@ const MAX_LIMIT: u8 = 10;
 pub fn handle_module_address_query(deps: Deps, env: Env, ids: Vec<String>) -> StdResult<Binary> {
     let contracts = query_module_addresses(deps, &env.contract.address, &ids)?;
     let vector = contracts.into_iter().map(|(v, k)| (v, k)).collect();
-    to_binary(&ModuleAddressesResponse { modules: vector })
+    to_json_binary(&ModuleAddressesResponse { modules: vector })
 }
 
 pub fn handle_contract_versions_query(deps: Deps, env: Env, ids: Vec<String>) -> StdResult<Binary> {
     let response = query_module_versions(deps, &env.contract.address, &ids)?;
     let versions = response.into_values().collect();
-    to_binary(&ModuleVersionsResponse { versions })
+    to_json_binary(&ModuleVersionsResponse { versions })
 }
 
 pub fn handle_account_info_query(deps: Deps) -> StdResult<Binary> {
     let info: AccountInfo = INFO.load(deps.storage)?;
-    to_binary(&InfoResponse { info })
+    to_json_binary(&InfoResponse { info })
 }
 
 pub fn handle_config_query(deps: Deps) -> StdResult<Binary> {
@@ -41,7 +41,7 @@ pub fn handle_config_query(deps: Deps) -> StdResult<Binary> {
         ..
     } = CONFIG.load(deps.storage)?;
     let is_suspended = SUSPENSION_STATUS.load(deps.storage)?;
-    to_binary(&ConfigResponse {
+    to_json_binary(&ConfigResponse {
         account_id,
         is_suspended,
         version_control_address,
@@ -77,7 +77,7 @@ pub fn handle_module_info_query(
         })
     }
 
-    to_binary(&ModuleInfosResponse {
+    to_json_binary(&ModuleInfosResponse {
         module_infos: resp_vec,
     })
 }
@@ -95,7 +95,7 @@ pub fn handle_sub_accounts_query(
         .take(limit)
         .collect::<StdResult<Vec<u32>>>()?;
 
-    to_binary(&SubAccountIdsResponse { sub_accounts: res })
+    to_json_binary(&SubAccountIdsResponse { sub_accounts: res })
 }
 
 /// RawQuery the version of an enabled module

--- a/framework/contracts/account/manager/tests/apps.rs
+++ b/framework/contracts/account/manager/tests/apps.rs
@@ -41,7 +41,7 @@ fn execute_on_proxy_through_manager() -> AResult {
     let forwarded_coin: Coin = coin(100, "other_coin");
 
     account.manager.exec_on_module(
-        cosmwasm_std::to_binary(&abstract_core::proxy::ExecuteMsg::ModuleAction {
+        cosmwasm_std::to_json_binary(&abstract_core::proxy::ExecuteMsg::ModuleAction {
             msgs: vec![CosmosMsg::Bank(cosmwasm_std::BankMsg::Burn {
                 amount: burn_amount,
             })],

--- a/framework/contracts/account/manager/tests/proxy.rs
+++ b/framework/contracts/account/manager/tests/proxy.rs
@@ -16,7 +16,7 @@ use abstract_testing::prelude::{TEST_ACCOUNT_ID, TEST_MODULE_ID};
 use common::{
     create_default_account, init_mock_adapter, install_adapter, mock_modules, AResult, TEST_COIN,
 };
-use cosmwasm_std::{coin, to_binary, wasm_execute, Addr, Coin, CosmosMsg};
+use cosmwasm_std::{coin, to_json_binary, wasm_execute, Addr, Coin, CosmosMsg};
 use cw_orch::deploy::Deploy;
 use cw_orch::prelude::*;
 use module_factory::error::ModuleFactoryError;
@@ -76,7 +76,7 @@ fn exec_through_manager() -> AResult {
     let burn_amount: Vec<Coin> = vec![Coin::new(10_000, TEST_COIN)];
 
     account.manager.exec_on_module(
-        cosmwasm_std::to_binary(&abstract_core::proxy::ExecuteMsg::ModuleAction {
+        cosmwasm_std::to_json_binary(&abstract_core::proxy::ExecuteMsg::ModuleAction {
             msgs: vec![CosmosMsg::Bank(cosmwasm_std::BankMsg::Burn {
                 amount: burn_amount,
             })],
@@ -152,7 +152,7 @@ fn with_response_data() -> AResult {
         .expect("test module installed");
     // proxy should be final executor because of the reply
     let resp = account.manager.exec_on_module(
-        cosmwasm_std::to_binary(&abstract_core::proxy::ExecuteMsg::ModuleActionWithData {
+        cosmwasm_std::to_json_binary(&abstract_core::proxy::ExecuteMsg::ModuleActionWithData {
             // execute a message on the adapter, which sets some data in its response
             msg: wasm_execute(
                 adapter_addr.address,
@@ -352,11 +352,11 @@ fn install_multiple_modules() -> AResult {
             vec![
                 ModuleInstallConfig::new(
                     ModuleInfo::from_id_latest("abstract:standalone1")?,
-                    Some(to_binary(&mock_modules::standalone_cw2::MockMsg).unwrap()),
+                    Some(to_json_binary(&mock_modules::standalone_cw2::MockMsg).unwrap()),
                 ),
                 ModuleInstallConfig::new(
                     ModuleInfo::from_id_latest("abstract:standalone2")?,
-                    Some(to_binary(&mock_modules::standalone_no_cw2::MockMsg).unwrap()),
+                    Some(to_json_binary(&mock_modules::standalone_no_cw2::MockMsg).unwrap()),
                 ),
             ],
             Some(&[coin(86, "token1"), coin(500, "token2")]),
@@ -372,11 +372,11 @@ fn install_multiple_modules() -> AResult {
     account.install_modules_auto(vec![
         ModuleInstallConfig::new(
             ModuleInfo::from_id_latest("abstract:standalone1")?,
-            Some(to_binary(&mock_modules::standalone_cw2::MockMsg).unwrap()),
+            Some(to_json_binary(&mock_modules::standalone_cw2::MockMsg).unwrap()),
         ),
         ModuleInstallConfig::new(
             ModuleInfo::from_id_latest("abstract:standalone2")?,
-            Some(to_binary(&mock_modules::standalone_no_cw2::MockMsg).unwrap()),
+            Some(to_json_binary(&mock_modules::standalone_no_cw2::MockMsg).unwrap()),
         ),
     ])?;
 

--- a/framework/contracts/account/manager/tests/upgrades.rs
+++ b/framework/contracts/account/manager/tests/upgrades.rs
@@ -26,7 +26,7 @@ use abstract_testing::addresses::{TEST_ACCOUNT_ID, TEST_NAMESPACE};
 
 use common::mock_modules::*;
 use common::{create_default_account, AResult};
-use cosmwasm_std::{coin, to_binary};
+use cosmwasm_std::{coin, to_json_binary};
 use cw2::ContractVersion;
 use cw_orch::deploy::Deploy;
 use cw_orch::prelude::*;
@@ -187,7 +187,7 @@ fn upgrade_app() -> AResult {
     let res = manager.upgrade(vec![
         (
             ModuleInfo::from_id(app_1::MOCK_APP_ID, ModuleVersion::Version(V1.to_string()))?,
-            Some(to_binary(&app::MigrateMsg {
+            Some(to_json_binary(&app::MigrateMsg {
                 base: app::BaseMigrateMsg {},
                 module: MockMigrateMsg,
             })?),
@@ -215,7 +215,7 @@ fn upgrade_app() -> AResult {
     // attempt to upgrade app 1 to version 2 while not updating other modules
     let res = manager.upgrade(vec![(
         ModuleInfo::from_id(app_1::MOCK_APP_ID, ModuleVersion::Version(V2.to_string()))?,
-        Some(to_binary(&app::MigrateMsg {
+        Some(to_json_binary(&app::MigrateMsg {
             base: app::BaseMigrateMsg {},
             module: MockMigrateMsg,
         })?),
@@ -236,7 +236,7 @@ fn upgrade_app() -> AResult {
     let res = manager.upgrade(vec![
         (
             ModuleInfo::from_id(app_1::MOCK_APP_ID, ModuleVersion::Version(V2.to_string()))?,
-            Some(to_binary(&app::MigrateMsg {
+            Some(to_json_binary(&app::MigrateMsg {
                 base: app::BaseMigrateMsg {},
                 module: MockMigrateMsg,
             })?),
@@ -272,7 +272,7 @@ fn upgrade_app() -> AResult {
     manager.upgrade(vec![
         (
             ModuleInfo::from_id_latest(app_1::MOCK_APP_ID)?,
-            Some(to_binary(&app::MigrateMsg {
+            Some(to_json_binary(&app::MigrateMsg {
                 base: app::BaseMigrateMsg {},
                 module: MockMigrateMsg,
             })?),
@@ -401,14 +401,14 @@ fn upgrade_manager_last() -> AResult {
     let res = manager.upgrade(vec![
         (
             ModuleInfo::from_id_latest(app_1::MOCK_APP_ID)?,
-            Some(to_binary(&app::MigrateMsg {
+            Some(to_json_binary(&app::MigrateMsg {
                 base: app::BaseMigrateMsg {},
                 module: MockMigrateMsg,
             })?),
         ),
         (
             ModuleInfo::from_id_latest("abstract:manager")?,
-            Some(to_binary(&manager::MigrateMsg {})?),
+            Some(to_json_binary(&manager::MigrateMsg {})?),
         ),
         (ModuleInfo::from_id_latest(adapter_1::MOCK_ADAPTER_ID)?, None),
         (ModuleInfo::from_id_latest(adapter_2::MOCK_ADAPTER_ID)?, None),
@@ -530,7 +530,7 @@ fn create_account_with_installed_module() -> AResult {
                             app_1::MOCK_APP_ID,
                             ModuleVersion::Version(V1.to_owned()),
                         )?,
-                        Some(to_binary(&app::InstantiateMsg {
+                        Some(to_json_binary(&app::InstantiateMsg {
                             module: MockInitMsg,
                             base: BaseInstantiateMsg {
                                 ans_host_address: deployment.ans_host.addr_str()?,
@@ -617,7 +617,7 @@ fn create_sub_account_with_installed_module() -> AResult {
             ),
             ModuleInstallConfig::new(
                 ModuleInfo::from_id(app_1::MOCK_APP_ID, ModuleVersion::Version(V1.to_owned()))?,
-                Some(to_binary(&app::InstantiateMsg {
+                Some(to_json_binary(&app::InstantiateMsg {
                     module: MockInitMsg,
                     base: BaseInstantiateMsg {
                         ans_host_address: deployment.ans_host.addr_str()?,
@@ -767,7 +767,7 @@ fn create_account_with_installed_module_and_monetization() -> AResult {
                             app_1::MOCK_APP_ID,
                             ModuleVersion::Version(V1.to_owned()),
                         )?,
-                        Some(to_binary(&app::InstantiateMsg {
+                        Some(to_json_binary(&app::InstantiateMsg {
                             module: MockInitMsg,
                             base: BaseInstantiateMsg {
                                 ans_host_address: deployment.ans_host.addr_str()?,
@@ -906,7 +906,7 @@ fn create_account_with_installed_module_and_monetization_should_fail() -> AResul
                 ),
                 ModuleInstallConfig::new(
                     ModuleInfo::from_id(app_1::MOCK_APP_ID, ModuleVersion::Version(V1.to_owned()))?,
-                    Some(to_binary(&app::InstantiateMsg {
+                    Some(to_json_binary(&app::InstantiateMsg {
                         module: MockInitMsg,
                         base: BaseInstantiateMsg {
                             ans_host_address: deployment.ans_host.addr_str()?,
@@ -1053,7 +1053,7 @@ fn create_account_with_installed_module_and_init_funds() -> AResult {
                             app_1::MOCK_APP_ID,
                             ModuleVersion::Version(V1.to_owned()),
                         )?,
-                        Some(to_binary(&app::InstantiateMsg {
+                        Some(to_json_binary(&app::InstantiateMsg {
                             module: MockInitMsg,
                             base: BaseInstantiateMsg {
                                 ans_host_address: deployment.ans_host.addr_str()?,
@@ -1067,7 +1067,7 @@ fn create_account_with_installed_module_and_init_funds() -> AResult {
                             name: "standalone".to_owned(),
                             version: V1.into(),
                         },
-                        Some(to_binary(&MockInitMsg)?),
+                        Some(to_json_binary(&MockInitMsg)?),
                     ),
                 ],
             },
@@ -1205,7 +1205,7 @@ fn create_account_with_installed_module_monetization_and_init_funds() -> AResult
                             app_1::MOCK_APP_ID,
                             ModuleVersion::Version(V1.to_owned()),
                         )?,
-                        Some(to_binary(&app::InstantiateMsg {
+                        Some(to_json_binary(&app::InstantiateMsg {
                             module: MockInitMsg,
                             base: BaseInstantiateMsg {
                                 ans_host_address: deployment.ans_host.addr_str()?,
@@ -1219,7 +1219,7 @@ fn create_account_with_installed_module_monetization_and_init_funds() -> AResult
                             name: "standalone".to_owned(),
                             version: V1.into(),
                         },
-                        Some(to_binary(&MockInitMsg)?),
+                        Some(to_json_binary(&MockInitMsg)?),
                     ),
                 ],
             },

--- a/framework/contracts/account/proxy/src/commands.rs
+++ b/framework/contracts/account/proxy/src/commands.rs
@@ -392,7 +392,7 @@ mod test {
     mod execute_ibc {
         use abstract_core::{manager, proxy::state::State};
         use abstract_testing::{prelude::TEST_MANAGER, MockQuerierBuilder};
-        use cosmwasm_std::{to_binary, SubMsg};
+        use cosmwasm_std::{to_json_binary, SubMsg};
 
         use super::*;
 
@@ -436,7 +436,7 @@ mod test {
             assert_that!(res.messages[0]).is_equal_to(SubMsg::new(CosmosMsg::Wasm(
                 cosmwasm_std::WasmMsg::Execute {
                     contract_addr: "ibc_client_addr".into(),
-                    msg: to_binary(&abstract_core::ibc_client::ExecuteMsg::Register {
+                    msg: to_json_binary(&abstract_core::ibc_client::ExecuteMsg::Register {
                         host_chain: "juno".into(),
                     })
                     .unwrap(),

--- a/framework/contracts/account/proxy/src/contract.rs
+++ b/framework/contracts/account/proxy/src/contract.rs
@@ -16,7 +16,7 @@ use abstract_sdk::{
     feature_objects::AnsHost,
 };
 use cosmwasm_std::{
-    to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response, SubMsgResult,
+    to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response, SubMsgResult,
 };
 use semver::Version;
 
@@ -83,24 +83,24 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> ProxyResult {
 #[cfg_attr(feature = "export", cosmwasm_std::entry_point)]
 pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> ProxyResult<Binary> {
     match msg {
-        QueryMsg::Config {} => to_binary(&query_config(deps)?),
-        QueryMsg::TotalValue {} => to_binary(&query_total_value(deps, env)?),
+        QueryMsg::Config {} => to_json_binary(&query_config(deps)?),
+        QueryMsg::TotalValue {} => to_json_binary(&query_total_value(deps, env)?),
         QueryMsg::HoldingAmount { identifier } => {
-            to_binary(&query_holding_amount(deps, env, identifier)?)
+            to_json_binary(&query_holding_amount(deps, env, identifier)?)
         }
         QueryMsg::TokenValue { identifier } => {
-            to_binary(&query_token_value(deps, env, identifier)?)
+            to_json_binary(&query_token_value(deps, env, identifier)?)
         }
-        QueryMsg::AssetConfig { identifier } => to_binary(&AssetConfigResponse {
+        QueryMsg::AssetConfig { identifier } => to_json_binary(&AssetConfigResponse {
             price_source: Oracle::new().asset_config(deps, &identifier)?,
         }),
         QueryMsg::AssetsConfig { start_after, limit } => {
-            to_binary(&query_oracle_asset_config(deps, start_after, limit)?)
+            to_json_binary(&query_oracle_asset_config(deps, start_after, limit)?)
         }
         QueryMsg::AssetsInfo { start_after, limit } => {
-            to_binary(&query_oracle_asset_info(deps, start_after, limit)?)
+            to_json_binary(&query_oracle_asset_info(deps, start_after, limit)?)
         }
-        QueryMsg::BaseAsset {} => to_binary(&query_base_asset(deps)?),
+        QueryMsg::BaseAsset {} => to_json_binary(&query_base_asset(deps)?),
     }
     .map_err(Into::into)
 }

--- a/framework/contracts/account/proxy/src/queries.rs
+++ b/framework/contracts/account/proxy/src/queries.rs
@@ -164,7 +164,7 @@ mod test {
         .unwrap();
 
         let base_asset: BaseAssetResponse = from_json(
-            &query(
+            query(
                 deps.as_ref(),
                 mock_env(),
                 abstract_core::proxy::QueryMsg::BaseAsset {},
@@ -194,7 +194,7 @@ mod test {
         .unwrap();
 
         let config: ConfigResponse = from_json(
-            &query(
+            query(
                 deps.as_ref(),
                 mock_env(),
                 abstract_core::proxy::QueryMsg::Config {},
@@ -231,7 +231,7 @@ mod test {
         // get the balance of the asset
         // returns HoldingAmountResponse
         let holding_amount: HoldingAmountResponse = from_json(
-            &query(
+            query(
                 deps.as_ref(),
                 mock_env(),
                 abstract_core::proxy::QueryMsg::HoldingAmount {
@@ -246,7 +246,7 @@ mod test {
         // get the value of the asset
         // returns AccountValue
         let account_value: AccountValue = from_json(
-            &query(
+            query(
                 deps.as_ref(),
                 mock_env(),
                 abstract_core::proxy::QueryMsg::TotalValue {},
@@ -263,7 +263,7 @@ mod test {
         // get the token value
         // returns TokenValueResponse
         let token_value: TokenValueResponse = from_json(
-            &query(
+            query(
                 deps.as_ref(),
                 mock_env(),
                 abstract_core::proxy::QueryMsg::TokenValue {
@@ -277,7 +277,7 @@ mod test {
 
         // query USD asset config
         let asset_config: AssetConfigResponse = from_json(
-            &query(
+            query(
                 deps.as_ref(),
                 mock_env(),
                 abstract_core::proxy::QueryMsg::AssetConfig {
@@ -305,7 +305,7 @@ mod test {
         .unwrap();
 
         let assets: AssetsConfigResponse = from_json(
-            &query(
+            query(
                 deps.as_ref(),
                 mock_env(),
                 abstract_core::proxy::QueryMsg::AssetsConfig {
@@ -339,7 +339,7 @@ mod test {
         .unwrap();
 
         let assets: AssetsInfoResponse = from_json(
-            &query(
+            query(
                 deps.as_ref(),
                 mock_env(),
                 abstract_core::proxy::QueryMsg::AssetsInfo {

--- a/framework/contracts/account/proxy/src/queries.rs
+++ b/framework/contracts/account/proxy/src/queries.rs
@@ -163,7 +163,7 @@ mod test {
         )
         .unwrap();
 
-        let base_asset: BaseAssetResponse = from_binary(
+        let base_asset: BaseAssetResponse = from_json(
             &query(
                 deps.as_ref(),
                 mock_env(),
@@ -193,7 +193,7 @@ mod test {
         )
         .unwrap();
 
-        let config: ConfigResponse = from_binary(
+        let config: ConfigResponse = from_json(
             &query(
                 deps.as_ref(),
                 mock_env(),
@@ -230,7 +230,7 @@ mod test {
 
         // get the balance of the asset
         // returns HoldingAmountResponse
-        let holding_amount: HoldingAmountResponse = from_binary(
+        let holding_amount: HoldingAmountResponse = from_json(
             &query(
                 deps.as_ref(),
                 mock_env(),
@@ -245,7 +245,7 @@ mod test {
 
         // get the value of the asset
         // returns AccountValue
-        let account_value: AccountValue = from_binary(
+        let account_value: AccountValue = from_json(
             &query(
                 deps.as_ref(),
                 mock_env(),
@@ -262,7 +262,7 @@ mod test {
 
         // get the token value
         // returns TokenValueResponse
-        let token_value: TokenValueResponse = from_binary(
+        let token_value: TokenValueResponse = from_json(
             &query(
                 deps.as_ref(),
                 mock_env(),
@@ -276,7 +276,7 @@ mod test {
         assert_eq!(token_value.value.u128(), 1000u128);
 
         // query USD asset config
-        let asset_config: AssetConfigResponse = from_binary(
+        let asset_config: AssetConfigResponse = from_json(
             &query(
                 deps.as_ref(),
                 mock_env(),
@@ -304,7 +304,7 @@ mod test {
         )
         .unwrap();
 
-        let assets: AssetsConfigResponse = from_binary(
+        let assets: AssetsConfigResponse = from_json(
             &query(
                 deps.as_ref(),
                 mock_env(),
@@ -338,7 +338,7 @@ mod test {
         )
         .unwrap();
 
-        let assets: AssetsInfoResponse = from_binary(
+        let assets: AssetsInfoResponse = from_json(
             &query(
                 deps.as_ref(),
                 mock_env(),

--- a/framework/contracts/native/account-factory/src/commands.rs
+++ b/framework/contracts/native/account-factory/src/commands.rs
@@ -6,8 +6,8 @@ use abstract_core::AbstractError;
 
 use abstract_core::{manager::ExecuteMsg, objects::module::assert_module_data_validity};
 use cosmwasm_std::{
-    ensure_eq, to_json_binary, wasm_execute, Addr, Coins, CosmosMsg, DepsMut, Empty, Env, MessageInfo,
-    QuerierWrapper, ReplyOn, StdError, SubMsg, SubMsgResult, WasmMsg,
+    ensure_eq, to_json_binary, wasm_execute, Addr, Coins, CosmosMsg, DepsMut, Empty, Env,
+    MessageInfo, QuerierWrapper, ReplyOn, StdError, SubMsg, SubMsgResult, WasmMsg,
 };
 use protobuf::Message;
 

--- a/framework/contracts/native/account-factory/src/commands.rs
+++ b/framework/contracts/native/account-factory/src/commands.rs
@@ -6,7 +6,7 @@ use abstract_core::AbstractError;
 
 use abstract_core::{manager::ExecuteMsg, objects::module::assert_module_data_validity};
 use cosmwasm_std::{
-    ensure_eq, to_binary, wasm_execute, Addr, Coins, CosmosMsg, DepsMut, Empty, Env, MessageInfo,
+    ensure_eq, to_json_binary, wasm_execute, Addr, Coins, CosmosMsg, DepsMut, Empty, Env, MessageInfo,
     QuerierWrapper, ReplyOn, StdError, SubMsg, SubMsgResult, WasmMsg,
 };
 use protobuf::Message;
@@ -146,7 +146,7 @@ pub fn execute_create_account(
                 // Currently set admin to self, update later when we know the contract's address.
                 admin: Some(env.contract.address.to_string()),
                 label: format!("Proxy of Account: {}", account_id),
-                msg: to_binary(&ProxyInstantiateMsg {
+                msg: to_json_binary(&ProxyInstantiateMsg {
                     account_id,
                     ans_host_address: config.ans_host_contract.to_string(),
                 })?,
@@ -203,7 +203,7 @@ pub fn after_proxy_create_manager(
                 funds: vec![],
                 admin: Some(env.contract.address.into_string()),
                 label: format!("Abstract Account: {}", context.account_id),
-                msg: to_binary(&ManagerInstantiateMsg {
+                msg: to_json_binary(&ManagerInstantiateMsg {
                     account_id: context.account_id,
                     version_control_address: config.version_control_contract.to_string(),
                     module_factory_address: config.module_factory_address.to_string(),
@@ -285,7 +285,7 @@ pub fn after_proxy_add_to_manager_and_set_admin(
     let add_account_to_version_control_msg: CosmosMsg<Empty> = CosmosMsg::Wasm(WasmMsg::Execute {
         contract_addr: config.version_control_contract.to_string(),
         funds: vec![],
-        msg: to_binary(&VCExecuteMsg::AddAccount {
+        msg: to_json_binary(&VCExecuteMsg::AddAccount {
             account_id: account_id.clone(),
             account_base,
         })?,
@@ -295,7 +295,7 @@ pub fn after_proxy_add_to_manager_and_set_admin(
     let whitelist_manager: CosmosMsg<Empty> = CosmosMsg::Wasm(WasmMsg::Execute {
         contract_addr: proxy_address.to_string(),
         funds: vec![],
-        msg: to_binary(&ProxyExecMsg::AddModules {
+        msg: to_json_binary(&ProxyExecMsg::AddModules {
             modules: vec![manager_address.to_string()],
         })?,
     });
@@ -307,7 +307,7 @@ pub fn after_proxy_add_to_manager_and_set_admin(
             Ok::<_, StdError>(CosmosMsg::Wasm(WasmMsg::Execute {
                 contract_addr: proxy_address.to_string(),
                 funds: vec![],
-                msg: to_binary(&ProxyExecMsg::UpdateAssets {
+                msg: to_json_binary(&ProxyExecMsg::UpdateAssets {
                     to_add: vec![(a, UncheckedPriceSource::None)],
                     to_remove: vec![],
                 })?,
@@ -322,7 +322,7 @@ pub fn after_proxy_add_to_manager_and_set_admin(
             Ok::<_, StdError>(CosmosMsg::Wasm(WasmMsg::Execute {
                 contract_addr: config.version_control_contract.to_string(),
                 funds: vec![],
-                msg: to_binary(&VCExecuteMsg::ClaimNamespace {
+                msg: to_json_binary(&VCExecuteMsg::ClaimNamespace {
                     account_id: account_id.clone(),
                     namespace: n,
                 })?,
@@ -333,7 +333,7 @@ pub fn after_proxy_add_to_manager_and_set_admin(
     let set_proxy_admin_msg: CosmosMsg<Empty> = CosmosMsg::Wasm(WasmMsg::Execute {
         contract_addr: proxy_address.to_string(),
         funds: vec![],
-        msg: to_binary(&ProxyExecMsg::SetAdmin {
+        msg: to_json_binary(&ProxyExecMsg::SetAdmin {
             admin: manager_address.to_string(),
         })?,
     });
@@ -358,7 +358,7 @@ pub fn after_proxy_add_to_manager_and_set_admin(
         manager_address.to_string(),
         &ExecuteMsg::UpdateInternalConfig(
             // Binary format to prevent users from easily calling the endpoint (because that's dangerous.)
-            to_binary(&InternalConfigAction::UpdateModuleAddresses {
+            to_json_binary(&InternalConfigAction::UpdateModuleAddresses {
                 to_add: Some(vec![(PROXY.to_string(), proxy_address.to_string())]),
                 to_remove: None,
             })

--- a/framework/contracts/native/account-factory/src/contract.rs
+++ b/framework/contracts/native/account-factory/src/contract.rs
@@ -3,7 +3,7 @@ use abstract_core::objects::module_version::assert_contract_upgrade;
 use abstract_macros::abstract_response;
 use abstract_sdk::core::{account_factory::*, ACCOUNT_FACTORY};
 use cosmwasm_std::{
-    to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response, StdResult,
+    to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response, StdResult,
 };
 
 use abstract_sdk::{execute_update_ownership, query_ownership};
@@ -106,7 +106,7 @@ pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> AccountFactoryResult {
 #[cfg_attr(feature = "export", cosmwasm_std::entry_point)]
 pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
-        QueryMsg::Config {} => to_binary(&queries::query_config(deps)?),
+        QueryMsg::Config {} => to_json_binary(&queries::query_config(deps)?),
         QueryMsg::Ownership {} => query_ownership!(deps),
     }
 }
@@ -341,7 +341,7 @@ mod tests {
         mock_init(deps.as_mut())?;
 
         let res = query(deps.as_ref(), mock_env(), QueryMsg::Config {}).unwrap();
-        let config: ConfigResponse = from_binary(&res).unwrap();
+        let config: ConfigResponse = from_json(&res).unwrap();
 
         assert_that!(config.version_control_contract.as_str()).is_equal_to(TEST_VERSION_CONTROL);
         assert_that!(config.ans_host_contract.as_str()).is_equal_to(TEST_ANS_HOST);
@@ -356,7 +356,7 @@ mod tests {
         mock_init(deps.as_mut())?;
 
         let res = query(deps.as_ref(), mock_env(), QueryMsg::Ownership {}).unwrap();
-        let ownership: cw_ownable::Ownership<Addr> = from_binary(&res).unwrap();
+        let ownership: cw_ownable::Ownership<Addr> = from_json(&res).unwrap();
 
         assert_that!(ownership.owner)
             .is_some()

--- a/framework/contracts/native/account-factory/src/contract.rs
+++ b/framework/contracts/native/account-factory/src/contract.rs
@@ -341,7 +341,7 @@ mod tests {
         mock_init(deps.as_mut())?;
 
         let res = query(deps.as_ref(), mock_env(), QueryMsg::Config {}).unwrap();
-        let config: ConfigResponse = from_json(&res).unwrap();
+        let config: ConfigResponse = from_json(res).unwrap();
 
         assert_that!(config.version_control_contract.as_str()).is_equal_to(TEST_VERSION_CONTROL);
         assert_that!(config.ans_host_contract.as_str()).is_equal_to(TEST_ANS_HOST);
@@ -356,7 +356,7 @@ mod tests {
         mock_init(deps.as_mut())?;
 
         let res = query(deps.as_ref(), mock_env(), QueryMsg::Ownership {}).unwrap();
-        let ownership: cw_ownable::Ownership<Addr> = from_json(&res).unwrap();
+        let ownership: cw_ownable::Ownership<Addr> = from_json(res).unwrap();
 
         assert_that!(ownership.owner)
             .is_some()

--- a/framework/contracts/native/ans-host/src/queries.rs
+++ b/framework/contracts/native/ans-host/src/queries.rs
@@ -595,7 +595,7 @@ mod test {
             names: vec!["bar".to_string(), "foo".to_string()],
         };
         // send query message
-        let res: AssetsResponse = from_json(&query_helper(deps.as_ref(), msg)?)?;
+        let res: AssetsResponse = from_json(query_helper(deps.as_ref(), msg)?)?;
 
         // Stage data for equality test
         let expected = create_asset_response(create_test_assets(
@@ -621,7 +621,7 @@ mod test {
         let msg = QueryMsg::Contracts {
             entries: create_contract_entry(vec![("foo", "foo")]),
         };
-        let res: ContractsResponse = from_json(&query_helper(deps.as_ref(), msg)?)?;
+        let res: ContractsResponse = from_json(query_helper(deps.as_ref(), msg)?)?;
 
         // Stage data for equality test
         let expected = ContractsResponse {
@@ -651,7 +651,7 @@ mod test {
 
         // create and send and deserialise msg
         let msg = create_channel_msg(vec![("foo", "foo")]);
-        let res: ChannelsResponse = from_json(&query_helper(deps.as_ref(), msg)?)?;
+        let res: ChannelsResponse = from_json(query_helper(deps.as_ref(), msg)?)?;
 
         // Stage data for equality test
         let expected = ChannelsResponse {
@@ -685,15 +685,15 @@ mod test {
 
         // return all entries
         let msg = query_asset_list_msg("".to_string(), 42);
-        let res: AssetListResponse = from_json(&query_helper(deps.as_ref(), msg)?)?;
+        let res: AssetListResponse = from_json(query_helper(deps.as_ref(), msg)?)?;
 
         // limit response to 1st result - entries are stored alphabetically
         let msg = query_asset_list_msg("".to_string(), 1);
-        let res_first_entry: AssetListResponse = from_json(&query_helper(deps.as_ref(), msg)?)?;
+        let res_first_entry: AssetListResponse = from_json(query_helper(deps.as_ref(), msg)?)?;
 
         // results after specified entry
         let msg = query_asset_list_msg("foo".to_string(), 1);
-        let res_of_foobar: AssetListResponse = from_json(&query_helper(deps.as_ref(), msg)?)?;
+        let res_of_foobar: AssetListResponse = from_json(query_helper(deps.as_ref(), msg)?)?;
 
         // Stage data for equality test
         let expected = create_asset_list_response(create_test_assets(
@@ -743,7 +743,7 @@ mod test {
         update_asset_addresses(deps.as_mut(), test_assets_large)?;
 
         let msg = query_asset_list_msg("".to_string(), 42);
-        let res: AssetListResponse = from_json(&query_helper(deps.as_ref(), msg)?)?;
+        let res: AssetListResponse = from_json(query_helper(deps.as_ref(), msg)?)?;
         assert!(res.assets.len() == 25_usize);
 
         // Assert that despite 30 entries the returned data is capped at the `MAX_LIMIT` of 25 results
@@ -774,7 +774,7 @@ mod test {
             limit: Some(42_u8),
             filter: None,
         };
-        let res: ContractListResponse = from_json(&query_helper(deps.as_ref(), msg)?)?;
+        let res: ContractListResponse = from_json(query_helper(deps.as_ref(), msg)?)?;
 
         let msg = QueryMsg::ContractList {
             start_after: Some(ContractEntry {
@@ -784,7 +784,7 @@ mod test {
             limit: Some(42_u8),
             filter: None,
         };
-        let res_expect_foo: ContractListResponse = from_json(&query_helper(deps.as_ref(), msg)?)?;
+        let res_expect_foo: ContractListResponse = from_json(query_helper(deps.as_ref(), msg)?)?;
 
         // Stage data for equality test
         let expected = ContractListResponse {
@@ -835,7 +835,7 @@ mod test {
             limit: Some(42_u8),
             filter: None,
         };
-        let res_all = from_json(&query_helper(deps.as_ref(), msg)?)?;
+        let res_all = from_json(query_helper(deps.as_ref(), msg)?)?;
 
         // Filter for entries after `Foo` - Alphabetically
         let msg = QueryMsg::ChannelList {
@@ -846,7 +846,7 @@ mod test {
             limit: Some(42_u8),
             filter: None,
         };
-        let res_foobar = from_json(&query_helper(deps.as_ref(), msg)?)?;
+        let res_foobar = from_json(query_helper(deps.as_ref(), msg)?)?;
 
         // Return first entry - Alphabetically
         let msg = QueryMsg::ChannelList {
@@ -854,7 +854,7 @@ mod test {
             limit: Some(1_u8),
             filter: None,
         };
-        let res_bar = from_json(&query_helper(deps.as_ref(), msg)?)?;
+        let res_bar = from_json(query_helper(deps.as_ref(), msg)?)?;
 
         // Stage data for equality test
 
@@ -899,7 +899,7 @@ mod test {
         // create msg
         let msg = QueryMsg::RegisteredDexes {};
         // deserialize response
-        let res: RegisteredDexesResponse = from_json(&query_helper(deps.as_ref(), msg)?)?;
+        let res: RegisteredDexesResponse = from_json(query_helper(deps.as_ref(), msg)?)?;
 
         // comparisons
         let expected = RegisteredDexesResponse {
@@ -926,7 +926,7 @@ mod test {
         let msg = QueryMsg::Pools {
             pairings: vec![create_dex_asset_pairing("btc", "eth", "foo")],
         };
-        let res: PoolsResponse = from_json(&query_helper(deps.as_ref(), msg)?)?;
+        let res: PoolsResponse = from_json(query_helper(deps.as_ref(), msg)?)?;
         //comparisons
         let expected = ASSET_PAIRINGS
             .load(
@@ -964,14 +964,14 @@ mod test {
             None,
             None,
         )?;
-        let res_bar: PoolsResponse = from_json(&query_helper(deps.as_ref(), msg_bar)?)?;
+        let res_bar: PoolsResponse = from_json(query_helper(deps.as_ref(), msg_bar)?)?;
 
         let msg_foo = create_pool_list_msg(
             Some(create_asset_pairing_filter("juno", "atom", None)?),
             None,
             Some(42),
         )?;
-        let res_foo: PoolsResponse = from_json(&query_helper(deps.as_ref(), msg_foo)?)?;
+        let res_foo: PoolsResponse = from_json(query_helper(deps.as_ref(), msg_foo)?)?;
 
         let msg_foo_using_start_after = create_pool_list_msg(
             Some(AssetPairingFilter {
@@ -982,7 +982,7 @@ mod test {
             Some(42),
         )?;
         let res_foo_using_start_after: PoolsResponse =
-            from_json(&query_helper(deps.as_ref(), msg_foo_using_start_after)?)?;
+            from_json(query_helper(deps.as_ref(), msg_foo_using_start_after)?)?;
 
         // create comparisons - bar / foo / all
         let expected_bar =
@@ -1015,7 +1015,7 @@ mod test {
         };
         // comparison all
         let msg_all = create_pool_list_msg(None, None, Some(42))?;
-        let res_all: PoolsResponse = from_json(&query_helper(deps.as_ref(), msg_all)?)?;
+        let res_all: PoolsResponse = from_json(query_helper(deps.as_ref(), msg_all)?)?;
 
         // assert
         assert_eq!(&res_bar, &expected_bar);
@@ -1044,12 +1044,12 @@ mod test {
         let msg_bar = QueryMsg::PoolMetadatas {
             ids: vec![UniquePoolId::new(42)],
         };
-        let res_bar: PoolMetadatasResponse = from_json(&query_helper(deps.as_ref(), msg_bar)?)?;
+        let res_bar: PoolMetadatasResponse = from_json(query_helper(deps.as_ref(), msg_bar)?)?;
 
         let msg_foo = QueryMsg::PoolMetadatas {
             ids: vec![UniquePoolId::new(69)],
         };
-        let res_foo: PoolMetadatasResponse = from_json(&query_helper(deps.as_ref(), msg_foo)?)?;
+        let res_foo: PoolMetadatasResponse = from_json(query_helper(deps.as_ref(), msg_foo)?)?;
 
         // create comparisons
         let expected_bar = PoolMetadatasResponse {
@@ -1096,7 +1096,7 @@ mod test {
             start_after: None,
             limit: None,
         };
-        let res_bar: PoolMetadatasResponse = from_json(&query_helper(deps.as_ref(), msg_bar)?)?;
+        let res_bar: PoolMetadatasResponse = from_json(query_helper(deps.as_ref(), msg_bar)?)?;
         let expected_bar = PoolMetadatasResponse {
             metadatas: vec![(bar_key, bar_metadata.clone())],
         };
@@ -1114,7 +1114,7 @@ mod test {
             start_after: None,
             limit: Some(42),
         };
-        let res_both: PoolMetadatasResponse = from_json(&query_helper(deps.as_ref(), msg_both)?)?;
+        let res_both: PoolMetadatasResponse = from_json(query_helper(deps.as_ref(), msg_both)?)?;
 
         let expected_both = PoolMetadatasResponse {
             metadatas: vec![
@@ -1132,7 +1132,7 @@ mod test {
             start_after: Some(bar_key),
             limit: Some(42),
         };
-        let res_foo: PoolMetadatasResponse = from_json(&query_helper(deps.as_ref(), msg_foo)?)?;
+        let res_foo: PoolMetadatasResponse = from_json(query_helper(deps.as_ref(), msg_foo)?)?;
 
         let expected_foo = PoolMetadatasResponse {
             metadatas: vec![(foo_key, foo_metadata)],

--- a/framework/contracts/native/ans-host/src/tests/mock_querier.rs
+++ b/framework/contracts/native/ans-host/src/tests/mock_querier.rs
@@ -1,8 +1,8 @@
 #![allow(dead_code)]
 use cosmwasm_std::testing::{MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR};
 use cosmwasm_std::{
-    from_json, from_slice, to_json_binary, Coin, ContractResult, Empty, OwnedDeps, Querier,
-    QuerierResult, QueryRequest, SystemError, SystemResult, Uint128, WasmQuery,
+    from_json, to_json_binary, Coin, ContractResult, Empty, OwnedDeps, Querier, QuerierResult,
+    QueryRequest, SystemError, SystemResult, Uint128, WasmQuery,
 };
 use cw20::{BalanceResponse as Cw20BalanceResponse, Cw20QueryMsg};
 use std::collections::HashMap;
@@ -61,7 +61,7 @@ pub(crate) fn balances_to_map(
 impl Querier for WasmMockQuerier {
     fn raw_query(&self, bin_request: &[u8]) -> QuerierResult {
         // MockQuerier doesn't support Custom, so we ignore it completely here
-        let request: QueryRequest<Empty> = match from_slice(bin_request) {
+        let request: QueryRequest<Empty> = match from_json(bin_request) {
             Ok(v) => v,
             Err(e) => {
                 return SystemResult::Err(SystemError::InvalidRequest {

--- a/framework/contracts/native/ans-host/src/tests/mock_querier.rs
+++ b/framework/contracts/native/ans-host/src/tests/mock_querier.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 use cosmwasm_std::testing::{MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR};
 use cosmwasm_std::{
-    from_binary, from_slice, to_binary, Coin, ContractResult, Empty, OwnedDeps, Querier,
+    from_json, from_slice, to_json_binary, Coin, ContractResult, Empty, OwnedDeps, Querier,
     QuerierResult, QueryRequest, SystemError, SystemResult, Uint128, WasmQuery,
 };
 use cw20::{BalanceResponse as Cw20BalanceResponse, Cw20QueryMsg};
@@ -78,7 +78,7 @@ impl WasmMockQuerier {
     pub fn handle_query(&self, request: &QueryRequest<Empty>) -> QuerierResult {
         match &request {
             QueryRequest::Wasm(WasmQuery::Smart { contract_addr, msg }) => {
-                match from_binary(msg).unwrap() {
+                match from_json(msg).unwrap() {
                     Cw20QueryMsg::Balance { address } => {
                         let balances: &HashMap<String, Uint128> =
                             match self.token_querier.balances.get(contract_addr) {
@@ -97,7 +97,7 @@ impl WasmMockQuerier {
                             Some(v) => *v,
                             None => {
                                 return SystemResult::Ok(ContractResult::Ok(
-                                    to_binary(&Cw20BalanceResponse {
+                                    to_json_binary(&Cw20BalanceResponse {
                                         balance: Uint128::zero(),
                                     })
                                     .unwrap(),
@@ -106,7 +106,7 @@ impl WasmMockQuerier {
                         };
 
                         SystemResult::Ok(ContractResult::Ok(
-                            to_binary(&Cw20BalanceResponse { balance }).unwrap(),
+                            to_json_binary(&Cw20BalanceResponse { balance }).unwrap(),
                         ))
                     }
                     _ => panic!("DO NOT ENTER HERE"),

--- a/framework/contracts/native/ibc-client/src/commands.rs
+++ b/framework/contracts/native/ibc-client/src/commands.rs
@@ -25,7 +25,7 @@ use abstract_sdk::{
     AccountVerification, Resolve,
 };
 use cosmwasm_std::{
-    to_binary, wasm_execute, Coin, CosmosMsg, Deps, DepsMut, Empty, Env, IbcMsg, MessageInfo,
+    to_json_binary, wasm_execute, Coin, CosmosMsg, Deps, DepsMut, Empty, Env, IbcMsg, MessageInfo,
     QueryRequest, Storage,
 };
 use polytone::callbacks::CallbackRequest;
@@ -100,7 +100,7 @@ pub fn execute_register_infrastructure(
             msgs: vec![],
             callback: Some(CallbackRequest {
                 receiver: env.contract.address.to_string(),
-                msg: to_binary(&IbcClientCallback::WhoAmI {})?,
+                msg: to_json_binary(&IbcClientCallback::WhoAmI {})?,
             }),
             timeout_seconds: PACKET_LIFETIME.into(),
         },
@@ -220,7 +220,7 @@ pub fn execute_send_packet(
 
     let callback_request = callback_info.map(|c| CallbackRequest {
         receiver: env.contract.address.to_string(),
-        msg: to_binary(&IbcClientCallback::UserRemoteAction(c)).unwrap(),
+        msg: to_json_binary(&IbcClientCallback::UserRemoteAction(c)).unwrap(),
     });
 
     let note_message = send_remote_host_action(
@@ -247,7 +247,7 @@ pub fn execute_send_query(
 
     let callback_request = CallbackRequest {
         receiver: env.contract.address.to_string(),
-        msg: to_binary(&IbcClientCallback::UserRemoteAction(callback_info)).unwrap(),
+        msg: to_json_binary(&IbcClientCallback::UserRemoteAction(callback_info)).unwrap(),
     };
 
     let note_message =

--- a/framework/contracts/native/ibc-client/src/contract.rs
+++ b/framework/contracts/native/ibc-client/src/contract.rs
@@ -11,7 +11,7 @@ use abstract_core::{
 };
 use abstract_macros::abstract_response;
 use abstract_sdk::feature_objects::VersionControlContract;
-use cosmwasm_std::{to_binary, Deps, DepsMut, Env, MessageInfo, QueryResponse, Response};
+use cosmwasm_std::{to_json_binary, Deps, DepsMut, Env, MessageInfo, QueryResponse, Response};
 use cw_semver::Version;
 
 pub const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -95,17 +95,17 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> I
 #[cfg_attr(feature = "export", cosmwasm_std::entry_point)]
 pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> IbcClientResult<QueryResponse> {
     match msg {
-        QueryMsg::Config {} => to_binary(&queries::config(deps)?),
-        QueryMsg::Host { chain_name } => to_binary(&queries::host(deps, chain_name)?),
+        QueryMsg::Config {} => to_json_binary(&queries::config(deps)?),
+        QueryMsg::Host { chain_name } => to_json_binary(&queries::host(deps, chain_name)?),
         QueryMsg::Account { chain, account_id } => {
-            to_binary(&queries::account(deps, chain, account_id)?)
+            to_json_binary(&queries::account(deps, chain, account_id)?)
         }
         QueryMsg::ListAccounts { start, limit } => {
-            to_binary(&queries::list_accounts(deps, start, limit)?)
+            to_json_binary(&queries::list_accounts(deps, start, limit)?)
         }
-        QueryMsg::ListRemoteHosts {} => to_binary(&queries::list_remote_hosts(deps)?),
-        QueryMsg::ListRemoteProxies {} => to_binary(&queries::list_remote_proxies(deps)?),
-        QueryMsg::ListIbcInfrastructures {} => to_binary(&queries::list_ibc_counterparts(deps)?),
+        QueryMsg::ListRemoteHosts {} => to_json_binary(&queries::list_remote_hosts(deps)?),
+        QueryMsg::ListRemoteProxies {} => to_json_binary(&queries::list_remote_proxies(deps)?),
+        QueryMsg::ListIbcInfrastructures {} => to_json_binary(&queries::list_ibc_counterparts(deps)?),
     }
     .map_err(Into::into)
 }
@@ -352,7 +352,7 @@ mod tests {
                     msgs: vec![],
                     callback: Some(CallbackRequest {
                         receiver: mock_env().contract.address.to_string(),
-                        msg: to_binary(&IbcClientCallback::WhoAmI {})?,
+                        msg: to_json_binary(&IbcClientCallback::WhoAmI {})?,
                     }),
                     timeout_seconds: PACKET_LIFETIME.into(),
                 },
@@ -564,7 +564,7 @@ mod tests {
             };
 
             let callback_request = CallbackRequest {
-                msg: to_binary(&IbcClientCallback::UserRemoteAction(callback_info.clone()))?,
+                msg: to_json_binary(&IbcClientCallback::UserRemoteAction(callback_info.clone()))?,
                 receiver: mock_env().contract.address.to_string(),
             };
 
@@ -642,7 +642,7 @@ mod tests {
             };
 
             let callback_request = CallbackRequest {
-                msg: to_binary(&IbcClientCallback::UserRemoteAction(callback_info.clone()))?,
+                msg: to_json_binary(&IbcClientCallback::UserRemoteAction(callback_info.clone()))?,
                 receiver: mock_env().contract.address.to_string(),
             };
 
@@ -783,7 +783,7 @@ mod tests {
         use abstract_testing::prelude::{
             mocked_account_querier_builder, TEST_CHAIN, TEST_MANAGER, TEST_PROXY,
         };
-        use cosmwasm_std::{from_binary, wasm_execute};
+        use cosmwasm_std::{from_json, wasm_execute};
 
         use crate::commands::PACKET_LIFETIME;
 
@@ -819,8 +819,8 @@ mod tests {
                 .builder()
                 .with_smart_handler(
                     TEST_MANAGER,
-                    |msg| match from_binary::<manager::QueryMsg>(msg).unwrap() {
-                        manager::QueryMsg::Info {} => to_binary(&manager::InfoResponse {
+                    |msg| match from_json::<manager::QueryMsg>(msg).unwrap() {
+                        manager::QueryMsg::Info {} => to_json_binary(&manager::InfoResponse {
                             info: manager::state::AccountInfo {
                                 name: String::from("name"),
                                 governance_details: GovernanceDetails::Monarchy {
@@ -1120,7 +1120,7 @@ mod tests {
 
             let msg = ExecuteMsg::Callback(CallbackMessage {
                 initiator: env.contract.address,
-                initiator_msg: to_binary(&IbcClientCallback::WhoAmI {})?,
+                initiator_msg: to_json_binary(&IbcClientCallback::WhoAmI {})?,
                 result: Callback::Execute(Ok(ExecutionResponse {
                     executed_by: String::from("addr"),
                     result: vec![],
@@ -1158,7 +1158,7 @@ mod tests {
             REVERSE_POLYTONE_NOTE.save(deps.as_mut().storage, &note, &chain_name)?;
             let callback_msg = CallbackMessage {
                 initiator: env.contract.address,
-                initiator_msg: to_binary(&IbcClientCallback::WhoAmI {})?,
+                initiator_msg: to_json_binary(&IbcClientCallback::WhoAmI {})?,
                 result: Callback::FatalError(String::from("error")),
             };
 
@@ -1198,7 +1198,7 @@ mod tests {
 
             let msg = ExecuteMsg::Callback(CallbackMessage {
                 initiator: env.contract.address,
-                initiator_msg: to_binary(&IbcClientCallback::WhoAmI {})?,
+                initiator_msg: to_json_binary(&IbcClientCallback::WhoAmI {})?,
                 result: Callback::Execute(Ok(ExecutionResponse {
                     executed_by: remote_proxy.clone(),
                     result: vec![],
@@ -1239,7 +1239,7 @@ mod tests {
             REVERSE_POLYTONE_NOTE.save(deps.as_mut().storage, &note, &chain_name)?;
             let callback_msg = CallbackMessage {
                 initiator: env.contract.address,
-                initiator_msg: to_binary(&IbcClientCallback::CreateAccount {
+                initiator_msg: to_json_binary(&IbcClientCallback::CreateAccount {
                     account_id: TEST_ACCOUNT_ID,
                 })?,
                 result: Callback::FatalError(String::from("error")),
@@ -1269,7 +1269,7 @@ mod tests {
             REVERSE_POLYTONE_NOTE.save(deps.as_mut().storage, &note, &chain_name)?;
             let callback_msg = CallbackMessage {
                 initiator: env.contract.address,
-                initiator_msg: to_binary(&IbcClientCallback::CreateAccount {
+                initiator_msg: to_json_binary(&IbcClientCallback::CreateAccount {
                     account_id: TEST_ACCOUNT_ID,
                 })?,
                 result: Callback::Execute(Ok(ExecutionResponse {
@@ -1305,7 +1305,7 @@ mod tests {
             REVERSE_POLYTONE_NOTE.save(deps.as_mut().storage, &note, &chain_name)?;
             let callback_msg = CallbackMessage {
                 initiator: env.contract.address,
-                initiator_msg: to_binary(&IbcClientCallback::CreateAccount {
+                initiator_msg: to_json_binary(&IbcClientCallback::CreateAccount {
                     account_id: TEST_ACCOUNT_ID,
                 })?,
                 result: Callback::Execute(Ok(ExecutionResponse {
@@ -1341,7 +1341,7 @@ mod tests {
             REVERSE_POLYTONE_NOTE.save(deps.as_mut().storage, &note, &chain_name)?;
             let callback_msg = CallbackMessage {
                 initiator: env.contract.address,
-                initiator_msg: to_binary(&IbcClientCallback::CreateAccount {
+                initiator_msg: to_json_binary(&IbcClientCallback::CreateAccount {
                     account_id: TEST_ACCOUNT_ID,
                 })?,
                 result: Callback::Execute(Ok(ExecutionResponse {
@@ -1390,7 +1390,7 @@ mod tests {
             let receiver = String::from("receiver");
             let callback_msg = CallbackMessage {
                 initiator: env.contract.address,
-                initiator_msg: to_binary(&IbcClientCallback::UserRemoteAction(CallbackInfo {
+                initiator_msg: to_json_binary(&IbcClientCallback::UserRemoteAction(CallbackInfo {
                     id: id.clone(),
                     msg: Some(callback_info_msg.clone()),
                     receiver: receiver.clone(),

--- a/framework/contracts/native/ibc-client/src/ibc.rs
+++ b/framework/contracts/native/ibc-client/src/ibc.rs
@@ -11,7 +11,7 @@ use abstract_core::{
     objects::chain_name::ChainName,
 };
 use abstract_sdk::core::ibc_client::state::ACCOUNTS;
-use cosmwasm_std::{from_binary, DepsMut, Env, MessageInfo};
+use cosmwasm_std::{from_json, DepsMut, Env, MessageInfo};
 
 use polytone::callbacks::{Callback, CallbackMessage};
 
@@ -36,7 +36,7 @@ pub fn receive_action_callback(
 
     // 2. From here on, we can trust the message that we are receiving
 
-    let callback_msg: IbcClientCallback = from_binary(&callback.initiator_msg)?;
+    let callback_msg: IbcClientCallback = from_json(&callback.initiator_msg)?;
 
     match callback_msg {
         IbcClientCallback::WhoAmI {} => {

--- a/framework/contracts/native/ibc-host/src/account_commands.rs
+++ b/framework/contracts/native/ibc-host/src/account_commands.rs
@@ -17,7 +17,7 @@ use abstract_sdk::{
     AbstractSdkError, AccountVerification, Resolve,
 };
 use cosmwasm_std::{
-    to_binary, wasm_execute, CosmosMsg, Deps, DepsMut, Env, IbcMsg, Response, SubMsg,
+    to_json_binary, wasm_execute, CosmosMsg, Deps, DepsMut, Env, IbcMsg, Response, SubMsg,
 };
 
 // one hour
@@ -144,7 +144,7 @@ pub fn send_all_back(
         account.manager,
         &manager::ExecuteMsg::ExecOnModule {
             module_id: PROXY.into(),
-            exec_msg: to_binary(&proxy::ExecuteMsg::ModuleAction { msgs })?,
+            exec_msg: to_json_binary(&proxy::ExecuteMsg::ModuleAction { msgs })?,
         },
         vec![],
     )?;

--- a/framework/contracts/native/ibc-host/src/endpoints/query.rs
+++ b/framework/contracts/native/ibc-host/src/endpoints/query.rs
@@ -105,7 +105,7 @@ mod test {
             },
         )
         .unwrap();
-        let queried_client_name: ClientProxyResponse = from_json(&client_name).unwrap();
+        let queried_client_name: ClientProxyResponse = from_json(client_name).unwrap();
         assert_eq!(queried_client_name.proxy, "juno-proxy");
     }
 }

--- a/framework/contracts/native/ibc-host/src/endpoints/query.rs
+++ b/framework/contracts/native/ibc-host/src/endpoints/query.rs
@@ -8,18 +8,18 @@ use abstract_core::{
     objects::chain_name::ChainName,
 };
 use abstract_sdk::core::ibc_host::QueryMsg;
-use cosmwasm_std::{to_binary, Binary, Deps, Env};
+use cosmwasm_std::{to_json_binary, Binary, Deps, Env};
 use cw_storage_plus::Bound;
 
 use crate::{contract::HostResult, HostError};
 
 pub fn query(deps: Deps, _env: Env, query: QueryMsg) -> HostResult<Binary> {
     match query {
-        QueryMsg::Config {} => to_binary(&config(deps)?),
+        QueryMsg::Config {} => to_json_binary(&config(deps)?),
         QueryMsg::ClientProxies { start_after, limit } => {
-            to_binary(&registered_chains(deps, start_after, limit)?)
+            to_json_binary(&registered_chains(deps, start_after, limit)?)
         }
-        QueryMsg::ClientProxy { chain } => to_binary(&associated_client(deps, chain)?),
+        QueryMsg::ClientProxy { chain } => to_json_binary(&associated_client(deps, chain)?),
     }
     .map_err(Into::into)
 }
@@ -65,7 +65,7 @@ mod test {
         use abstract_core::ibc_host::QueryMsg;
 
         use crate::contract::{execute, instantiate, query};
-        use cosmwasm_std::from_binary;
+        use cosmwasm_std::from_json;
         use cosmwasm_std::testing::mock_dependencies;
         use cosmwasm_std::testing::mock_env;
         use cosmwasm_std::testing::mock_info;
@@ -105,7 +105,7 @@ mod test {
             },
         )
         .unwrap();
-        let queried_client_name: ClientProxyResponse = from_binary(&client_name).unwrap();
+        let queried_client_name: ClientProxyResponse = from_json(&client_name).unwrap();
         assert_eq!(queried_client_name.proxy, "juno-proxy");
     }
 }

--- a/framework/contracts/native/module-factory/src/commands.rs
+++ b/framework/contracts/native/module-factory/src/commands.rs
@@ -377,14 +377,14 @@ mod test {
     mod instantiate_contract {
         use super::*;
         use abstract_core::objects::module::ModuleVersion;
-        use cosmwasm_std::{coin, testing::mock_info, to_binary};
+        use cosmwasm_std::{coin, testing::mock_info, to_json_binary};
 
         #[test]
         fn should_create_submsg_with_instantiate_msg() -> ModuleFactoryTestResult {
             let _deps = mock_dependencies();
             let _info = mock_info("anyone", &[]);
 
-            let expected_module_init_msg = to_binary(&Empty {}).unwrap();
+            let expected_module_init_msg = to_json_binary(&Empty {}).unwrap();
             let expected_code_id = 10;
             let expected_reply_id = 69;
 
@@ -428,7 +428,7 @@ mod test {
         }
     }
 
-    use cosmwasm_std::to_binary;
+    use cosmwasm_std::to_json_binary;
 
     mod update_factory_binaries {
         use super::*;
@@ -447,7 +447,7 @@ mod test {
             (
                 ModuleInfo::from_id("test:module", ModuleVersion::Version("0.1.2".to_string()))
                     .unwrap(),
-                to_binary(&"tasty pizza usually has pineapple").unwrap(),
+                to_json_binary(&"tasty pizza usually has pineapple").unwrap(),
             )
         }
 

--- a/framework/contracts/native/module-factory/src/contract.rs
+++ b/framework/contracts/native/module-factory/src/contract.rs
@@ -10,7 +10,7 @@ use abstract_sdk::{
     ModuleRegistryInterface,
 };
 use cosmwasm_std::{
-    to_binary, Binary, Coins, Deps, DepsMut, Env, MessageInfo, Reply, Response, StdResult,
+    to_json_binary, Binary, Coins, Deps, DepsMut, Env, MessageInfo, Reply, Response, StdResult,
 };
 use cw2::set_contract_version;
 use semver::Version;
@@ -87,10 +87,10 @@ pub fn reply(deps: DepsMut, _env: Env, msg: Reply) -> ModuleFactoryResult {
 #[cfg_attr(feature = "export", cosmwasm_std::entry_point)]
 pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
-        QueryMsg::Config {} => to_binary(&query_config(deps)?),
-        QueryMsg::Context {} => to_binary(&query_context(deps)?),
+        QueryMsg::Config {} => to_json_binary(&query_config(deps)?),
+        QueryMsg::Context {} => to_json_binary(&query_context(deps)?),
         QueryMsg::SimulateInstallModules { modules } => {
-            to_binary(&query_simulate_install_modules(deps, modules)?)
+            to_json_binary(&query_simulate_install_modules(deps, modules)?)
         }
         QueryMsg::Ownership {} => abstract_sdk::query_ownership!(deps),
     }

--- a/framework/contracts/native/version-control/src/commands.rs
+++ b/framework/contracts/native/version-control/src/commands.rs
@@ -552,7 +552,7 @@ pub fn set_factory(deps: DepsMut, info: MessageInfo, new_admin: String) -> VCRes
 mod test {
     use abstract_core::objects::account::AccountTrace;
     use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
-    use cosmwasm_std::{from_binary, to_binary, Addr, Coin};
+    use cosmwasm_std::{from_json, to_json_binary, Addr, Coin};
     use cw_controllers::AdminError;
     use cw_ownable::OwnershipError;
     use speculoos::prelude::*;
@@ -582,7 +582,7 @@ mod test {
     pub fn mock_manager_querier() -> MockQuerierBuilder {
         MockQuerierBuilder::default()
             .with_smart_handler(TEST_MANAGER, |msg| {
-                match from_binary(msg).unwrap() {
+                match from_json(msg).unwrap() {
                     ManagerQueryMsg::Config {} => {
                         let resp = ManagerConfigResponse {
                             version_control_address: Addr::unchecked(TEST_VERSION_CONTROL),
@@ -590,7 +590,7 @@ mod test {
                             account_id: TEST_ACCOUNT_ID, // mock value, not used
                             is_suspended: false,
                         };
-                        Ok(to_binary(&resp).unwrap())
+                        Ok(to_json_binary(&resp).unwrap())
                     }
                     ManagerQueryMsg::Ownership {} => {
                         let resp = cw_ownable::Ownership {
@@ -598,7 +598,7 @@ mod test {
                             pending_expiry: None,
                             pending_owner: None,
                         };
-                        Ok(to_binary(&resp).unwrap())
+                        Ok(to_json_binary(&resp).unwrap())
                     }
                     _ => panic!("unexpected message"),
                 }
@@ -961,7 +961,7 @@ mod test {
             let account_1_manager = "manager2";
             deps.querier = mock_manager_querier()
                 // add manager 2
-                .with_smart_handler(account_1_manager, |msg| match from_binary(msg).unwrap() {
+                .with_smart_handler(account_1_manager, |msg| match from_json(msg).unwrap() {
                     ManagerQueryMsg::Config {} => {
                         let resp = ManagerConfigResponse {
                             version_control_address: Addr::unchecked(TEST_VERSION_CONTROL),
@@ -969,7 +969,7 @@ mod test {
                             account_id: TEST_ACCOUNT_ID,
                             is_suspended: false,
                         };
-                        Ok(to_binary(&resp).unwrap())
+                        Ok(to_json_binary(&resp).unwrap())
                     }
                     ManagerQueryMsg::Ownership {} => {
                         let resp = cw_ownable::Ownership {
@@ -977,7 +977,7 @@ mod test {
                             pending_expiry: None,
                             pending_owner: None,
                         };
-                        Ok(to_binary(&resp).unwrap())
+                        Ok(to_json_binary(&resp).unwrap())
                     }
                     _ => panic!("unexpected message"),
                 })
@@ -1870,7 +1870,7 @@ mod test {
                 infos: vec![new_module.clone()],
             };
             let res = query(deps.as_ref(), mock_env(), query_msg)?;
-            let ser_res = from_binary::<ModulesResponse>(&res)?;
+            let ser_res = from_json::<ModulesResponse>(&res)?;
             assert_that!(ser_res.modules).has_length(1);
             assert_eq!(
                 ser_res.modules[0],
@@ -1919,7 +1919,7 @@ mod test {
                 infos: vec![new_module.clone()],
             };
             let res = query(deps.as_ref(), mock_env(), query_msg)?;
-            let ser_res = from_binary::<ModulesResponse>(&res)?;
+            let ser_res = from_json::<ModulesResponse>(&res)?;
             assert_that!(ser_res.modules).has_length(1);
             assert_eq!(
                 ser_res.modules[0],
@@ -1972,7 +1972,7 @@ mod test {
                 infos: vec![new_module.clone()],
             };
             let res = query(deps.as_ref(), mock_env(), query_msg)?;
-            let ser_res = from_binary::<ModulesResponse>(&res)?;
+            let ser_res = from_json::<ModulesResponse>(&res)?;
             assert_that!(ser_res.modules).has_length(1);
             assert_eq!(
                 ser_res.modules[0],

--- a/framework/contracts/native/version-control/src/contract.rs
+++ b/framework/contracts/native/version-control/src/contract.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{to_binary, Binary, Coin, Deps, DepsMut, Env, MessageInfo, Response, Uint128};
+use cosmwasm_std::{to_json_binary, Binary, Coin, Deps, DepsMut, Env, MessageInfo, Response, Uint128};
 
 use cw_semver::Version;
 
@@ -118,24 +118,24 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> V
 pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> VCResult<Binary> {
     match msg {
         QueryMsg::AccountBase { account_id } => {
-            to_binary(&queries::handle_account_address_query(deps, account_id)?)
+            to_json_binary(&queries::handle_account_address_query(deps, account_id)?)
         }
-        QueryMsg::Modules { infos } => to_binary(&queries::handle_modules_query(deps, infos)?),
+        QueryMsg::Modules { infos } => to_json_binary(&queries::handle_modules_query(deps, infos)?),
         QueryMsg::Namespaces { accounts } => {
-            to_binary(&queries::handle_namespaces_query(deps, accounts)?)
+            to_json_binary(&queries::handle_namespaces_query(deps, accounts)?)
         }
         QueryMsg::Namespace { namespace } => {
-            to_binary(&queries::handle_namespace_query(deps, namespace)?)
+            to_json_binary(&queries::handle_namespace_query(deps, namespace)?)
         }
         QueryMsg::Config {} => {
             let factory = FACTORY.get(deps)?.unwrap();
-            to_binary(&ConfigResponse { factory })
+            to_json_binary(&ConfigResponse { factory })
         }
         QueryMsg::ModuleList {
             filter,
             start_after,
             limit,
-        } => to_binary(&queries::handle_module_list_query(
+        } => to_json_binary(&queries::handle_module_list_query(
             deps,
             start_after,
             limit,
@@ -143,13 +143,13 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> VCResult<Binary> {
         )?),
         QueryMsg::NamespaceList { start_after, limit } => {
             let start_after = start_after.map(Namespace::try_from).transpose()?;
-            to_binary(&queries::handle_namespace_list_query(
+            to_json_binary(&queries::handle_namespace_list_query(
                 deps,
                 start_after,
                 limit,
             )?)
         }
-        QueryMsg::Ownership {} => to_binary(&query_ownership!(deps)?),
+        QueryMsg::Ownership {} => to_json_binary(&query_ownership!(deps)?),
     }
     .map_err(Into::into)
 }

--- a/framework/contracts/native/version-control/src/contract.rs
+++ b/framework/contracts/native/version-control/src/contract.rs
@@ -1,4 +1,6 @@
-use cosmwasm_std::{to_json_binary, Binary, Coin, Deps, DepsMut, Env, MessageInfo, Response, Uint128};
+use cosmwasm_std::{
+    to_json_binary, Binary, Coin, Deps, DepsMut, Env, MessageInfo, Response, Uint128,
+};
 
 use cw_semver::Version;
 

--- a/framework/contracts/native/version-control/src/queries.rs
+++ b/framework/contracts/native/version-control/src/queries.rs
@@ -426,7 +426,7 @@ mod test {
             };
 
             let ModulesResponse { mut modules } =
-                from_json(&query_helper(deps.as_ref(), query_msg)?)?;
+                from_json(query_helper(deps.as_ref(), query_msg)?)?;
             assert_that!(modules.swap_remove(0).module.info).is_equal_to(&new_module_info);
             Ok(())
         }
@@ -491,7 +491,7 @@ mod test {
             };
 
             let ModulesResponse { mut modules } =
-                from_json(&query_helper(deps.as_ref(), query_msg)?)?;
+                from_json(query_helper(deps.as_ref(), query_msg)?)?;
             assert_that!(modules.swap_remove(0).module.info).is_equal_to(&newest_version);
             Ok(())
         }
@@ -593,7 +593,7 @@ mod test {
                 ],
             };
 
-            let ModulesResponse { modules } = from_json(&query_helper(deps.as_ref(), query_msg)?)?;
+            let ModulesResponse { modules } = from_json(query_helper(deps.as_ref(), query_msg)?)?;
             assert_that!(modules).has_length(3);
             for module in modules {
                 assert_that!(module.module.info.namespace).is_equal_to(namespace.clone());

--- a/framework/contracts/native/version-control/src/queries.rs
+++ b/framework/contracts/native/version-control/src/queries.rs
@@ -593,8 +593,7 @@ mod test {
                 ],
             };
 
-            let ModulesResponse { modules } =
-                from_json(&query_helper(deps.as_ref(), query_msg)?)?;
+            let ModulesResponse { modules } = from_json(&query_helper(deps.as_ref(), query_msg)?)?;
             assert_that!(modules).has_length(3);
             for module in modules {
                 assert_that!(module.module.info.namespace).is_equal_to(namespace.clone());

--- a/framework/contracts/native/version-control/src/queries.rs
+++ b/framework/contracts/native/version-control/src/queries.rs
@@ -1037,7 +1037,7 @@ mod test {
                 },
             );
 
-            // let res2 = from_json(&res.unwrap())?;
+            // let res2 = from_json(res.unwrap())?;
 
             assert_that!(res)
                 .is_err()

--- a/framework/contracts/native/version-control/src/queries.rs
+++ b/framework/contracts/native/version-control/src/queries.rs
@@ -264,7 +264,7 @@ mod test {
     };
     use abstract_testing::{MockQuerierBuilder, MockQuerierOwnership};
     use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
-    use cosmwasm_std::{to_binary, Addr, Binary, DepsMut, StdError};
+    use cosmwasm_std::{to_json_binary, Addr, Binary, DepsMut, StdError};
 
     use abstract_core::{manager, version_control::*};
 
@@ -286,7 +286,7 @@ mod test {
     pub fn mock_manager_querier() -> MockQuerierBuilder {
         MockQuerierBuilder::default()
             .with_smart_handler(TEST_MANAGER, |msg| {
-                match from_binary(msg).unwrap() {
+                match from_json(msg).unwrap() {
                     manager::QueryMsg::Config {} => {
                         let resp = manager::ConfigResponse {
                             version_control_address: Addr::unchecked(TEST_VERSION_CONTROL),
@@ -294,13 +294,13 @@ mod test {
                             account_id: TEST_ACCOUNT_ID, // mock value, not used
                             is_suspended: false,
                         };
-                        Ok(to_binary(&resp).unwrap())
+                        Ok(to_json_binary(&resp).unwrap())
                     }
                     _ => panic!("unexpected message"),
                 }
             })
             .with_smart_handler(TEST_OTHER_MANAGER_ADDR, |msg| {
-                match from_binary(msg).unwrap() {
+                match from_json(msg).unwrap() {
                     manager::QueryMsg::Config {} => {
                         let resp = manager::ConfigResponse {
                             version_control_address: Addr::unchecked(TEST_VERSION_CONTROL),
@@ -308,7 +308,7 @@ mod test {
                             account_id: TEST_OTHER_ACCOUNT_ID, // mock value, not used
                             is_suspended: false,
                         };
-                        Ok(to_binary(&resp).unwrap())
+                        Ok(to_json_binary(&resp).unwrap())
                     }
                     _ => panic!("unexpected message"),
                 }
@@ -381,7 +381,7 @@ mod test {
         use super::*;
         use abstract_core::objects::module::ModuleVersion::Latest;
 
-        use cosmwasm_std::from_binary;
+        use cosmwasm_std::from_json;
 
         fn add_namespace(deps: DepsMut, namespace: &str) {
             let msg = ExecuteMsg::ClaimNamespace {
@@ -426,7 +426,7 @@ mod test {
             };
 
             let ModulesResponse { mut modules } =
-                from_binary(&query_helper(deps.as_ref(), query_msg)?)?;
+                from_json(&query_helper(deps.as_ref(), query_msg)?)?;
             assert_that!(modules.swap_remove(0).module.info).is_equal_to(&new_module_info);
             Ok(())
         }
@@ -491,13 +491,13 @@ mod test {
             };
 
             let ModulesResponse { mut modules } =
-                from_binary(&query_helper(deps.as_ref(), query_msg)?)?;
+                from_json(&query_helper(deps.as_ref(), query_msg)?)?;
             assert_that!(modules.swap_remove(0).module.info).is_equal_to(&newest_version);
             Ok(())
         }
     }
 
-    use cosmwasm_std::from_binary;
+    use cosmwasm_std::from_json;
 
     /// Add namespaces
     fn add_namespaces(mut deps: DepsMut, acc_and_namespace: Vec<(AccountId, &str)>, sender: &str) {
@@ -594,7 +594,7 @@ mod test {
             };
 
             let ModulesResponse { modules } =
-                from_binary(&query_helper(deps.as_ref(), query_msg)?)?;
+                from_json(&query_helper(deps.as_ref(), query_msg)?)?;
             assert_that!(modules).has_length(3);
             for module in modules {
                 assert_that!(module.module.info.namespace).is_equal_to(namespace.clone());
@@ -653,7 +653,7 @@ mod test {
             let res = query_helper(deps.as_ref(), list_msg);
 
             assert_that!(res).is_ok().map(|res| {
-                let ModulesListResponse { modules } = from_binary(res).unwrap();
+                let ModulesListResponse { modules } = from_json(res).unwrap();
                 assert_that!(modules).has_length(3);
 
                 for entry in modules {
@@ -698,7 +698,7 @@ mod test {
             let res = query_helper(deps.as_ref(), list_msg);
 
             assert_that!(res).is_ok().map(|res| {
-                let ModulesListResponse { modules } = from_binary(res).unwrap();
+                let ModulesListResponse { modules } = from_json(res).unwrap();
                 assert_that!(modules).has_length(6);
 
                 let yanked_module_names = ["module4".to_string(), "module5".to_string()];
@@ -754,7 +754,7 @@ mod test {
             let res = query_helper(deps.as_ref(), list_msg);
 
             assert_that!(res).is_ok().map(|res| {
-                let ModulesListResponse { modules } = from_binary(res).unwrap();
+                let ModulesListResponse { modules } = from_json(res).unwrap();
                 assert_that!(modules).has_length(2);
 
                 for entry in modules {
@@ -795,7 +795,7 @@ mod test {
             let res = query_helper(deps.as_ref(), list_msg);
 
             assert_that!(res).is_ok().map(|res| {
-                let ModulesListResponse { modules } = from_binary(res).unwrap();
+                let ModulesListResponse { modules } = from_json(res).unwrap();
                 assert_that!(modules).has_length(1);
 
                 res
@@ -822,7 +822,7 @@ mod test {
             let res = query_helper(deps.as_ref(), list_msg);
 
             assert_that!(res).is_ok().map(|res| {
-                let ModulesListResponse { modules } = from_binary(res).unwrap();
+                let ModulesListResponse { modules } = from_json(res).unwrap();
                 assert_that!(modules).has_length(1);
 
                 let module = modules[0].clone();
@@ -863,7 +863,7 @@ mod test {
             let res = query_helper(deps.as_ref(), list_msg);
 
             assert_that!(res).is_ok().map(|res| {
-                let ModulesListResponse { modules } = from_binary(res).unwrap();
+                let ModulesListResponse { modules } = from_json(res).unwrap();
                 assert_that!(modules).has_length(2);
 
                 for module in modules {
@@ -893,7 +893,7 @@ mod test {
             let res = query_helper(deps.as_ref(), list_msg);
 
             assert_that!(res).is_ok().map(|res| {
-                let ModulesListResponse { modules } = from_binary(res).unwrap();
+                let ModulesListResponse { modules } = from_json(res).unwrap();
                 assert_that!(modules).has_length(6);
 
                 for module in modules {
@@ -922,7 +922,7 @@ mod test {
             let res = query_helper(deps.as_ref(), list_msg);
 
             assert_that!(res).is_ok().map(|res| {
-                let ModulesListResponse { modules } = from_binary(res).unwrap();
+                let ModulesListResponse { modules } = from_json(res).unwrap();
                 assert_that!(modules).is_empty();
 
                 res
@@ -949,7 +949,7 @@ mod test {
             let res = query_helper(deps.as_ref(), list_msg);
 
             assert_that!(res).is_ok().map(|res| {
-                let ModulesListResponse { modules } = from_binary(res).unwrap();
+                let ModulesListResponse { modules } = from_json(res).unwrap();
                 // We expect two because both cw-plus and snth have a module2 with version 0.1.2
                 assert_that!(modules).has_length(2);
 
@@ -982,7 +982,7 @@ mod test {
             let res = query_helper(deps.as_ref(), list_msg);
 
             assert_that!(res).is_ok().map(|res| {
-                let ModulesListResponse { modules } = from_binary(res).unwrap();
+                let ModulesListResponse { modules } = from_json(res).unwrap();
                 assert_that!(modules).has_length(3);
 
                 for module in modules {
@@ -1014,7 +1014,7 @@ mod test {
                 },
             );
             assert_that!(res).is_ok().map(|res| {
-                let NamespacesResponse { namespaces } = from_binary(res).unwrap();
+                let NamespacesResponse { namespaces } = from_json(res).unwrap();
                 assert_that!(namespaces[0].0.to_string()).is_equal_to("4t2".to_string());
                 res
             });
@@ -1038,7 +1038,7 @@ mod test {
                 },
             );
 
-            // let res2 = from_binary(&res.unwrap())?;
+            // let res2 = from_json(&res.unwrap())?;
 
             assert_that!(res)
                 .is_err()
@@ -1062,7 +1062,7 @@ mod test {
             );
 
             assert_that!(res).is_ok().map(|res| {
-                let AccountBaseResponse { account_base } = from_binary(res).unwrap();
+                let AccountBaseResponse { account_base } = from_json(res).unwrap();
                 assert_that!(account_base).is_equal_to(test_account_base());
                 res
             });

--- a/framework/packages/abstract-adapter/src/endpoints/query.rs
+++ b/framework/packages/abstract-adapter/src/endpoints/query.rs
@@ -6,7 +6,7 @@ use abstract_core::{
     objects::module_version::{ModuleDataResponse, MODULE},
 };
 use abstract_sdk::base::{Handler, QueryEndpoint};
-use cosmwasm_std::{to_binary, Addr, Binary, Deps, Env, StdResult};
+use cosmwasm_std::{to_json_binary, Addr, Binary, Deps, Env, StdResult};
 
 /// Where we dispatch the queries for the AdapterContract
 /// These AdapterQueryMsg declarations can be found in `abstract_sdk::core::common_module::app_msg`
@@ -35,7 +35,7 @@ impl<Error: ContractError, CustomInitMsg, CustomExecMsg, CustomQueryMsg, Receive
     fn base_query(&self, deps: Deps, _env: Env, query: BaseQueryMsg) -> Result<Binary, Error> {
         match query {
             BaseQueryMsg::BaseConfig {} => {
-                to_binary(&self.dapp_config(deps).map_err(Error::from)?).map_err(Into::into)
+                to_json_binary(&self.dapp_config(deps).map_err(Error::from)?).map_err(Into::into)
             }
             BaseQueryMsg::AuthorizedAddresses { proxy_address } => {
                 let proxy_address = deps.api.addr_validate(&proxy_address)?;
@@ -44,13 +44,13 @@ impl<Error: ContractError, CustomInitMsg, CustomExecMsg, CustomQueryMsg, Receive
                     .may_load(deps.storage, proxy_address)?
                     .unwrap_or_default();
 
-                to_binary(&AuthorizedAddressesResponse {
+                to_json_binary(&AuthorizedAddressesResponse {
                     addresses: authorized_addrs,
                 })
                 .map_err(Into::into)
             }
             BaseQueryMsg::ModuleData {} => {
-                to_binary(&self.module_data(deps).map_err(Error::from)?).map_err(Into::into)
+                to_json_binary(&self.module_data(deps).map_err(Error::from)?).map_err(Into::into)
             }
         }
     }

--- a/framework/packages/abstract-adapter/src/lib.rs
+++ b/framework/packages/abstract-adapter/src/lib.rs
@@ -32,7 +32,7 @@ pub mod mock {
     };
     use cosmwasm_std::{
         testing::{mock_env, mock_info},
-        to_binary, DepsMut, Empty, Response, StdError,
+        to_json_binary, DepsMut, Empty, Response, StdError,
     };
     use cw_orch::prelude::*;
     use thiserror::Error;
@@ -93,7 +93,7 @@ pub mod mock {
         MockAdapterContract::new(TEST_MODULE_ID, TEST_VERSION, Some(TEST_METADATA))
             .with_instantiate(|_, _, _, _, _| Ok(Response::new().set_data("mock_init".as_bytes())))
             .with_execute(|_, _, _, _, _| Ok(Response::new().set_data("mock_exec".as_bytes())))
-            .with_query(|_, _, _, _| to_binary("mock_query").map_err(Into::into))
+            .with_query(|_, _, _, _| to_json_binary("mock_query").map_err(Into::into))
             .with_sudo(|_, _, _, _| Ok(Response::new().set_data("mock_sudo".as_bytes())))
             .with_receive(|_, _, _, _, _| Ok(Response::new().set_data("mock_receive".as_bytes())))
             .with_ibc_callbacks(&[("c_id", |_, _, _, _, _, _, _| {

--- a/framework/packages/abstract-adapter/src/state.rs
+++ b/framework/packages/abstract-adapter/src/state.rs
@@ -174,7 +174,7 @@ mod tests {
         crate::mock::MockAdapterContract::new(TEST_MODULE_ID, TEST_VERSION, Some(TEST_METADATA))
             .with_instantiate(|_, _, _, _, _| Ok(Response::new().set_data("mock_init".as_bytes())))
             .with_execute(|_, _, _, _, _| Ok(Response::new().set_data("mock_exec".as_bytes())))
-            .with_query(|_, _, _, _| cosmwasm_std::to_binary("mock_query").map_err(Into::into))
+            .with_query(|_, _, _, _| cosmwasm_std::to_json_binary("mock_query").map_err(Into::into))
             .with_sudo(|_, _, _, _| Ok(Response::new().set_data("mock_sudo".as_bytes())))
             .with_receive(|_, _, _, _, _| Ok(Response::new().set_data("mock_receive".as_bytes())))
             .with_ibc_callbacks(&[("c_id", |_, _, _, _, _, _, _| {

--- a/framework/packages/abstract-app/examples/counter.rs
+++ b/framework/packages/abstract-app/examples/counter.rs
@@ -100,7 +100,7 @@ mod handlers {
     pub const instantiate: InstantiateHandlerFn<CounterApp, CounterInitMsg, CounterError> =
         |_, _, _, _, _| Ok(Response::new().set_data("counter_init".as_bytes()));
     pub const query: QueryHandlerFn<CounterApp, CounterQueryMsg, CounterError> =
-        |_, _, _, _| to_binary("counter_query").map_err(Into::into);
+        |_, _, _, _| to_json_binary("counter_query").map_err(Into::into);
     pub const sudo: SudoHandlerFn<CounterApp, CounterSudoMsg, CounterError> =
         |_, _, _, _| Ok(Response::new().set_data("counter_sudo".as_bytes()));
     pub const receive: ReceiveHandlerFn<CounterApp, CounterReceiveMsg, CounterError> =

--- a/framework/packages/abstract-app/src/endpoints/query.rs
+++ b/framework/packages/abstract-app/src/endpoints/query.rs
@@ -164,7 +164,7 @@ mod test {
             let config_query = QueryMsg::Base(BaseQueryMsg::BaseConfig {});
             let res = query_helper(deps.as_ref(), config_query)?;
 
-            assert_that!(from_json(&res).unwrap()).is_equal_to(AppConfigResponse {
+            assert_that!(from_json(res).unwrap()).is_equal_to(AppConfigResponse {
                 proxy_address: Addr::unchecked(TEST_PROXY),
                 ans_host_address: Addr::unchecked(TEST_ANS_HOST),
                 manager_address: Addr::unchecked(TEST_MANAGER),
@@ -180,7 +180,7 @@ mod test {
             let admin_query = QueryMsg::Base(BaseQueryMsg::BaseAdmin {});
             let res = query_helper(deps.as_ref(), admin_query)?;
 
-            assert_that!(from_json(&res).unwrap()).is_equal_to(AdminResponse {
+            assert_that!(from_json(res).unwrap()).is_equal_to(AdminResponse {
                 admin: Some(TEST_MANAGER.to_string()),
             });
 

--- a/framework/packages/abstract-app/src/endpoints/query.rs
+++ b/framework/packages/abstract-app/src/endpoints/query.rs
@@ -6,7 +6,7 @@ use abstract_core::{
     app::{AppConfigResponse, AppQueryMsg, BaseQueryMsg, QueryMsg},
     objects::module_version::{ModuleDataResponse, MODULE},
 };
-use cosmwasm_std::{to_binary, Binary, Deps, Env, StdResult};
+use cosmwasm_std::{to_json_binary, Binary, Deps, Env, StdResult};
 use cw_controllers::AdminResponse;
 
 impl<
@@ -60,9 +60,9 @@ impl<
 {
     pub fn base_query(&self, deps: Deps, _env: Env, query: BaseQueryMsg) -> StdResult<Binary> {
         match query {
-            BaseQueryMsg::BaseConfig {} => to_binary(&self.dapp_config(deps)?),
-            BaseQueryMsg::BaseAdmin {} => to_binary(&self.admin(deps)?),
-            BaseQueryMsg::ModuleData {} => to_binary(&self.module_data(deps)?),
+            BaseQueryMsg::BaseConfig {} => to_json_binary(&self.dapp_config(deps)?),
+            BaseQueryMsg::BaseAdmin {} => to_json_binary(&self.admin(deps)?),
+            BaseQueryMsg::ModuleData {} => to_json_binary(&self.module_data(deps)?),
         }
     }
 
@@ -136,7 +136,7 @@ mod test {
             msg: MockQueryMsg,
         ) -> Result<Binary, MockError> {
             // simply return the message as binary
-            to_binary(&msg).map_err(Into::into)
+            to_json_binary(&msg).map_err(Into::into)
         }
 
         #[test]
@@ -147,7 +147,7 @@ mod test {
             let with_mocked_query = BASIC_MOCK_APP.with_query(mock_query_handler);
             let res = with_mocked_query.query(deps.as_ref(), mock_env(), msg);
 
-            let expected = to_binary(&MockQueryMsg).unwrap();
+            let expected = to_json_binary(&MockQueryMsg).unwrap();
             assert_that!(res).is_ok().is_equal_to(expected);
         }
     }
@@ -155,7 +155,7 @@ mod test {
     mod base_query {
         use super::*;
         use abstract_testing::prelude::{TEST_ANS_HOST, TEST_MANAGER, TEST_PROXY};
-        use cosmwasm_std::{from_binary, Addr};
+        use cosmwasm_std::{from_json, Addr};
 
         #[test]
         fn config() -> AppTestResult {
@@ -164,7 +164,7 @@ mod test {
             let config_query = QueryMsg::Base(BaseQueryMsg::BaseConfig {});
             let res = query_helper(deps.as_ref(), config_query)?;
 
-            assert_that!(from_binary(&res).unwrap()).is_equal_to(AppConfigResponse {
+            assert_that!(from_json(&res).unwrap()).is_equal_to(AppConfigResponse {
                 proxy_address: Addr::unchecked(TEST_PROXY),
                 ans_host_address: Addr::unchecked(TEST_ANS_HOST),
                 manager_address: Addr::unchecked(TEST_MANAGER),
@@ -180,7 +180,7 @@ mod test {
             let admin_query = QueryMsg::Base(BaseQueryMsg::BaseAdmin {});
             let res = query_helper(deps.as_ref(), admin_query)?;
 
-            assert_that!(from_binary(&res).unwrap()).is_equal_to(AdminResponse {
+            assert_that!(from_json(&res).unwrap()).is_equal_to(AdminResponse {
                 admin: Some(TEST_MANAGER.to_string()),
             });
 

--- a/framework/packages/abstract-app/src/lib.rs
+++ b/framework/packages/abstract-app/src/lib.rs
@@ -101,8 +101,9 @@ pub mod mock {
     crate::export_endpoints!(MOCK_APP, MockAppContract);
 
     pub fn app_base_mock_querier() -> MockQuerierBuilder {
-        MockQuerierBuilder::default().with_smart_handler(TEST_MODULE_FACTORY, |msg| {
-            match from_json(msg).unwrap() {
+        MockQuerierBuilder::default().with_smart_handler(
+            TEST_MODULE_FACTORY,
+            |msg| match from_json(msg).unwrap() {
                 abstract_core::module_factory::QueryMsg::Context {} => {
                     let resp = ContextResponse {
                         account_base: AccountBase {
@@ -115,8 +116,8 @@ pub mod mock {
                     Ok(to_json_binary(&resp).unwrap())
                 }
                 _ => panic!("unexpected message"),
-            }
-        })
+            },
+        )
     }
 
     /// Instantiate the contract with the default [`TEST_MODULE_FACTORY`].

--- a/framework/packages/abstract-app/src/lib.rs
+++ b/framework/packages/abstract-app/src/lib.rs
@@ -19,7 +19,7 @@ pub mod mock {
     pub use abstract_core::app;
     use abstract_interface::AppDeployer;
     pub use cosmwasm_std::testing::*;
-    use cosmwasm_std::{from_binary, to_binary, Addr, Response, StdError};
+    use cosmwasm_std::{from_json, to_json_binary, Addr, Response, StdError};
     use cw_orch::prelude::*;
 
     pub type AppTestResult = Result<(), MockError>;
@@ -87,7 +87,7 @@ pub mod mock {
     pub const MOCK_APP: MockAppContract = MockAppContract::new(TEST_MODULE_ID, TEST_VERSION, None)
         .with_instantiate(|_, _, _, _, _| Ok(Response::new().set_data("mock_init".as_bytes())))
         .with_execute(|_, _, _, _, _| Ok(Response::new().set_data("mock_exec".as_bytes())))
-        .with_query(|_, _, _, _| to_binary("mock_query").map_err(Into::into))
+        .with_query(|_, _, _, _| to_json_binary("mock_query").map_err(Into::into))
         .with_sudo(|_, _, _, _| Ok(Response::new().set_data("mock_sudo".as_bytes())))
         .with_receive(|_, _, _, _, _| Ok(Response::new().set_data("mock_receive".as_bytes())))
         .with_ibc_callbacks(&[("c_id", |_, _, _, _, _, _, _| {
@@ -102,7 +102,7 @@ pub mod mock {
 
     pub fn app_base_mock_querier() -> MockQuerierBuilder {
         MockQuerierBuilder::default().with_smart_handler(TEST_MODULE_FACTORY, |msg| {
-            match from_binary(msg).unwrap() {
+            match from_json(msg).unwrap() {
                 abstract_core::module_factory::QueryMsg::Context {} => {
                     let resp = ContextResponse {
                         account_base: AccountBase {
@@ -112,7 +112,7 @@ pub mod mock {
                         modules: vec![],
                         modules_to_register: vec![],
                     };
-                    Ok(to_binary(&resp).unwrap())
+                    Ok(to_json_binary(&resp).unwrap())
                 }
                 _ => panic!("unexpected message"),
             }

--- a/framework/packages/abstract-app/src/state.rs
+++ b/framework/packages/abstract-app/src/state.rs
@@ -180,7 +180,7 @@ mod tests {
         MockAppContract::new(TEST_MODULE_ID, TEST_VERSION, None)
             .with_instantiate(|_, _, _, _, _| Ok(Response::new().set_data("mock_init".as_bytes())))
             .with_execute(|_, _, _, _, _| Ok(Response::new().set_data("mock_exec".as_bytes())))
-            .with_query(|_, _, _, _| cosmwasm_std::to_binary("mock_query").map_err(Into::into))
+            .with_query(|_, _, _, _| cosmwasm_std::to_json_binary("mock_query").map_err(Into::into))
             .with_sudo(|_, _, _, _| Ok(Response::new().set_data("mock_sudo".as_bytes())))
             .with_receive(|_, _, _, _, _| Ok(Response::new().set_data("mock_receive".as_bytes())))
             .with_ibc_callbacks(&[("c_id", |_, _, _, _, _, _, _| {

--- a/framework/packages/abstract-core/src/native/ibc.rs
+++ b/framework/packages/abstract-core/src/native/ibc.rs
@@ -27,7 +27,7 @@ pub struct IbcResponseMsg {
 
 impl IbcResponseMsg {
     /// serializes the message
-    pub fn into_binary(self) -> StdResult<Binary> {
+    pub fn into_json_binary(self) -> StdResult<Binary> {
         let msg = IbcCallbackMsg::IbcCallback(self);
         to_json_binary(&msg)
     }

--- a/framework/packages/abstract-core/src/native/ibc.rs
+++ b/framework/packages/abstract-core/src/native/ibc.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{to_binary, wasm_execute, Binary, CosmosMsg, StdResult};
+use cosmwasm_std::{to_json_binary, wasm_execute, Binary, CosmosMsg, StdResult};
 use polytone::callbacks::Callback;
 use schemars::JsonSchema;
 
@@ -29,7 +29,7 @@ impl IbcResponseMsg {
     /// serializes the message
     pub fn into_binary(self) -> StdResult<Binary> {
         let msg = IbcCallbackMsg::IbcCallback(self);
-        to_binary(&msg)
+        to_json_binary(&msg)
     }
 
     /// creates a cosmos_msg sending this struct to the named contract

--- a/framework/packages/abstract-core/src/native/ibc_client.rs
+++ b/framework/packages/abstract-core/src/native/ibc_client.rs
@@ -211,7 +211,7 @@ pub struct RemoteProxyResponse {
 #[cfg(test)]
 mod tests {
     use crate::ibc::IbcResponseMsg;
-    use cosmwasm_std::{to_binary, CosmosMsg, Empty};
+    use cosmwasm_std::{to_json_binary, CosmosMsg, Empty};
     use polytone::callbacks::Callback;
     use speculoos::prelude::*;
 
@@ -221,7 +221,7 @@ mod tests {
     fn test_response_msg_to_callback_msg() {
         let receiver = "receiver".to_string();
         let callback_id = "15".to_string();
-        let callback_msg = to_binary("15").unwrap();
+        let callback_msg = to_json_binary("15").unwrap();
 
         let result = Callback::FatalError("ibc execution error".to_string());
 

--- a/framework/packages/abstract-core/src/objects/module.rs
+++ b/framework/packages/abstract-core/src/objects/module.rs
@@ -3,7 +3,7 @@ use crate::objects::fee::FixedFee;
 use crate::objects::module_version::MODULE;
 use crate::objects::namespace::Namespace;
 use crate::{error::AbstractError, AbstractResult};
-use cosmwasm_std::{ensure_eq, to_binary, Addr, Binary, QuerierWrapper, StdError, StdResult};
+use cosmwasm_std::{ensure_eq, to_json_binary, Addr, Binary, QuerierWrapper, StdError, StdResult};
 use cw2::ContractVersion;
 use cw_semver::Version;
 use cw_storage_plus::{Key, KeyDeserialize, Prefixer, PrimaryKey};
@@ -343,7 +343,7 @@ impl ModuleInitMsg {
             ModuleInitMsg {
                 fixed_init: Some(_),
                 owner_init: Some(_),
-            } => to_binary(&self),
+            } => to_json_binary(&self),
             // If not, we can simplify by only sending the custom or fixed message.
             ModuleInitMsg {
                 fixed_init: None,

--- a/framework/packages/abstract-core/src/objects/price_source.rs
+++ b/framework/packages/abstract-core/src/objects/price_source.rs
@@ -10,7 +10,7 @@
 //! **There should only be ONE base asset when configuring your proxy**
 
 use cosmwasm_std::{
-    to_binary, Addr, Decimal, Deps, QuerierWrapper, QueryRequest, StdError, Uint128, WasmQuery,
+    to_json_binary, Addr, Decimal, Deps, QuerierWrapper, QueryRequest, StdError, Uint128, WasmQuery,
 };
 use cw_asset::{Asset, AssetInfo};
 use schemars::JsonSchema;
@@ -246,7 +246,7 @@ fn query_cw20_supply(querier: &QuerierWrapper, contract_addr: &Addr) -> Abstract
     let response: cw20::TokenInfoResponse =
         querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
             contract_addr: contract_addr.into(),
-            msg: to_binary(&cw20::Cw20QueryMsg::TokenInfo {})?,
+            msg: to_json_binary(&cw20::Cw20QueryMsg::TokenInfo {})?,
         }))?;
     Ok(response.total_supply)
 }
@@ -405,7 +405,7 @@ mod tests {
                         _ => panic!("unexpected message"),
                     };
 
-                    Ok(to_binary(&res).unwrap())
+                    Ok(to_json_binary(&res).unwrap())
                 })
                 .build();
 

--- a/framework/packages/abstract-core/src/objects/price_source.rs
+++ b/framework/packages/abstract-core/src/objects/price_source.rs
@@ -395,7 +395,7 @@ mod tests {
                     },
                 )
                 .with_smart_handler(TEST_LP_TOKEN_ADDR, |msg| {
-                    let res = match from_binary::<cw20::Cw20QueryMsg>(msg).unwrap() {
+                    let res = match from_json::<cw20::Cw20QueryMsg>(msg).unwrap() {
                         cw20::Cw20QueryMsg::TokenInfo {} => cw20::TokenInfoResponse {
                             name: "test".to_string(),
                             symbol: "test".to_string(),

--- a/framework/packages/abstract-interface/src/account/manager.rs
+++ b/framework/packages/abstract-interface/src/account/manager.rs
@@ -8,7 +8,7 @@ use abstract_core::{
     objects::module::{ModuleInfo, ModuleVersion},
     PROXY,
 };
-use cosmwasm_std::{to_binary, Binary, Empty};
+use cosmwasm_std::{to_json_binary, Binary, Empty};
 use cw_orch::environment::TxHandler;
 use cw_orch::interface;
 use cw_orch::prelude::*;
@@ -45,7 +45,7 @@ impl<Chain: CwEnv> Manager<Chain> {
             &ExecuteMsg::Upgrade {
                 modules: vec![(
                     ModuleInfo::from_id(module_id, ModuleVersion::Latest)?,
-                    Some(to_binary(migrate_msg).unwrap()),
+                    Some(to_json_binary(migrate_msg).unwrap()),
                 )],
             },
             None,
@@ -112,7 +112,7 @@ impl<Chain: CwEnv> Manager<Chain> {
             &ExecuteMsg::InstallModules {
                 modules: vec![ModuleInstallConfig::new(
                     ModuleInfo::from_id(module_id, version)?,
-                    Some(to_binary(init_msg).unwrap()),
+                    Some(to_json_binary(init_msg).unwrap()),
                 )],
             },
             funds,
@@ -129,7 +129,7 @@ impl<Chain: CwEnv> Manager<Chain> {
         self.execute(
             &ExecuteMsg::ExecOnModule {
                 module_id: module.into(),
-                exec_msg: to_binary(&msg).unwrap(),
+                exec_msg: to_json_binary(&msg).unwrap(),
             },
             None,
         )
@@ -179,7 +179,7 @@ impl<Chain: CwEnv> Manager<Chain> {
     ) -> Result<<Chain as cw_orch::prelude::TxHandler>::Response, crate::AbstractInterfaceError>
     {
         let result = self.exec_on_module(
-            to_binary(&abstract_core::proxy::ExecuteMsg::IbcAction {
+            to_json_binary(&abstract_core::proxy::ExecuteMsg::IbcAction {
                 msgs: vec![abstract_core::ibc_client::ExecuteMsg::Register {
                     host_chain: host_chain.into(),
                 }],

--- a/framework/packages/abstract-sdk/src/apis/adapter.rs
+++ b/framework/packages/abstract-sdk/src/apis/adapter.rs
@@ -143,7 +143,7 @@ mod tests {
                 .is_ok()
                 .is_equal_to(CosmosMsg::Wasm(WasmMsg::Execute {
                     contract_addr: TEST_MODULE_ADDRESS.into(),
-                    msg: to_binary(&expected_msg).unwrap(),
+                    msg: to_json_binary(&expected_msg).unwrap(),
                     funds: vec![],
                 }));
         }

--- a/framework/packages/abstract-sdk/src/apis/app.rs
+++ b/framework/packages/abstract-sdk/src/apis/app.rs
@@ -151,7 +151,7 @@ mod tests {
                 .is_ok()
                 .is_equal_to(CosmosMsg::Wasm(WasmMsg::Execute {
                     contract_addr: TEST_MODULE_ADDRESS.into(),
-                    msg: to_binary(&expected_msg).unwrap(),
+                    msg: to_json_binary(&expected_msg).unwrap(),
                     funds: vec![],
                 }));
         }
@@ -205,7 +205,7 @@ mod tests {
                 .is_ok()
                 .is_equal_to::<CosmosMsg>(CosmosMsg::Wasm(WasmMsg::Execute {
                     contract_addr: TEST_MODULE_ADDRESS.into(),
-                    msg: to_binary(&expected_msg).unwrap(),
+                    msg: to_json_binary(&expected_msg).unwrap(),
                     funds: vec![],
                 }));
         }

--- a/framework/packages/abstract-sdk/src/apis/bank.rs
+++ b/framework/packages/abstract-sdk/src/apis/bank.rs
@@ -5,7 +5,7 @@ use crate::core::objects::{AnsAsset, AssetEntry};
 use crate::features::AccountIdentification;
 use crate::AccountAction;
 use crate::{ans_resolve::Resolve, features::AbstractNameService, AbstractSdkResult};
-use cosmwasm_std::to_binary;
+use cosmwasm_std::to_json_binary;
 use cosmwasm_std::{Addr, Coin, CosmosMsg, Deps, Env};
 use cw_asset::Asset;
 use serde::Serialize;
@@ -163,7 +163,7 @@ impl<'a, T: TransferInterface> Bank<'a, T> {
     ) -> AbstractSdkResult<AccountAction> {
         let transferable_funds = funds.transferable_asset(self.base, self.deps)?;
 
-        let msgs = transferable_funds.send_msg(recipient, to_binary(message)?)?;
+        let msgs = transferable_funds.send_msg(recipient, to_json_binary(message)?)?;
 
         Ok(AccountAction::from_vec(vec![msgs]))
     }
@@ -345,10 +345,10 @@ mod test {
 
             let expected_msg: CosmosMsg = CosmosMsg::Wasm(WasmMsg::Execute {
                 contract_addr: asset.to_string(),
-                msg: to_binary(&Cw20ExecuteMsg::Send {
+                msg: to_json_binary(&Cw20ExecuteMsg::Send {
                     contract: expected_recipient.to_string(),
                     amount: expected_amount.into(),
-                    msg: to_binary(&hook_msg).unwrap(),
+                    msg: to_json_binary(&hook_msg).unwrap(),
                 })
                 .unwrap(),
                 funds: vec![],

--- a/framework/packages/abstract-sdk/src/apis/distribution.rs
+++ b/framework/packages/abstract-sdk/src/apis/distribution.rs
@@ -7,7 +7,7 @@ use cosmos_sdk_proto::{
     cosmos::{base, distribution},
     traits::Message,
 };
-use cosmwasm_std::{to_binary, Addr, Coin, CosmosMsg};
+use cosmwasm_std::{to_json_binary, Addr, Coin, CosmosMsg};
 
 use crate::AbstractSdkResult;
 use crate::AccountAction;
@@ -66,7 +66,7 @@ impl Distribution {
 
         let msg = CosmosMsg::Stargate {
             type_url: "/cosmos.distribution.v1beta1.MsgSetWithdrawAddress".to_string(),
-            value: to_binary(&msg)?,
+            value: to_json_binary(&msg)?,
         };
 
         Ok(msg.into())
@@ -86,7 +86,7 @@ impl Distribution {
 
         let msg = CosmosMsg::Stargate {
             type_url: "/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward".to_string(),
-            value: to_binary(&msg)?,
+            value: to_json_binary(&msg)?,
         };
 
         Ok(msg.into())
@@ -104,7 +104,7 @@ impl Distribution {
 
         let msg = CosmosMsg::Stargate {
             type_url: "/cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission".to_string(),
-            value: to_binary(&msg)?,
+            value: to_json_binary(&msg)?,
         };
 
         Ok(msg.into())
@@ -130,7 +130,7 @@ impl Distribution {
 
         let msg = CosmosMsg::Stargate {
             type_url: "/cosmos.distribution.v1beta1.MsgFundCommunityPool".to_string(),
-            value: to_binary(&msg)?,
+            value: to_json_binary(&msg)?,
         };
 
         Ok(msg.into())

--- a/framework/packages/abstract-sdk/src/apis/execution.rs
+++ b/framework/packages/abstract-sdk/src/apis/execution.rs
@@ -170,7 +170,7 @@ mod test {
 
     mod execute {
         use super::*;
-        use cosmwasm_std::to_binary;
+        use cosmwasm_std::to_json_binary;
 
         /// Tests that no error is thrown with empty messages provided
         #[test]
@@ -186,7 +186,7 @@ mod test {
 
             let expected = ExecutorMsg(CosmosMsg::Wasm(WasmMsg::Execute {
                 contract_addr: TEST_PROXY.to_string(),
-                msg: to_binary(&ExecuteMsg::ModuleAction {
+                msg: to_json_binary(&ExecuteMsg::ModuleAction {
                     msgs: flatten_actions(messages),
                 })
                 .unwrap(),
@@ -209,7 +209,7 @@ mod test {
 
             let expected = ExecutorMsg(CosmosMsg::Wasm(WasmMsg::Execute {
                 contract_addr: TEST_PROXY.to_string(),
-                msg: to_binary(&ExecuteMsg::ModuleAction {
+                msg: to_json_binary(&ExecuteMsg::ModuleAction {
                     msgs: flatten_actions(messages),
                 })
                 .unwrap(),
@@ -245,7 +245,7 @@ mod test {
                 id: expected_reply_id,
                 msg: CosmosMsg::Wasm(WasmMsg::Execute {
                     contract_addr: TEST_PROXY.to_string(),
-                    msg: to_binary(&ExecuteMsg::ModuleAction {
+                    msg: to_json_binary(&ExecuteMsg::ModuleAction {
                         msgs: flatten_actions(empty_actions),
                     })
                     .unwrap(),
@@ -280,7 +280,7 @@ mod test {
                 id: expected_reply_id,
                 msg: CosmosMsg::Wasm(WasmMsg::Execute {
                     contract_addr: TEST_PROXY.to_string(),
-                    msg: to_binary(&ExecuteMsg::ModuleAction {
+                    msg: to_json_binary(&ExecuteMsg::ModuleAction {
                         msgs: flatten_actions(action),
                     })
                     .unwrap(),
@@ -312,7 +312,7 @@ mod test {
 
             let expected_msg = CosmosMsg::Wasm(WasmMsg::Execute {
                 contract_addr: TEST_PROXY.to_string(),
-                msg: to_binary(&ExecuteMsg::ModuleAction {
+                msg: to_json_binary(&ExecuteMsg::ModuleAction {
                     msgs: flatten_actions(empty_actions),
                 })
                 .unwrap(),
@@ -344,7 +344,7 @@ mod test {
 
             let expected_msg = CosmosMsg::Wasm(WasmMsg::Execute {
                 contract_addr: TEST_PROXY.to_string(),
-                msg: to_binary(&ExecuteMsg::ModuleAction {
+                msg: to_json_binary(&ExecuteMsg::ModuleAction {
                     msgs: flatten_actions(action),
                 })
                 .unwrap(),

--- a/framework/packages/abstract-sdk/src/apis/grant.rs
+++ b/framework/packages/abstract-sdk/src/apis/grant.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use crate::features::AccountIdentification;
 
 use cosmos_sdk_proto::{cosmos::base, cosmos::feegrant, traits::Message, Any};
-use cosmwasm_std::{to_binary, Addr, Coin, CosmosMsg, Timestamp};
+use cosmwasm_std::{to_json_binary, Addr, Coin, CosmosMsg, Timestamp};
 
 use crate::AbstractSdkResult;
 use crate::AccountAction;
@@ -68,7 +68,7 @@ impl Grant {
 
         let msg = CosmosMsg::Stargate {
             type_url: "/cosmos.feegrant.v1beta1.MsgGrantAllowance".to_string(),
-            value: to_binary(&msg)?,
+            value: to_json_binary(&msg)?,
         };
 
         Ok(msg.into())
@@ -92,7 +92,7 @@ impl Grant {
 
         let msg = CosmosMsg::Stargate {
             type_url: "/cosmos.feegrant.v1beta1.MsgGrantAllowance".to_string(),
-            value: to_binary(&msg)?,
+            value: to_json_binary(&msg)?,
         };
 
         Ok(msg.into())
@@ -108,7 +108,7 @@ impl Grant {
 
         let msg = CosmosMsg::Stargate {
             type_url: "/cosmos.feegrant.v1beta1.AllowedMsgAllowance".to_string(),
-            value: to_binary(&msg)?,
+            value: to_json_binary(&msg)?,
         };
 
         Ok(msg.into())
@@ -124,7 +124,7 @@ impl Grant {
 
         let msg = CosmosMsg::Stargate {
             type_url: "/cosmos.feegrant.v1beta1.AllowedMsgAllowance".to_string(),
-            value: to_binary(&msg)?,
+            value: to_json_binary(&msg)?,
         };
 
         Ok(msg.into())
@@ -144,7 +144,7 @@ impl Grant {
 
         let msg = CosmosMsg::Stargate {
             type_url: "/cosmos.feegrant.v1beta1.AllowedMsgAllowance".to_string(),
-            value: to_binary(&msg)?,
+            value: to_json_binary(&msg)?,
         };
 
         Ok(msg.into())
@@ -160,7 +160,7 @@ impl Grant {
 
         let msg = CosmosMsg::Stargate {
             type_url: "/cosmos.feegrant.v1beta1.MsgRevokeAllowance".to_string(),
-            value: to_binary(&msg)?,
+            value: to_json_binary(&msg)?,
         };
 
         Ok(msg.into())

--- a/framework/packages/abstract-sdk/src/apis/ibc.rs
+++ b/framework/packages/abstract-sdk/src/apis/ibc.rs
@@ -12,7 +12,7 @@ use abstract_core::{
     proxy::ExecuteMsg,
     IBC_CLIENT,
 };
-use cosmwasm_std::{to_binary, wasm_execute, Addr, Coin, CosmosMsg, Deps};
+use cosmwasm_std::{to_json_binary, wasm_execute, Addr, Coin, CosmosMsg, Deps};
 use serde::Serialize;
 
 /// Interact with other chains over IBC.
@@ -106,7 +106,7 @@ impl<'a, T: IbcInterface> IbcClient<'a, T> {
                     modules: vec![ModuleInstallConfig::new(
                         module,
                         Some(
-                            to_binary(&abstract_core::app::InstantiateMsg {
+                            to_json_binary(&abstract_core::app::InstantiateMsg {
                                 base: abstract_core::app::BaseInstantiateMsg {
                                     ans_host_address: remote_ans_host_address.to_string(),
                                     version_control_address: remote_version_control_address
@@ -140,7 +140,7 @@ impl<'a, T: IbcInterface> IbcClient<'a, T> {
                     modules: vec![ModuleInstallConfig::new(
                         module,
                         Some(
-                            to_binary(&abstract_core::adapter::InstantiateMsg {
+                            to_json_binary(&abstract_core::adapter::InstantiateMsg {
                                 base: abstract_core::adapter::BaseInstantiateMsg {
                                     ans_host_address: remote_ans_host_address.to_string(),
                                     version_control_address: remote_version_control_address
@@ -169,7 +169,7 @@ impl<'a, T: IbcInterface> IbcClient<'a, T> {
             HostAction::Dispatch {
                 manager_msg: abstract_core::manager::ExecuteMsg::ExecOnModule {
                     module_id,
-                    exec_msg: to_binary(exec_msg)?,
+                    exec_msg: to_json_binary(exec_msg)?,
                 },
             },
             None,
@@ -243,7 +243,7 @@ mod test {
 
         let expected = CosmosMsg::Wasm(WasmMsg::Execute {
             contract_addr: TEST_PROXY.to_string(),
-            msg: to_binary(&ExecuteMsg::IbcAction {
+            msg: to_json_binary(&ExecuteMsg::IbcAction {
                 msgs: vec![IbcClientMsg::RemoteAction {
                     host_chain: TEST_HOST_CHAIN.into(),
                     action: HostAction::Dispatch {
@@ -287,7 +287,7 @@ mod test {
 
         let expected = CosmosMsg::Wasm(WasmMsg::Execute {
             contract_addr: TEST_PROXY.to_string(),
-            msg: to_binary(&ExecuteMsg::IbcAction {
+            msg: to_json_binary(&ExecuteMsg::IbcAction {
                 msgs: vec![IbcClientMsg::RemoteAction {
                     host_chain: TEST_HOST_CHAIN.into(),
                     action: HostAction::Dispatch {
@@ -319,7 +319,7 @@ mod test {
 
         let expected = CosmosMsg::Wasm(WasmMsg::Execute {
             contract_addr: TEST_PROXY.to_string(),
-            msg: to_binary(&ExecuteMsg::IbcAction {
+            msg: to_json_binary(&ExecuteMsg::IbcAction {
                 msgs: vec![IbcClientMsg::SendFunds {
                     host_chain: TEST_HOST_CHAIN.into(),
                     funds: expected_funds,

--- a/framework/packages/abstract-sdk/src/base/contract_base.rs
+++ b/framework/packages/abstract-sdk/src/base/contract_base.rs
@@ -347,7 +347,7 @@ mod test {
     #[test]
     fn test_with_query() {
         let contract = MockAppContract::new("test_contract", "0.1.0", ModuleMetadata::default())
-            .with_query(|_, _, _, _| Ok(cosmwasm_std::to_binary(&Empty {}).unwrap()));
+            .with_query(|_, _, _, _| Ok(cosmwasm_std::to_json_binary(&Empty {}).unwrap()));
 
         assert!(contract.query_handler.is_some());
     }

--- a/framework/packages/abstract-sdk/src/cw_helpers/cosmwasm_std/wasm_query.rs
+++ b/framework/packages/abstract-sdk/src/cw_helpers/cosmwasm_std/wasm_query.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{to_binary, QueryRequest, StdResult, WasmQuery};
+use cosmwasm_std::{to_json_binary, QueryRequest, StdResult, WasmQuery};
 use serde::Serialize;
 
 /// Shortcut helper as the construction of QueryRequest::Wasm(WasmQuery::Smart {...}) can be quite verbose in contract code
@@ -6,7 +6,7 @@ pub fn wasm_smart_query<C>(
     contract_addr: impl Into<String>,
     msg: &impl Serialize,
 ) -> StdResult<QueryRequest<C>> {
-    let query_msg = to_binary(msg)?;
+    let query_msg = to_json_binary(msg)?;
     Ok(QueryRequest::Wasm(WasmQuery::Smart {
         contract_addr: contract_addr.into(),
         msg: query_msg,
@@ -37,7 +37,7 @@ mod test {
         match query {
             QueryRequest::Wasm(WasmQuery::Smart { contract_addr, msg }) => {
                 assert_eq!(contract_addr, "contract");
-                assert_eq!(msg, to_binary(&query_msg).unwrap());
+                assert_eq!(msg, to_json_binary(&query_msg).unwrap());
             }
             _ => panic!("Unexpected query"),
         }

--- a/framework/packages/abstract-sdk/src/cw_helpers/cw_ownable.rs
+++ b/framework/packages/abstract-sdk/src/cw_helpers/cw_ownable.rs
@@ -34,7 +34,7 @@ macro_rules! execute_update_ownership {
 #[macro_export]
 macro_rules! query_ownership {
     ($deps:expr) => {{
-        cosmwasm_std::to_binary(&cw_ownable::get_ownership($deps.storage)?)
+        cosmwasm_std::to_json_binary(&cw_ownable::get_ownership($deps.storage)?)
     }};
 }
 
@@ -44,7 +44,7 @@ mod tests {
     use cosmwasm_schema::cw_serde;
     use cosmwasm_schema::QueryResponses;
     use cosmwasm_std::{
-        from_binary,
+        from_json,
         testing::{mock_dependencies, mock_env, mock_info},
         Addr, Binary, StdError, StdResult,
     };
@@ -139,7 +139,7 @@ mod tests {
         };
 
         // Deserialize the query response
-        let actual: cw_ownable::Ownership<Addr> = from_binary(&result.unwrap())?;
+        let actual: cw_ownable::Ownership<Addr> = from_json(&result.unwrap())?;
 
         assert_eq!(actual, expected);
 

--- a/framework/packages/abstract-sdk/src/cw_helpers/cw_ownable.rs
+++ b/framework/packages/abstract-sdk/src/cw_helpers/cw_ownable.rs
@@ -139,7 +139,7 @@ mod tests {
         };
 
         // Deserialize the query response
-        let actual: cw_ownable::Ownership<Addr> = from_json(&result.unwrap())?;
+        let actual: cw_ownable::Ownership<Addr> = from_json(result.unwrap())?;
 
         assert_eq!(actual, expected);
 

--- a/framework/packages/abstract-testing/src/lib.rs
+++ b/framework/packages/abstract-testing/src/lib.rs
@@ -72,8 +72,8 @@ pub mod prelude {
     pub use super::MockDeps;
 
     pub use cosmwasm_std::{
-        from_binary,
+        from_json,
         testing::{MockApi as CwMockApi, MockQuerier, MockStorage},
-        to_binary,
+        to_json_binary,
     };
 }

--- a/framework/packages/abstract-testing/src/mock_querier.rs
+++ b/framework/packages/abstract-testing/src/mock_querier.rs
@@ -9,7 +9,7 @@ use abstract_core::{
 };
 use cosmwasm_std::ContractInfoResponse;
 use cosmwasm_std::{
-    from_binary, testing::MockQuerier, to_binary, Addr, Binary, ContractResult, Empty,
+    from_json, testing::MockQuerier, to_json_binary, Addr, Binary, ContractResult, Empty,
     QuerierWrapper, SystemResult, WasmQuery,
 };
 use cw2::{ContractVersion, CONTRACT};
@@ -28,19 +28,19 @@ type RawHandler = dyn for<'a> Fn(&'a str) -> BinaryQueryResult;
 /// Usage:
 ///
 /// ```
-/// use cosmwasm_std::{from_binary, to_binary};
+/// use cosmwasm_std::{from_json, to_json_binary};
 /// use abstract_testing::MockQuerierBuilder;
 /// use cosmwasm_std::testing::MockQuerier;
 /// use abstract_sdk::mock_module::MockModuleExecuteMsg;
 ///
 /// let querier = MockQuerierBuilder::default().with_smart_handler("contract_address", |msg| {
 ///    // handle the message
-///     let res = match from_binary::<MockModuleExecuteMsg>(msg).unwrap() {
+///     let res = match from_json::<MockModuleExecuteMsg>(msg).unwrap() {
 ///         // handle the message
 ///        _ => panic!("unexpected message"),
 ///    };
 ///
-///   Ok(to_binary(&msg).unwrap())
+///   Ok(to_json_binary(&msg).unwrap())
 /// }).build();
 /// ```
 pub struct MockQuerierBuilder {
@@ -118,17 +118,17 @@ impl MockQuerierBuilder {
     /// contract address is queried with the given message.
     /// Usage:
     /// ```rust
-    /// use cosmwasm_std::{from_binary, to_binary};
+    /// use cosmwasm_std::{from_json, to_json_binary};
     /// use abstract_testing::MockQuerierBuilder;
     /// use cosmwasm_std::testing::MockQuerier;
     /// use abstract_sdk::mock_module::{MockModuleQueryMsg, MockModuleQueryResponse};
     /// # // ANCHOR: smart_query
     /// let querier = MockQuerierBuilder::default().with_smart_handler("contract_address", |msg| {
     ///    // handle the message
-    ///     let res = match from_binary::<MockModuleQueryMsg>(msg).unwrap() {
+    ///     let res = match from_json::<MockModuleQueryMsg>(msg).unwrap() {
     ///         // handle the message
     ///         MockModuleQueryMsg =>
-    ///                         return to_binary(&MockModuleQueryResponse {}).map_err(|e| e.to_string())
+    ///                         return to_json_binary(&MockModuleQueryResponse {}).map_err(|e| e.to_string())
     ///    };
     /// }).build();
     /// # // ANCHOR_END: smart_query
@@ -146,7 +146,7 @@ impl MockQuerierBuilder {
     /// contract address is queried with the given message.
     /// Usage:
     /// ```rust
-    /// use cosmwasm_std::{from_binary, to_binary};
+    /// use cosmwasm_std::{from_json, to_json_binary};
     /// use abstract_testing::MockQuerierBuilder;
     /// use cosmwasm_std::testing::MockQuerier;
     /// use abstract_sdk::mock_module::{MockModuleQueryMsg, MockModuleQueryResponse};
@@ -154,8 +154,8 @@ impl MockQuerierBuilder {
     /// let querier = MockQuerierBuilder::default().with_raw_handler("contract1", |key: &str| {
     ///     // Example: Let's say, in the raw storage, the key "the key" maps to the value "the value"
     ///     match key {
-    ///         "the key" => to_binary("the value").map_err(|e| e.to_string()),
-    ///         _ => to_binary("").map_err(|e| e.to_string())
+    ///         "the key" => to_json_binary("the value").map_err(|e| e.to_string()),
+    ///         _ => to_json_binary("").map_err(|e| e.to_string())
     ///     }
     /// # // ANCHOR_END: raw_query
     /// ```
@@ -213,7 +213,7 @@ impl MockQuerierBuilder {
             self.insert_contract_key_value(
                 contract,
                 raw_map_key(&cw_map, key),
-                to_binary(&value).unwrap(),
+                to_json_binary(&value).unwrap(),
             );
         }
 
@@ -269,7 +269,7 @@ impl MockQuerierBuilder {
         self.insert_contract_key_value(
             contract,
             cw_item.as_slice().to_vec(),
-            to_binary(value).unwrap(),
+            to_json_binary(value).unwrap(),
         );
 
         self
@@ -333,7 +333,7 @@ impl MockQuerierBuilder {
                 WasmQuery::ContractInfo { contract_addr } => {
                     let mut info = ContractInfoResponse::default();
                     info.admin = self.contract_admin.get(contract_addr).cloned();
-                    Ok(to_binary(&info).unwrap())
+                    Ok(to_json_binary(&info).unwrap())
                 }
                 unexpected => panic!("Unexpected query: {unexpected:?}"),
             };
@@ -406,8 +406,8 @@ pub fn mock_querier() -> MockQuerier {
         )
         .with_contract_item(TEST_MANAGER, ACCOUNT_ID, &TEST_ACCOUNT_ID)
         .with_smart_handler(TEST_MODULE_ADDRESS, |msg| {
-            let Empty {} = from_binary(msg).unwrap();
-            Ok(to_binary(TEST_MODULE_RESPONSE).unwrap())
+            let Empty {} = from_json(msg).unwrap();
+            Ok(to_json_binary(TEST_MODULE_RESPONSE).unwrap())
         })
         .with_contract_map_entry(
             TEST_MANAGER,

--- a/framework/packages/standards/utils/src/util.rs
+++ b/framework/packages/standards/utils/src/util.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{to_binary, Addr, Coin, CosmosMsg, StdResult, WasmMsg};
+use cosmwasm_std::{to_json_binary, Addr, Coin, CosmosMsg, StdResult, WasmMsg};
 use cw20::Cw20ExecuteMsg;
 use cw_asset::{Asset, AssetInfo};
 
@@ -13,7 +13,7 @@ pub fn cw_approve_msgs(assets: &[Asset], spender: &Addr) -> StdResult<Vec<Cosmos
             };
             msgs.push(CosmosMsg::Wasm(WasmMsg::Execute {
                 contract_addr: addr.to_string(),
-                msg: to_binary(&msg)?,
+                msg: to_json_binary(&msg)?,
                 funds: vec![],
             }))
         }


### PR DESCRIPTION
`to_binary` is now deprecated in favour of `to_json_binary` which is causing clippy to fail in https://github.com/AbstractSDK/abstract/pull/116 This PR replaces all instances of `to_binary` and `from_binary` to `to_json_binary` and `from_json` respectively. The following commands were used for those curious after realizing this was going to complain for all of the files: 

`find . -type f -name "*.rs" -exec gsed -i 's/from_binary/from_json/g' {} +` 

`find . -type f -name "*.rs" -exec gsed -i 's/to_binary/to_json_binary/g' {} +`

`gsed` is the version of `sed` on GNU which is easier to work with than the sed from BSD, which is what is shipped with mac (how I can't wait to go back to a linux machine lol). 


### Checklist

- [x] CI is green.
- [ ] Changelog updated.
