### PR TITLE
Incorporate docs feedback

### DIFF
--- a/framework/docs/src/0_introduction.md
+++ b/framework/docs/src/0_introduction.md
@@ -11,6 +11,10 @@ Abstract's CosmWasm framework is your gateway
 to taking amazing ideas from concept to reality. Whether you're a coding genius or just getting started, Abstract has
 got your back! By building composable modules you'll be crafting scalable masterpieces in no time.
 
+```admonish info
+Coming from 👾EVM👾 ? Be sure to read up on CosmWasm and its differences from EVM in the [CosmWasm](./3_framework/0_prerequisites.md#cosmwasm) section.
+```
+
 ## Abstract in a Nutshell
 
 Abstract is your one-stop solution for streamlined CosmWasm smart-contract development. We provide an

--- a/framework/docs/src/3_framework/0_prerequisites.md
+++ b/framework/docs/src/3_framework/0_prerequisites.md
@@ -75,7 +75,19 @@ The application of the actor model in the CosmWasm framework provides the follow
   prevents
   inconsistent states in the contract.
 
-To learn more about CosmWasm, check out the <a href="https://book.cosmwasm.com/" target="_blank">official
+#### Coming from EVM?
+
+There are a few key differences between the EVM and CosmWasm that you should be aware of. The most important one is that instances of contracts and the code that they run against are two different concepts in CosmWasm. This means that you can have multiple instances of the same contract code running at the same time, each with their own state. This is not possible in EVM, where the contract code and the contract instance are the same thing.
+
+This is an important difference to be aware of when we talk about migrations further in our documentation.
+
+```admonish summary
+Migrations are a key feature of CosmWasm. They allow you to upgrade a contract's code while retaining the state of the contract.
+```
+
+A migration doesn't delete the code that was previously running for a contract. Code (a WebAssembly binary) is referred to by code-ids and contracts run against a specific code-id and get their own address space (and state) when they are instantiated. Hence migrations just update the code-id that a contract uses to run. I.e. The contract keeps its address and state but now runs on a different code-id (binary).
+
+To learn more about CosmWasm, check out its <a href="https://book.cosmwasm.com/" target="_blank">official
 documentation</a>.
 
 ## Javascript

--- a/framework/docs/src/3_framework/0_prerequisites.md
+++ b/framework/docs/src/3_framework/0_prerequisites.md
@@ -87,8 +87,10 @@ Migrations are a key feature of CosmWasm. They allow you to upgrade a contract's
 
 A migration doesn't delete the code that was previously running for a contract. Code (a WebAssembly binary) is referred to by code-ids and contracts run against a specific code-id and get their own address space (and state) when they are instantiated. Hence migrations just update the code-id that a contract uses to run. I.e. The contract keeps its address and state but now runs on a different code-id (binary).
 
+> If you're looking for a more in-depth comparison go read this <a href="https://medium.com/cosmwasm/cosmwasm-for-ctos-f1ffa19cccb8" target="_blank">article</a> by the creator of CosmWasm.
+
 To learn more about CosmWasm, check out its <a href="https://book.cosmwasm.com/" target="_blank">official
-documentation</a>.
+documentation</a>. 
 
 ## Javascript
 

--- a/framework/docs/src/3_framework/3_architecture.md
+++ b/framework/docs/src/3_framework/3_architecture.md
@@ -50,10 +50,8 @@ Account. It is responsible for various important operations, including:
 - **Owner Authentication** 🔐: Authenticating privileged calls and ensuring only approved entities can interact with the
   account.
 
-
 - **Application Management** 📦: Managing and storing information about the applications installed on the account, their
   inter-dependencies, permissions and configurations.
-
 
 - **Account Details** 📄: Storing the account's details, such as its name, description, and other relevant information.
 
@@ -65,25 +63,32 @@ Abstract Account, taking care of:
 - **Asset Management & Pricing** 💰: Holding the account's assets, including tokens, NFTs, and other fungible and
   non-fungible assets as well as allows for pricing assets based on decentralized exchange or oracle prices.
 
-
 - **Transaction Forwarding (Proxying)** 🔀: Routing approved transactions from the **Manager** or other connected
   smart-contracts to other actors.
 
+```admonish question
+**Why are these two contracts instead of one?**
+
+1. *Separation of concerns:* By separating the contracts the proxy's functionality (and attack surface) is as small as possible. The separation also allows for simple permission management as we want to separate the admin calls (verified by the manager) from module calls.
+
+2. *Minimizing WASM size:* Whenever a contract is loaded for execution the whole WASM binary needs to be loaded into memory. Because all the apps proxy their messages through the Proxy contract it would be smart to have this contract be as small as possible to make it cheap to load. While CosmWasm currently has a fixed cost for loading a contract irrespective of its size. We think that might change in the future.
+```
+
 ### Account Interactions
 
-The diagram below depicts a User interacting with its Abstract account through the **Manager**, and proxying a call to
+The diagram below depicts an Owner interacting with its Abstract account through the **Manager**, and proxying a call to
 an
 external contract through the **Proxy**.
 
 ```mermaid
 sequenceDiagram
-    actor User
+    actor Owner
     participant Manager
     participant Proxy
     participant External Contract
 
 
-    User ->> Manager: Account Action
+    Owner ->> Manager: Account Action
     Manager ->> Proxy: Forward to Proxy
     Proxy ->> External Contract: Execute
 
@@ -97,7 +102,7 @@ message. By doing so the IBC client will be registered to your account, enabling
 ```mermaid
 sequenceDiagram
     autonumber
-    actor U as User
+    actor U as Owner
     participant M as Manager
     participant VC as Version Control
     participant P as Proxy
@@ -110,5 +115,3 @@ sequenceDiagram
     M ->> P: Add IBC client to allowlist
 
 ```
-
-> For disabling IBC, see [Uninstall Module](6_module_types.md#installing-and-uninstalling-modules)

--- a/framework/docs/src/3_framework/4_ownership.md
+++ b/framework/docs/src/3_framework/4_ownership.md
@@ -16,7 +16,7 @@ Not interested in account ownership? Skip to our section on [Framework Component
 ## Monarchy
 
 In a monarchy, a single wallet has full control over the dApp. If you're connected with a wallet, your address will be
-automatically inserted as the root user.
+automatically inserted as the owner.
 
 ```mermaid
 graph TD

--- a/framework/docs/src/3_framework/6_module_types.md
+++ b/framework/docs/src/3_framework/6_module_types.md
@@ -100,7 +100,7 @@ the [web-app](https://app.abstract.money/).
 ```mermaid
 sequenceDiagram
     autonumber
-    actor U as User
+    actor U as Owner
     participant M as Manager
     participant MF as Module Factory
     participant VC as Version Control
@@ -123,7 +123,7 @@ sequenceDiagram
 ```mermaid
 sequenceDiagram
     autonumber
-    actor U as User
+    actor U as Owner
     participant M as Manager
     participant P as Proxy
     U ->> M: UninstallModule
@@ -180,36 +180,36 @@ the robustness and flexibility of the Abstract ecosystem.
 
 The following are sequence diagrams of the process of executing a module on an Abstract Account. There are three types
 of
-execution: Non-dependent Execution, Adapter Execution, and Module-dependent Execution.
+execution: Owner Execution, Adapter Execution, and Module Execution.
 
 Let's explore each of them.
 
-## Non-dependent Execution
+## Owner Execution
 
-To execute a message on a specific module, a user can call the `ExecOnModule` function on the Manager, providing
-the module id. This diagram depicts how the Manager interacts with any module.
+To execute a message on a specific module, the Owner can call the `ExecOnModule` function on the Manager, providing
+the module id. This diagram depicts how the Manager interacts with any module installed on the account.
 
 ```mermaid
 sequenceDiagram
     autonumber
-    actor U as User
+    actor U as Owner
     participant M as Manager
-    participant Md as Module
+    participant Md as Module ("addr123")
     U ->> M: ExecOnModule
-    Note right of U: ModuleMsg
+    Note right of U: ModuleMsg {"module_id": "xyz"}
     M -->> M: Load module address
     M ->> Md: Execute
-    Note right of M: ModuleMsg
+    Note right of M: ModuleMsg {"module_addr": "addr123"}
 ```
 
 ## Adapter Execution
 
-In the following example, the `abstract:dex` module is installed on an Account, and the user requests a swap on a dex.
+In the following example, the `abstract:dex` module is installed on an Account, and the owner requests a swap on a dex.
 
 ```mermaid
 sequenceDiagram
     autonumber
-    actor U as User
+    actor U as Owner
     participant M as Manager
     participant D as abstract:dex
     participant VC as Version Control
@@ -235,7 +235,7 @@ sequenceDiagram
 
 ```
 
-## Module-dependent Execution
+## Module Execution
 
 In this example, we use [Equilibrium](../7_use_cases/1_equilibrium.md)'s `Rebalance` function as an example. Modules
 with dependencies (`equilibrium:balancer` is dependent on `abstract:etf` and `abstract:dex`) have their addresses

--- a/framework/docs/src/3_framework/7_upgradability.md
+++ b/framework/docs/src/3_framework/7_upgradability.md
@@ -18,7 +18,7 @@ There are two types of possible migration paths, although they appear the same t
 
 ## Migration Update
 
-Most module updates will perform a contract migration. The migration can be evoked by the root user and is executed by
+Most module updates will perform a contract migration. The migration can be evoked by the owner and is executed by
 the manager contract. You can learn more about contract migrations in
 the <a href="https://docs.cosmwasm.com/docs/smart-contracts/migration" target="_blank">CosmWasm documentation</a>.
 
@@ -51,7 +51,7 @@ The process for upgrading modules is shown in the following diagram:
 ```mermaid
 sequenceDiagram
     autonumber
-    actor U as User
+    actor U as Owner
     participant M as Manager
     participant VC as Version Control
     participant P as Proxy

--- a/framework/docs/src/3_framework/8_ibc.md
+++ b/framework/docs/src/3_framework/8_ibc.md
@@ -94,7 +94,7 @@ flowchart LR
         ICAATerra --> ICAAArch([ICAA])
         ICAAArch --> ICAAOsmo2
     end
-    Owner[Owner] ==> Account
+    Owner[fa:fa-user Owner] ==> Account
 ```
 
 Each of these accounts has a unique `AccountId` defined by the account's origin chain and the path over which it was

--- a/framework/docs/src/4_get_started/2_installation.md
+++ b/framework/docs/src/4_get_started/2_installation.md
@@ -3,6 +3,10 @@
 Before you get started with the Abstract SDK, you will need to set up your development environment. This guide will walk
 you through the process of setting up your environment and creating your first Abstract app module.
 
+```admonish info
+Experienced with CosmWasm? Skip to the [Using The Template](#using-the-template) section.
+```
+
 ## Rust
 
 To work with the SDK you will need the Rust programming language installed on your
@@ -66,6 +70,10 @@ the "Use this template" button to create a new repository based on the template.
 you want, but we recommend using the name of your module.
 
 ![](../resources/get_started/use-this-template.webp)
+
+```admonish success
+To quickly get started, run `./template_setup.sh` and install the recommended tools.
+```
 
 Go ahead and read through the readme of the template repository to learn how it is structured. It contains instructions
 on how to set up your

--- a/framework/docs/src/4_get_started/8_dependencies.md
+++ b/framework/docs/src/4_get_started/8_dependencies.md
@@ -1,25 +1,27 @@
 # Module Dependencies
 
-In the Abstract SDK, modules have conditions that must be met before they can be registered or activated. These
+In the Abstract SDK, modules have conditions that must be met before they can be installed. These
 conditions largely revolve around module dependencies and version requirements. When installing a module, the system will
 check its dependencies and ensure that they are installed and meet the version requirements specified by the module.
 
-Here's how the process of registering a module and checking module dependencies looks:
+Here's how the process of installing a module and checking module dependencies looks:
 
 ```mermaid
 sequenceDiagram
     autonumber
-    actor U as User
+    actor U as Owner
     participant M as Manager
-    participant VC as Version Control
+    participant F as Module Factory
+    participant Mo as Module
     participant P as Proxy
 
-    U ->> M: RegisterModule
-    M -->>+ VC: Assert Install Requirements
-    VC -->> VC: Load Module Dependencies
-    VC -->> M: Assert Dependency Requirements
-    VC -->> VC: Check if Dependency is Installed
-    VC -->> VC: Assert Version Requirements
-    M -->>+ VC: Add Module as Dependent on its Dependencies
-    M -->>+ P: Add Module
+    U ->> M: Install Module
+    M -->> F: Install Module
+    opt App instantiate 
+    F -->> Mo: Instantiate Module
+    end
+    M -->> Mo: Query Module Dependencies
+    M -->> M: Assert Dependency Requirements
+    M -->>+ M: Add Module as Dependent on its Dependencies
+    M -->>+ P: Allowlist Module
 ```

--- a/framework/docs/src/5_platform/2_version_control.md
+++ b/framework/docs/src/5_platform/2_version_control.md
@@ -19,7 +19,7 @@ Below details the assertion process.
 ```mermaid
 sequenceDiagram
     autonumber
-    actor U as User
+    actor U as Owner
 
     participant VC as Version Control
     participant Man as Manager of Namespace

--- a/framework/docs/src/5_platform/5_module_factory.md
+++ b/framework/docs/src/5_platform/5_module_factory.md
@@ -15,7 +15,7 @@ When a developer requests the installation of a module, the following internal p
 ```mermaid
 sequenceDiagram
     autonumber
-    actor U as User
+    actor U as Owner
     participant M as Manager
     participant MF as Module Factory
     participant VC as Version Control
@@ -41,12 +41,12 @@ sequenceDiagram
 
 Once the module is installed, there are essentially three ways to interact with it depending on the type of module:
 
-### Non-dependent Execution
+### Owner Execution
 
 ```mermaid
 sequenceDiagram
     autonumber
-    actor U as User
+    actor U as Owner
     participant M as Manager
     participant Md as Module
 
@@ -67,7 +67,7 @@ In the following example, the `abstract:dex` module is installed on an Account, 
 ```mermaid
 sequenceDiagram
     autonumber
-    actor U as User
+    actor U as Owner
     participant M as Manager
     participant D as abstract:dex
     participant VC as Version Control
@@ -98,9 +98,9 @@ sequenceDiagram
 
 <figcaption align = "center"><b>Adapter Execution</b></figcaption>
 
-### Module-dependent Execution
+### User Execution
 
-In this example, we use [Equilibrium](../../use_cases/equilibrium.md)'s `Rebalance` function as an example. Modules with
+In this example, we use [Equilibrium](../../use_cases/equilibrium.md)'s `Rebalance` permissionless function as an example. Modules with
 dependencies (`equilibrium:balancer` is dependent on `abstract:etf` and `abstract:dex`) have their addresses dynamically
 resolved when called.
 

--- a/framework/docs/src/5_platform/7_oracle.md
+++ b/framework/docs/src/5_platform/7_oracle.md
@@ -2,6 +2,10 @@
 
 Have you ever wished to know the value of your portfolio? I'm guessing you have. Luckily Abstract has an integrated system to retrieve the value of your assets, on-chain!
 
+```admonish info
+This section is mainly focused on developers. If you're a user feel free to skip this section!
+```
+
 ## Value is relative
 
 The value of something is always relative to some other thing. A bitcoin isn't valued at 20,000, it's valued at 20,000 **USD**. Likewise the first decision that's required to work with Abstract's oracle is: In what currency do you want your Account's assets to be valued?

--- a/framework/docs/src/5_platform/7_oracle.md
+++ b/framework/docs/src/5_platform/7_oracle.md
@@ -1,0 +1,65 @@
+# Account Value Oracle
+
+Have you ever wished to know the value of your portfolio? I'm guessing you have. Luckily Abstract has an integrated system to retrieve the value of your assets, on-chain!
+
+## Value is relative
+
+The value of something is always relative to some other thing. A bitcoin isn't valued at 20,000, it's valued at 20,000 **USD**. Likewise the first decision that's required to work with Abstract's oracle is: In what currency do you want your Account's assets to be valued?
+
+We'll call this currency the *base asset*. There can never be more than one base asset and every asset will be valued in terms of this base asset.
+
+With a base asset selected you can set up a value-reference for each asset that is held in your Account. A value-reference is a configuration that references some data that tells the contract how it should determine the value for that asset. Consequently your base asset won't have an associated value-reference as everything is valued relative to it! Don't worry, we'll show some examples after covering the basics.
+
+## Types of Value-References
+
+To ensure that you configure and use the oracle correctly you'll need to understand, on a high level, how the value-reference system works and what its limitations are. Your app's security might depend on it!
+
+```admonish hint
+Remember: Every asset, apart from the base asset, has an associated value-reference and that value-reference allows your Account to determine the value of the asset in terms of the base asset.
+```
+
+Currently there are four value-reference types that can be applied to an asset. Lets go over them.
+
+### **1. Reference Pool**
+
+This is the most common value-reference type. It points to a dex trading pair where one of the two assets of the pair is the asset on which this value-reference is applied. The Account takes this information and does three things.
+
+1. Query how much X the Account holds.
+2. Determine the price of asset X, defined by the pool X/Y.
+3. Calculate the value of asset X in terms of asset Y given the price.
+This gives us the value of asset X in terms of asset Y.
+
+```admonish example
+Your Account has 10 $JUNO and 50 $USDC. You'd like to be shown the value of your assets in terms of USD.
+1. You identify that you want every asset denominated in US dollars. Therefore you choose $USDC as your base asset.
+2. You identify the easiest route to swap your $JUNO for $USDC which is a trading pair on Junoswap. Therefore you add $JUNO to your Account with a Pool value-reference.
+3. The ratio of $JUNO/$USDC in the pool is 1/10 so 1 $JUNO = 10 $USDC.
+
+The Account now knows that if you'd swap your $JUNO to $USDC in that pool, you'd end up getting 10 $USDC. Therefore the total value of your assets is 60 $USDC.
+```
+
+### **2. Liquidity Token**
+
+A liquidity token is nothing more than a claim on a set of assets in a liquidity pool. Therefore the value of each liquidity token is simply the composition of asset held within that pool.
+
+### **3. Value As**
+
+You might want to set the value of some asset in terms of another asset. For example, you could argue that every stablecoin is equal in value, irrespective of small fluctuations between them.
+
+### **4. External**
+
+Some assets/positions are more complex. These include, but are not limited to: staked tokens, locked tokens and most third-party vault-like products. The Account needs to interact with Adapter modules that interact with these services to find out how it should value the asset/position.
+
+## Use With Caution
+
+As we've outlined, each asset is valued relative to an asset or multiple assets. By recursively calling this value-reference function on each asset we can determine the value of any asset relative to our base asset.
+
+```admonish warning
+As each asset's value is referenced to some other asset through a price relation it exposes assets with a weak link to the base asset to a lot more volatility and attack surface. Therefore we recommend that you select a highly-liquid base asset with the highest liquidity trading pairs when configuring your assets.
+```
+
+```admonish danger
+While this way of determining an asset's value is very intuitive, it doesn't account for bad actors. Manipulation of asset prices to trigger smart-contract actions isn't uncommon. Therefore we don't recommend this version of the Account for creating high-value automated-trading products. No worries, an implementation based on oracle prices is in the works!
+```
+
+Any questions regarding the oracle and its configuration can be asked in our [Discord](https://discord.com/invite/uch3Tq3aym) server!

--- a/framework/docs/src/5_platform/index.md
+++ b/framework/docs/src/5_platform/index.md
@@ -38,3 +38,7 @@ directly through the Account Manager or the Account Console, installing modules 
 Unleash the potential of monetizing your modules in the Abstract framework. Set installation fees, and introduce
 monetization strategies to incentivize the creation and sharing of valuable modules, all while having a clear insight
 into the financial aspects.
+
+## [Value Oracle](./7_oracle.md)
+
+An integrated way to get the value of your account's assets **on-chain**.

--- a/framework/docs/src/SUMMARY.md
+++ b/framework/docs/src/SUMMARY.md
@@ -22,6 +22,7 @@
     - [Account Console](./5_platform/4_account_console.md)
     - [Module Factory](./5_platform/5_module_factory.md)
     - [Monetization](./5_platform/6_monetization.md)
+    - [Oracle](./5_platform/7_oracle.md)
 
 - [Abstract Products](1_products/index.md)
   - [CW-Orchestrator](./1_products/1_cw_orchestrator.md)


### PR DESCRIPTION
Incorporate some feedback on our documentation. This includes: 
1. Adding a section for devs coming from EVM
2. Updating much of our graphs to differentiate between User and Owner calls
3. Update the dependency assertion graph
4. Elaborate on why the Proxy and Manager are different contracts
5. Re-instate the section on the Oracle functionality.