### PR TITLE
QuickFix / Removed the need for an adapter install message

### DIFF
--- a/framework/contracts/account/manager/tests/adapters.rs
+++ b/framework/contracts/account/manager/tests/adapters.rs
@@ -388,7 +388,7 @@ fn account_install_adapter() -> AResult {
 
     let adapter = BootMockAdapter1V1::new_test(chain);
     adapter.deploy(V1.parse().unwrap(), MockInitMsg, DeployStrategy::Try)?;
-    let adapter_addr = account.install_adapter(adapter, &MockInitMsg, None)?;
+    let adapter_addr = account.install_adapter(adapter, None)?;
     let module_addr = account
         .manager
         .module_info(common::mock_modules::adapter_1::MOCK_ADAPTER_ID)?

--- a/framework/packages/abstract-interface/src/account/mod.rs
+++ b/framework/packages/abstract-interface/src/account/mod.rs
@@ -154,14 +154,13 @@ impl<Chain: CwEnv> AbstractAccount<Chain> {
     pub fn install_adapter<CustomInitMsg: Serialize, T: AdapterDeployer<Chain, CustomInitMsg>>(
         &self,
         adapter: T,
-        custom_init_msg: &CustomInitMsg,
         funds: Option<&[Coin]>,
     ) -> Result<Addr, crate::AbstractInterfaceError> {
         // retrieve the deployment
         let abstr = Abstract::load_from(self.manager.get_chain().to_owned())?;
 
         let init_msg = abstract_core::adapter::InstantiateMsg {
-            module: custom_init_msg,
+            module: Empty {}, // Adapters always have empty install messages
             base: abstract_core::adapter::BaseInstantiateMsg {
                 ans_host_address: abstr.ans_host.address()?.into(),
                 version_control_address: abstr.version_control.address()?.into(),


### PR DESCRIPTION
This PR removes the need for an adapter install message (no instantiate on instlal for adapters)

### Checklist

- [ ] CI is green.
- [ ] Changelog updated.
