### PR TITLE
Internalize execution stack and Deps

### DIFF
--- a/framework/packages/abstract-app/Cargo.toml
+++ b/framework/packages/abstract-app/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib", "rlib"]
 
 
 [features]
+default = ["test-utils"]
 test-utils = ["dep:abstract-testing", "dep:abstract-interface", "dep:cw-orch"]
 schema = []
 

--- a/framework/packages/abstract-app/src/lib.rs
+++ b/framework/packages/abstract-app/src/lib.rs
@@ -6,6 +6,7 @@ pub mod msgs;
 #[cfg(feature = "schema")]
 pub mod schema;
 pub mod state;
+mod test_app;
 pub(crate) use abstract_sdk::base::*;
 
 pub use crate::state::AppContract;

--- a/framework/packages/abstract-app/src/test_app.rs
+++ b/framework/packages/abstract-app/src/test_app.rs
@@ -1,0 +1,101 @@
+use abstract_sdk::{features::{ExecutionStack, Executables, DepsAccess}, namespaces::ADMIN_NAMESPACE};
+use cosmwasm_std::{Deps, DepsMut, Response, Empty};
+use cw_controllers::Admin;
+use cw_storage_plus::Item;
+
+use crate::{mock::{MockAppContract, MOCK_APP}, state::ModuleEnv, AppError};
+
+// TODO: add macro here that generates the private struct below
+// The macro should:
+// 1. Generate a struct that contains this struct and the ModuleEnv
+// 2. Generate a new function that instantiates the struct
+// 3. 
+
+// This is the custom struct defined by the dev. 
+// it contains all the state and handler functions of the contract.
+pub struct TestContract {
+    // Custom state goes here (like Sylvia)
+    pub admin: Admin<'static>,
+    pub config: Item<'static, u64>,
+}
+
+// #[contract] TODO: re-enable this macro
+impl TestContract {
+    // new function must be implemented manually (sylvia)
+    pub const fn new() -> Self {
+        Self {
+            admin: Admin::new(ADMIN_NAMESPACE),
+            config: Item::new("cfg"),
+        }
+    }
+
+    // TODO: re-enable macro #[msg(instantiate)] 
+    // the macro removes the impl here and applies it to `_TestContract`
+    // pub fn instantiate(
+    //     &self,
+    //     admin: Option<String>,
+    // ) -> Result<Response, AppError> {
+    //     let admin = admin.map(|a| deps.api.addr_validate(&a)).transpose()?;
+    //     self.admin.set(deps, admin)?;
+
+    //     Ok(Response::new())
+    // }
+}
+
+mod const_contract {
+    //! the ConstContract is a generated Const that contains the user-defined contract but exposes the 
+    //! base-implementation function endpoints (init, exec, query, migrate) with the custom implementation hooked up.
+    //! 
+    
+    // TODO: generate this struct
+
+
+}
+
+// Generated from previous struct
+pub struct _TestContract<'a> {
+    // Module environment (contains deps and executable stack)
+    env: ModuleEnv<'a>
+}
+
+impl<'a> _TestContract<'a> {
+    // This function gets called at the beginning of every endpoint (init, exec, query, migrate)
+    pub fn new(deps: DepsMut<'a>) -> Self {
+        Self {
+            env: ModuleEnv::new(deps),
+        }
+    }
+
+    pub const fn storage() -> TestContract {
+        TestContract::new()
+    }
+
+    pub fn _instantiate(
+        &mut self,
+        admin: Option<String>,
+        sequence: u16,
+    ) -> Result<Response, AppError> {
+        let admin = admin.map(|a| self.deps().api.addr_validate(&a)).transpose()?;
+        
+        Self::storage().admin.set(self.deps_mut(), admin)?;
+
+        Ok(Response::new())
+    }
+}
+
+impl ExecutionStack for _TestContract<'_> {
+    fn stack_mut(&mut self) -> &mut Executables {
+        &mut self.env.executable_stack
+    }
+}
+
+// Access the deps inserted into the contract at instantiation.
+impl<'a:'b, 'b:'c, 'c> DepsAccess<'a,'b, 'c> for _TestContract<'a> {
+    fn deps_mut(&'b mut self) -> DepsMut<'c> {
+        self.env.deps.branch()
+    }
+    fn deps(&'b self) -> Deps<'c> {
+        self.env.deps.as_ref()
+    }
+}
+

--- a/framework/packages/abstract-sdk/src/base/features/abstract_name_service.rs
+++ b/framework/packages/abstract-sdk/src/base/features/abstract_name_service.rs
@@ -21,7 +21,10 @@ pub trait AbstractNameService: Sized {
     }
 }
 
-impl<T, R: AbstractNameService> AbstractNameService for T where T: From<R> {
+impl<T, R: AbstractNameService> AbstractNameService for T
+where
+    T: From<R>,
+{
     fn ans_host(&self, deps: Deps) -> AbstractSdkResult<AnsHost> {
         Self::from::<R>().ans_host(deps)
     }

--- a/framework/packages/abstract-sdk/src/base/features/abstract_name_service.rs
+++ b/framework/packages/abstract-sdk/src/base/features/abstract_name_service.rs
@@ -20,6 +20,12 @@ pub trait AbstractNameService: Sized {
         }
     }
 }
+
+impl<T, R: AbstractNameService> AbstractNameService for T where T: From<R> {
+    fn ans_host(&self, deps: Deps) -> AbstractSdkResult<AnsHost> {
+        Self::from::<R>().ans_host(deps)
+    }
+}
 /// ANCHOR_END: ans
 
 #[derive(Clone)]

--- a/framework/packages/abstract-sdk/src/base/features/execution_stack.rs
+++ b/framework/packages/abstract-sdk/src/base/features/execution_stack.rs
@@ -1,0 +1,123 @@
+use crate::{core::objects::AccountId, AccountAction};
+use abstract_core::{
+    objects::common_namespace::ADMIN_NAMESPACE, proxy::state::ACCOUNT_ID,
+    version_control::AccountBase,
+};
+use cosmwasm_std::{Addr, Deps, CosmosMsg, DepsMut, Api, Env};
+use cw_storage_plus::Item;
+use crate::{AbstractSdkError, AbstractSdkResult};
+
+
+pub trait DepsAccess<'a:'b, 'b:'c, 'c> {
+    fn deps_mut(&'b mut self) -> DepsMut<'c>;
+    fn deps(&'b self) -> Deps<'c>;
+
+    fn api(&'b self) -> &'c dyn Api {
+        self.deps().api
+    }
+}
+
+#[derive(Clone)]
+pub enum Executable {
+    CosmosMsg(CosmosMsg),
+    AccountAction(AccountAction),
+}
+/// A list of messages that can be executed
+/// Can only be appended to and iterated over.
+pub struct Executables(pub(crate) Vec<Executable>);
+
+impl Default for Executables {
+    fn default() -> Self {
+        Self(Vec::with_capacity(8))
+    }
+}
+
+impl Executables {
+    pub fn push(&mut self, msg: Executable) {
+        self.0.push(msg)
+    }
+}
+
+pub trait ExecutionStack: Sized {
+    fn stack_mut(&mut self) -> &mut Executables;
+    /// Get the manager address for the current account.
+    fn push_executable(&mut self, executable: Executable) {
+        self.stack_mut().push(executable);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use abstract_testing::prelude::*;
+    use speculoos::prelude::*;
+
+    struct MockBinding;
+
+    // impl AccountIdentification for MockBinding {
+    //     fn proxy_address(&self, _deps: Deps) -> AbstractSdkResult<Addr> {
+    //         Ok(Addr::unchecked(TEST_PROXY))
+    //     }
+    // }
+
+    // mod account {
+    //     use super::*;
+    //     use cosmwasm_std::testing::mock_dependencies;
+
+    //     #[test]
+    //     fn test_proxy_address() {
+    //         let binding = MockBinding;
+    //         let deps = mock_dependencies();
+
+    //         let res = binding.proxy_address(deps.as_ref());
+    //         assert_that!(res)
+    //             .is_ok()
+    //             .is_equal_to(Addr::unchecked(TEST_PROXY));
+    //     }
+
+    //     #[test]
+    //     fn test_manager_address() {
+    //         let binding = MockBinding;
+    //         let mut deps = mock_dependencies();
+
+    //         deps.querier = MockQuerierBuilder::default()
+    //             .with_contract_item(TEST_PROXY, MANAGER, &Some(Addr::unchecked(TEST_MANAGER)))
+    //             .build();
+
+    //         assert_that!(binding.manager_address(deps.as_ref()))
+    //             .is_ok()
+    //             .is_equal_to(Addr::unchecked(TEST_MANAGER));
+    //     }
+
+    //     #[test]
+    //     fn test_account() {
+    //         let mut deps = mock_dependencies();
+    //         deps.querier = MockQuerierBuilder::default()
+    //             .with_contract_item(TEST_PROXY, MANAGER, &Some(Addr::unchecked(TEST_MANAGER)))
+    //             .build();
+
+    //         let expected_account_base = AccountBase {
+    //             manager: Addr::unchecked(TEST_MANAGER),
+    //             proxy: Addr::unchecked(TEST_PROXY),
+    //         };
+
+    //         let binding = MockBinding;
+    //         assert_that!(binding.account_base(deps.as_ref()))
+    //             .is_ok()
+    //             .is_equal_to(expected_account_base);
+    //     }
+
+    //     #[test]
+    //     fn account_id() {
+    //         let mut deps = mock_dependencies();
+    //         deps.querier = MockQuerierBuilder::default()
+    //             .with_contract_item(TEST_PROXY, ACCOUNT_ID, &TEST_ACCOUNT_ID)
+    //             .build();
+
+    //         let binding = MockBinding;
+    //         assert_that!(binding.account_id(deps.as_ref()))
+    //             .is_ok()
+    //             .is_equal_to(TEST_ACCOUNT_ID);
+    //     }
+    // }
+}

--- a/framework/packages/abstract-sdk/src/base/features/execution_stack.rs
+++ b/framework/packages/abstract-sdk/src/base/features/execution_stack.rs
@@ -1,14 +1,13 @@
 use crate::{core::objects::AccountId, AccountAction};
+use crate::{AbstractSdkError, AbstractSdkResult};
 use abstract_core::{
     objects::common_namespace::ADMIN_NAMESPACE, proxy::state::ACCOUNT_ID,
     version_control::AccountBase,
 };
-use cosmwasm_std::{Addr, Deps, CosmosMsg, DepsMut, Api, Env};
+use cosmwasm_std::{Addr, Api, CosmosMsg, Deps, DepsMut, Env};
 use cw_storage_plus::Item;
-use crate::{AbstractSdkError, AbstractSdkResult};
 
-
-pub trait DepsAccess<'a:'b, 'b:'c, 'c> {
+pub trait DepsAccess<'a: 'b, 'b: 'c, 'c> {
     fn deps_mut(&'b mut self) -> DepsMut<'c>;
     fn deps(&'b self) -> Deps<'c>;
 

--- a/framework/packages/abstract-sdk/src/base/features/mod.rs
+++ b/framework/packages/abstract-sdk/src/base/features/mod.rs
@@ -1,14 +1,14 @@
 mod abstract_name_service;
 mod abstract_registry_access;
 mod dependencies;
+mod execution_stack;
 mod identification;
 mod module_identification;
-mod execution_stack;
 
 pub use crate::apis::respond::AbstractResponse;
 pub use abstract_name_service::AbstractNameService;
 pub use abstract_registry_access::AbstractRegistryAccess;
 pub use dependencies::Dependencies;
+pub use execution_stack::{DepsAccess, Executable, Executables, ExecutionStack};
 pub use identification::AccountIdentification;
 pub use module_identification::ModuleIdentification;
-pub use execution_stack::{ExecutionStack, Executable, Executables, DepsAccess};

--- a/framework/packages/abstract-sdk/src/base/features/mod.rs
+++ b/framework/packages/abstract-sdk/src/base/features/mod.rs
@@ -3,6 +3,7 @@ mod abstract_registry_access;
 mod dependencies;
 mod identification;
 mod module_identification;
+mod execution_stack;
 
 pub use crate::apis::respond::AbstractResponse;
 pub use abstract_name_service::AbstractNameService;
@@ -10,3 +11,4 @@ pub use abstract_registry_access::AbstractRegistryAccess;
 pub use dependencies::Dependencies;
 pub use identification::AccountIdentification;
 pub use module_identification::ModuleIdentification;
+pub use execution_stack::{ExecutionStack, Executable, Executables, DepsAccess};


### PR DESCRIPTION
Add a runtime constructor for Apps that allows for deps inclusion in the app type as well as an execution stack that can be used to improve the APIs for executing calls.