### PR TITLE
Dogfood AbstractClient in calendar module tests

### DIFF
--- a/framework/packages/abstract-client/Cargo.toml
+++ b/framework/packages/abstract-client/Cargo.toml
@@ -12,6 +12,7 @@ keywords.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
+default = ["test-utils"]
 test-utils = ["cw-asset", "abstract-testing"]
 
 [dependencies]

--- a/framework/packages/abstract-client/Cargo.toml
+++ b/framework/packages/abstract-client/Cargo.toml
@@ -11,6 +11,9 @@ keywords.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+test-utils = ["cw-asset", "abstract-testing"]
+
 [dependencies]
 cosmwasm-std.workspace = true
 abstract-interface.workspace = true
@@ -20,7 +23,12 @@ serde.workspace = true
 semver.workspace = true
 thiserror.workspace = true
 
+# Used for test-utils feature
+cw-asset = { workspace = true, optional = true }
+abstract-testing = {workspace = true, optional = true }
+
 [dev-dependencies]
+abstract-client = { path = ".", features = ["test-utils"] }
 cw-asset.workspace = true
 cw-controllers.workspace = true
 abstract-app = { workspace = true, features = ["test-utils"] }

--- a/framework/packages/abstract-client/src/application.rs
+++ b/framework/packages/abstract-client/src/application.rs
@@ -1,4 +1,5 @@
 use std::ops::Deref;
+use std::ops::DerefMut;
 
 use cw_orch::prelude::*;
 
@@ -16,6 +17,12 @@ impl<Chain: CwEnv, M> Deref for Application<Chain, M> {
 
     fn deref(&self) -> &Self::Target {
         &self.module
+    }
+}
+
+impl<Chain: CwEnv, M> DerefMut for Application<Chain, M> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.module
     }
 }
 

--- a/framework/packages/abstract-client/src/client.rs
+++ b/framework/packages/abstract-client/src/client.rs
@@ -19,7 +19,7 @@ impl<Chain: CwEnv> AbstractClient<Chain> {
         Ok(Self { abstr })
     }
 
-    pub fn ans_host(&self) -> &AnsHost<Chain> {
+    pub fn name_service(&self) -> &AnsHost<Chain> {
         &self.abstr.ans_host
     }
 

--- a/framework/packages/abstract-client/src/client.rs
+++ b/framework/packages/abstract-client/src/client.rs
@@ -1,14 +1,16 @@
-use abstract_interface::{Abstract, AnsHost};
+use abstract_interface::{Abstract, AnsHost, VersionControl};
+use cosmwasm_std::BlockInfo;
 use cw_orch::{deploy::Deploy, prelude::CwEnv};
 
 use crate::{
     account::{Account, AccountBuilder},
     error::AbstractClientError,
+    infrastructure::Infrastructure,
     publisher::{Publisher, PublisherBuilder},
 };
 
 pub struct AbstractClient<Chain: CwEnv> {
-    abstr: Abstract<Chain>,
+    pub(crate) abstr: Abstract<Chain>,
 }
 
 pub type AbstractClientResult<T> = Result<T, AbstractClientError>;
@@ -21,6 +23,16 @@ impl<Chain: CwEnv> AbstractClient<Chain> {
 
     pub fn name_service(&self) -> &AnsHost<Chain> {
         &self.abstr.ans_host
+    }
+
+    pub fn version_control(&self) -> &VersionControl<Chain> {
+        &self.abstr.version_control
+    }
+
+    // Is there a way for us to return `AbstractClientResult<BlockInfo>` here instead? I think we
+    // would need to add <T: CwEnv> to `AbstractClientError` which I am not sure we want to do.
+    pub fn block_info(&self) -> Result<BlockInfo, <Chain as cw_orch::prelude::TxHandler>::Error> {
+        self.environment().block_info()
     }
 
     pub fn get_publisher_from_namespace(
@@ -43,5 +55,169 @@ impl<Chain: CwEnv> AbstractClient<Chain> {
         namespace: String,
     ) -> AbstractClientResult<Account<Chain>> {
         Account::from_namespace(&self.abstr, namespace)
+    }
+}
+
+#[cfg(feature = "test-utils")]
+mod test_utils {
+    use abstract_core::{
+        self,
+        objects::{
+            pool_id::UncheckedPoolAddress, PoolMetadata, UncheckedChannelEntry,
+            UncheckedContractEntry,
+        },
+    };
+    use abstract_interface::{Abstract, ExecuteMsgFns};
+    use cosmwasm_std::{Addr, Coin, Uint128};
+    use cw_asset::AssetInfoUnchecked;
+    use cw_orch::{
+        deploy::Deploy,
+        prelude::{Mock, TxHandler},
+    };
+
+    use crate::infrastructure::Infrastructure;
+
+    use super::{AbstractClient, AbstractClientResult};
+
+    impl AbstractClient<Mock> {
+        pub fn builder(sender: impl Into<String>) -> AbstractClientBuilder {
+            AbstractClientBuilder::new(sender.into())
+        }
+
+        pub fn wait_blocks(&self, amount: u64) -> AbstractClientResult<()> {
+            self.environment().wait_blocks(amount).map_err(Into::into)
+        }
+
+        // TODO: Also have this in non `Mock` case
+        pub fn query_balance(&self, address: &Addr, denom: &str) -> AbstractClientResult<Uint128> {
+            self.environment()
+                .query_balance(address, denom)
+                .map_err(Into::into)
+        }
+    }
+
+    pub struct AbstractClientBuilder {
+        mock: Mock,
+        sender: String,
+        balances: Vec<(String, Vec<Coin>)>,
+        contracts: Vec<(UncheckedContractEntry, String)>,
+        assets: Vec<(String, AssetInfoUnchecked)>,
+        channels: Vec<(UncheckedChannelEntry, String)>,
+        pools: Vec<(UncheckedPoolAddress, PoolMetadata)>,
+    }
+
+    impl AbstractClientBuilder {
+        pub fn new(sender: impl Into<String>) -> Self {
+            let sender: String = sender.into();
+            Self {
+                mock: Mock::new(&Addr::unchecked(&sender)),
+                sender,
+                balances: vec![],
+                contracts: vec![],
+                assets: vec![],
+                channels: vec![],
+                pools: vec![],
+            }
+        }
+
+        pub fn contract(
+            &mut self,
+            contract_entry: UncheckedContractEntry,
+            address: impl Into<String>,
+        ) -> &mut Self {
+            self.contracts.push((contract_entry, address.into()));
+            self
+        }
+
+        pub fn contracts(&mut self, contracts: Vec<(UncheckedContractEntry, String)>) -> &mut Self {
+            self.contracts = contracts;
+            self
+        }
+
+        pub fn asset(
+            &mut self,
+            name: impl Into<String>,
+            asset_info: AssetInfoUnchecked,
+        ) -> &mut Self {
+            self.assets.push((name.into(), asset_info));
+            self
+        }
+
+        pub fn assets(&mut self, assets: Vec<(String, AssetInfoUnchecked)>) -> &mut Self {
+            self.assets = assets;
+            self
+        }
+
+        pub fn channel(
+            &mut self,
+            channel_entry: UncheckedChannelEntry,
+            channel_value: impl Into<String>,
+        ) -> &mut Self {
+            self.channels.push((channel_entry, channel_value.into()));
+            self
+        }
+
+        pub fn channels(&mut self, channels: Vec<(UncheckedChannelEntry, String)>) -> &mut Self {
+            self.channels = channels;
+            self
+        }
+
+        pub fn pool(
+            &mut self,
+            pool_address: UncheckedPoolAddress,
+            pool_metadata: PoolMetadata,
+        ) -> &mut Self {
+            self.pools.push((pool_address, pool_metadata));
+            self
+        }
+
+        pub fn pools(&mut self, pools: Vec<(UncheckedPoolAddress, PoolMetadata)>) -> &mut Self {
+            self.pools = pools;
+            self
+        }
+
+        pub fn balance(&mut self, address: impl Into<String>, amount: Vec<Coin>) -> &mut Self {
+            self.balances.push((address.into(), amount));
+            self
+        }
+
+        pub fn balances(&mut self, balances: Vec<(String, Vec<Coin>)>) -> &mut Self {
+            self.balances = balances;
+            self
+        }
+
+        pub fn build(&self) -> AbstractClientResult<AbstractClient<Mock>> {
+            let abstr = Abstract::deploy_on(self.mock.clone(), self.sender.clone())?;
+            self.update_ans(&abstr)?;
+            self.update_balances()?;
+
+            AbstractClient::new(self.mock.clone())
+        }
+
+        fn update_balances(&self) -> AbstractClientResult<()> {
+            self.balances
+                .iter()
+                .try_for_each(|(address, amount)| -> AbstractClientResult<()> {
+                    self.mock
+                        .set_balance(&Addr::unchecked(address), amount.to_vec())?;
+                    Ok(())
+                })?;
+            Ok(())
+        }
+
+        fn update_ans(&self, abstr: &Abstract<Mock>) -> AbstractClientResult<()> {
+            abstr
+                .ans_host
+                .update_contract_addresses(self.contracts.clone(), vec![])?;
+            abstr
+                .ans_host
+                .update_asset_addresses(self.assets.clone(), vec![])?;
+            abstr
+                .ans_host
+                .update_channels(self.channels.clone(), vec![])?;
+            abstr.ans_host.update_pools(self.pools.clone(), vec![])?;
+
+            Ok(())
+        }
     }
 }

--- a/framework/packages/abstract-client/src/client.rs
+++ b/framework/packages/abstract-client/src/client.rs
@@ -1,4 +1,4 @@
-use abstract_interface::Abstract;
+use abstract_interface::{Abstract, AnsHost};
 use cw_orch::{deploy::Deploy, prelude::CwEnv};
 
 use crate::{
@@ -17,6 +17,10 @@ impl<Chain: CwEnv> AbstractClient<Chain> {
     pub fn new(chain: Chain) -> AbstractClientResult<Self> {
         let abstr = Abstract::load_from(chain)?;
         Ok(Self { abstr })
+    }
+
+    pub fn ans_host(&self) -> &AnsHost<Chain> {
+        &self.abstr.ans_host
     }
 
     pub fn get_publisher_from_namespace(

--- a/framework/packages/abstract-client/src/infrastructure.rs
+++ b/framework/packages/abstract-client/src/infrastructure.rs
@@ -2,7 +2,10 @@ use abstract_interface::{Abstract, AbstractInterfaceError};
 use cw_orch::deploy::Deploy;
 use cw_orch::prelude::*;
 
-use crate::account::{Account, AccountBuilder};
+use crate::{
+    account::{Account, AccountBuilder},
+    client::AbstractClient,
+};
 
 pub(crate) trait Infrastructure<T: CwEnv> {
     /// Get the execution environment
@@ -22,6 +25,12 @@ impl<Chain: CwEnv> Infrastructure<Chain> for Account<Chain> {
 }
 
 impl<'a, Chain: CwEnv> Infrastructure<Chain> for AccountBuilder<'a, Chain> {
+    fn environment(&self) -> Chain {
+        self.abstr.account.proxy.get_chain().clone()
+    }
+}
+
+impl<Chain: CwEnv> Infrastructure<Chain> for AbstractClient<Chain> {
     fn environment(&self) -> Chain {
         self.abstr.account.proxy.get_chain().clone()
     }

--- a/framework/packages/abstract-client/src/publisher.rs
+++ b/framework/packages/abstract-client/src/publisher.rs
@@ -83,7 +83,7 @@ impl<Chain: CwEnv> Publisher<Chain> {
         self.account.install_app(configuration, funds)
     }
 
-    pub fn deploy_app<
+    pub fn publish_app<
         M: ContractInstance<Chain> + RegisteredModule + From<Contract<Chain>> + AppDeployer<Chain>,
     >(
         &self,

--- a/framework/packages/abstract-client/tests/integration.rs
+++ b/framework/packages/abstract-client/tests/integration.rs
@@ -8,29 +8,16 @@ use abstract_core::{
     manager::state::AccountInfo,
     objects::{gov_type::GovernanceDetails, namespace::Namespace, AccountId, AssetEntry},
 };
-use abstract_interface::{Abstract, VCQueryFns};
+use abstract_interface::VCQueryFns;
 use cosmwasm_std::Addr;
-use cw_asset::AssetInfo;
-use cw_orch::{
-    deploy::Deploy,
-    prelude::{CallAs, CwOrchExecute, Mock},
-};
+use cw_asset::AssetInfoUnchecked;
+use cw_orch::prelude::{CallAs, Mock};
 
 const ADMIN: &str = "admin";
 
-fn deploy_abstract() -> anyhow::Result<(Mock, Abstract<Mock>)> {
-    let admin = Addr::unchecked(ADMIN);
-    let chain = Mock::new(&admin);
-    let abstr = Abstract::deploy_on(chain.clone(), admin.to_string())?;
-    Ok((chain, abstr))
-}
-
 #[test]
 fn can_create_account_without_optional_parameters() -> anyhow::Result<()> {
-    // Set up.
-    let (chain, _abstr) = deploy_abstract()?;
-
-    let client: AbstractClient<Mock> = AbstractClient::new(chain.clone())?;
+    let client = AbstractClient::builder(ADMIN).build()?;
 
     let account: Account<Mock> = client.account_builder().build()?;
 
@@ -41,7 +28,7 @@ fn can_create_account_without_optional_parameters() -> anyhow::Result<()> {
             chain_id: String::from("cosmos-testnet-14002"),
             description: None,
             governance_details: GovernanceDetails::Monarchy {
-                monarch: chain.sender
+                monarch: Addr::unchecked(ADMIN)
             },
             link: None,
         },
@@ -53,20 +40,11 @@ fn can_create_account_without_optional_parameters() -> anyhow::Result<()> {
 
 #[test]
 fn can_create_account_with_optional_parameters() -> anyhow::Result<()> {
-    // Set up.
-    let (chain, abstr) = deploy_abstract()?;
-
     let asset = "asset";
 
-    abstr.ans_host.execute(
-        &abstract_core::ans_host::ExecuteMsg::UpdateAssetAddresses {
-            to_add: vec![(asset.to_owned(), AssetInfo::native(asset).into())],
-            to_remove: vec![],
-        },
-        None,
-    )?;
-
-    let client: AbstractClient<Mock> = AbstractClient::new(chain.clone())?;
+    let client = AbstractClient::builder(ADMIN)
+        .asset(asset, AssetInfoUnchecked::native(asset))
+        .build()?;
 
     let name = "test-account";
     let description = "description";
@@ -99,8 +77,8 @@ fn can_create_account_with_optional_parameters() -> anyhow::Result<()> {
     );
 
     // Namespace is claimed.
-    let account_id = abstr
-        .version_control
+    let account_id = client
+        .version_control()
         .namespace(Namespace::new(namespace)?)?
         .account_id;
     assert_eq!(account_id, AccountId::local(1));
@@ -110,10 +88,7 @@ fn can_create_account_with_optional_parameters() -> anyhow::Result<()> {
 
 #[test]
 fn can_get_account_from_namespace() -> anyhow::Result<()> {
-    // Set up.
-    let (chain, _abstr) = deploy_abstract()?;
-
-    let client: AbstractClient<Mock> = AbstractClient::new(chain.clone())?;
+    let client = AbstractClient::builder(ADMIN).build()?;
 
     let namespace = "namespace";
     let account: Account<Mock> = client.account_builder().namespace(namespace).build()?;
@@ -131,10 +106,7 @@ fn can_get_account_from_namespace() -> anyhow::Result<()> {
 
 #[test]
 fn can_create_publisher_without_optional_parameters() -> anyhow::Result<()> {
-    // Set up.
-    let (chain, _abstr) = deploy_abstract()?;
-
-    let client: AbstractClient<Mock> = AbstractClient::new(chain.clone())?;
+    let client = AbstractClient::builder(ADMIN).build()?;
 
     let publisher: Publisher<Mock> = client.publisher_builder().build()?;
 
@@ -145,7 +117,7 @@ fn can_create_publisher_without_optional_parameters() -> anyhow::Result<()> {
             chain_id: String::from("cosmos-testnet-14002"),
             description: None,
             governance_details: GovernanceDetails::Monarchy {
-                monarch: chain.sender
+                monarch: Addr::unchecked(ADMIN)
             },
             link: None,
         },
@@ -157,20 +129,10 @@ fn can_create_publisher_without_optional_parameters() -> anyhow::Result<()> {
 
 #[test]
 fn can_create_publisher_with_optional_parameters() -> anyhow::Result<()> {
-    // Set up.
-    let (chain, abstr) = deploy_abstract()?;
-
     let asset = "asset";
-
-    abstr.ans_host.execute(
-        &abstract_core::ans_host::ExecuteMsg::UpdateAssetAddresses {
-            to_add: vec![(asset.to_owned(), AssetInfo::native(asset).into())],
-            to_remove: vec![],
-        },
-        None,
-    )?;
-
-    let client: AbstractClient<Mock> = AbstractClient::new(chain.clone())?;
+    let client = AbstractClient::builder(ADMIN)
+        .asset(asset, AssetInfoUnchecked::native(asset))
+        .build()?;
 
     let name = "test-account";
     let description = "description";
@@ -203,8 +165,8 @@ fn can_create_publisher_with_optional_parameters() -> anyhow::Result<()> {
     );
 
     // Namespace is claimed.
-    let account_id = abstr
-        .version_control
+    let account_id = client
+        .version_control()
         .namespace(Namespace::new(namespace)?)?
         .account_id;
     assert_eq!(account_id, AccountId::local(1));
@@ -214,10 +176,7 @@ fn can_create_publisher_with_optional_parameters() -> anyhow::Result<()> {
 
 #[test]
 fn can_get_publisher_from_namespace() -> anyhow::Result<()> {
-    // Set up.
-    let (chain, _abstr) = deploy_abstract()?;
-
-    let client: AbstractClient<Mock> = AbstractClient::new(chain.clone())?;
+    let client = AbstractClient::builder(ADMIN).build()?;
 
     let namespace = "namespace";
     let publisher: Publisher<Mock> = client.publisher_builder().namespace(namespace).build()?;
@@ -235,10 +194,7 @@ fn can_get_publisher_from_namespace() -> anyhow::Result<()> {
 
 #[test]
 fn can_publish_and_install_app() -> anyhow::Result<()> {
-    // Set up.
-    let (chain, _abstr) = deploy_abstract()?;
-
-    let client: AbstractClient<Mock> = AbstractClient::new(chain)?;
+    let client = AbstractClient::builder(ADMIN).build()?;
 
     let publisher: Publisher<Mock> = client.publisher_builder().namespace("tester").build()?;
 

--- a/framework/packages/abstract-client/tests/integration.rs
+++ b/framework/packages/abstract-client/tests/integration.rs
@@ -245,7 +245,7 @@ fn can_publish_and_install_app() -> anyhow::Result<()> {
     let publisher_admin = publisher.admin()?;
     let publisher_proxy = publisher.proxy()?;
 
-    publisher.deploy_app::<MockAppInterface<Mock>>()?;
+    publisher.publish_app::<MockAppInterface<Mock>>()?;
 
     let my_app: Application<Mock, MockAppInterface<Mock>> =
         publisher.install_app::<MockAppInterface<Mock>, MockInitMsg>(&MockInitMsg, &[])?;

--- a/framework/packages/abstract-testing/src/mock_ans.rs
+++ b/framework/packages/abstract-testing/src/mock_ans.rs
@@ -32,10 +32,7 @@ use crate::{addresses::*, MockQuerierBuilder};
 /// pub const POOL_METADATA: Map<UniquePoolId, PoolMetadata> = Map::new("pools");
 /// ```
 #[derive(Default)]
-pub struct MockAnsHost(MockAnsState);
-
-#[derive(Default)]
-pub struct MockAnsState {
+pub struct MockAnsHost {
     pub contracts: Vec<(ContractEntry, Addr)>,
     pub assets: Vec<(AssetEntry, AssetInfo)>,
     pub channels: Vec<(ChannelEntry, String)>,
@@ -56,30 +53,22 @@ impl MockAnsHost {
             .with_contract_map_entries(
                 TEST_ANS_HOST,
                 ASSET_ADDRESSES,
-                self.0.assets.iter().map(|(a, b)| (a, b.clone())).collect(),
+                self.assets.iter().map(|(a, b)| (a, b.clone())).collect(),
             )
             .with_contract_map_entries(
                 TEST_ANS_HOST,
                 CONTRACT_ADDRESSES,
-                self.0
-                    .contracts
-                    .iter()
-                    .map(|(a, b)| (a, b.clone()))
-                    .collect(),
+                self.contracts.iter().map(|(a, b)| (a, b.clone())).collect(),
             )
             .with_contract_map_entries(
                 TEST_ANS_HOST,
                 CHANNELS,
-                self.0
-                    .channels
-                    .iter()
-                    .map(|(a, b)| (a, b.clone()))
-                    .collect(),
+                self.channels.iter().map(|(a, b)| (a, b.clone())).collect(),
             );
 
         let mut unique_id = UniquePoolId::new(0);
         let mut dexes = vec![];
-        for (pool_addr, pool_meta) in self.0.pools {
+        for (pool_addr, pool_meta) in self.pools {
             let dex = pool_meta.dex.clone();
             if !dexes.contains(&dex) {
                 dexes.push(dex);
@@ -128,7 +117,7 @@ impl MockAnsHost {
     }
 
     pub fn with_defaults(mut self) -> Self {
-        self.0.assets.append(&mut vec![
+        self.assets.append(&mut vec![
             (AssetEntry::from(EUR), AssetInfo::native(EUR)),
             (AssetEntry::from(USD), AssetInfo::native(USD)),
             (
@@ -144,7 +133,7 @@ impl MockAnsHost {
                 AssetInfo::Cw20(Addr::unchecked(TTOKEN_EUR_LP)),
             ),
         ]);
-        self.0.pools.append(&mut vec![
+        self.pools.append(&mut vec![
             (
                 UncheckedPoolAddress::contract(EUR_USD_PAIR),
                 PoolMetadata::new(

--- a/framework/packages/abstract-testing/src/mock_ans.rs
+++ b/framework/packages/abstract-testing/src/mock_ans.rs
@@ -32,7 +32,10 @@ use crate::{addresses::*, MockQuerierBuilder};
 /// pub const POOL_METADATA: Map<UniquePoolId, PoolMetadata> = Map::new("pools");
 /// ```
 #[derive(Default)]
-pub struct MockAnsHost {
+pub struct MockAnsHost(MockAnsState);
+
+#[derive(Default)]
+pub struct MockAnsState {
     pub contracts: Vec<(ContractEntry, Addr)>,
     pub assets: Vec<(AssetEntry, AssetInfo)>,
     pub channels: Vec<(ChannelEntry, String)>,
@@ -53,22 +56,30 @@ impl MockAnsHost {
             .with_contract_map_entries(
                 TEST_ANS_HOST,
                 ASSET_ADDRESSES,
-                self.assets.iter().map(|(a, b)| (a, b.clone())).collect(),
+                self.0.assets.iter().map(|(a, b)| (a, b.clone())).collect(),
             )
             .with_contract_map_entries(
                 TEST_ANS_HOST,
                 CONTRACT_ADDRESSES,
-                self.contracts.iter().map(|(a, b)| (a, b.clone())).collect(),
+                self.0
+                    .contracts
+                    .iter()
+                    .map(|(a, b)| (a, b.clone()))
+                    .collect(),
             )
             .with_contract_map_entries(
                 TEST_ANS_HOST,
                 CHANNELS,
-                self.channels.iter().map(|(a, b)| (a, b.clone())).collect(),
+                self.0
+                    .channels
+                    .iter()
+                    .map(|(a, b)| (a, b.clone()))
+                    .collect(),
             );
 
         let mut unique_id = UniquePoolId::new(0);
         let mut dexes = vec![];
-        for (pool_addr, pool_meta) in self.pools {
+        for (pool_addr, pool_meta) in self.0.pools {
             let dex = pool_meta.dex.clone();
             if !dexes.contains(&dex) {
                 dexes.push(dex);
@@ -117,7 +128,7 @@ impl MockAnsHost {
     }
 
     pub fn with_defaults(mut self) -> Self {
-        self.assets.append(&mut vec![
+        self.0.assets.append(&mut vec![
             (AssetEntry::from(EUR), AssetInfo::native(EUR)),
             (AssetEntry::from(USD), AssetInfo::native(USD)),
             (
@@ -133,7 +144,7 @@ impl MockAnsHost {
                 AssetInfo::Cw20(Addr::unchecked(TTOKEN_EUR_LP)),
             ),
         ]);
-        self.pools.append(&mut vec![
+        self.0.pools.append(&mut vec![
             (
                 UncheckedPoolAddress::contract(EUR_USD_PAIR),
                 PoolMetadata::new(

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -57,6 +57,7 @@ abstract-testing = { version = "0.19.2" }
 abstract-core = { version = "0.19.2" }
 abstract-macros = { version = "0.19.2" }
 abstract-ica = { version = "0.19.2" }
+abstract-client = { version = "0.19.2" }
 
 abstract-adapter-utils = { version = "0.19.2" }
 abstract-dex-standard = { version = "0.19.2" }
@@ -97,6 +98,7 @@ abstract-macros = { path = "../framework/packages/abstract-macros" }
 abstract-adapter-utils = { path = "../framework/packages/standards/utils" }
 abstract-dex-standard = { path = "../framework/packages/standards/dex" }
 abstract-staking-standard = { path = "../framework/packages/standards/staking" }
+abstract-client = { path = "../framework/packages/abstract-client" }
 
 # Backup release profile, will result in warnings during optimization
 [profile.release]

--- a/modules/contracts/apps/calendar/Cargo.toml
+++ b/modules/contracts/apps/calendar/Cargo.toml
@@ -55,7 +55,7 @@ cw-orch = { workspace = true, optional = true }
 calendar-app = { path = ".", features = ["interface"] }
 abstract-interface = { workspace = true, features = ["daemon"] }
 abstract-testing = { workspace = true }
-abstract-client = { workspace = true }
+abstract-client = { workspace = true, features = ["test-utils"] }
 abstract-sdk = { workspace = true }
 speculoos = { workspace = true }
 semver = { workspace = true }

--- a/modules/contracts/apps/calendar/Cargo.toml
+++ b/modules/contracts/apps/calendar/Cargo.toml
@@ -55,6 +55,7 @@ cw-orch = { workspace = true, optional = true }
 calendar-app = { path = ".", features = ["interface"] }
 abstract-interface = { workspace = true, features = ["daemon"] }
 abstract-testing = { workspace = true }
+abstract-client = { workspace = true }
 abstract-sdk = { workspace = true }
 speculoos = { workspace = true }
 semver = { workspace = true }

--- a/modules/contracts/apps/calendar/tests/integration.rs
+++ b/modules/contracts/apps/calendar/tests/integration.rs
@@ -100,7 +100,7 @@ fn setup_with_time(
 
     let client = AbstractClient::new(mock.clone())?;
 
-    client.ans_host().execute(
+    client.name_service().execute(
         &abstract_core::ans_host::ExecuteMsg::UpdateAssetAddresses {
             to_add: vec![(DENOM.to_owned(), AssetInfo::native(DENOM).into())],
             to_remove: vec![],
@@ -117,7 +117,7 @@ fn setup_with_time(
         .namespace("my-namespace")
         .build()?;
 
-    publisher.deploy_app::<AppInterface<Mock>>()?;
+    publisher.publish_app::<AppInterface<Mock>>()?;
 
     let app: Application<Mock, AppInterface<Mock>> = publisher.install_app(
         &AppInstantiateMsg {

--- a/modules/contracts/apps/calendar/tests/integration.rs
+++ b/modules/contracts/apps/calendar/tests/integration.rs
@@ -1,6 +1,5 @@
 use abstract_client::{application::Application, client::AbstractClient, publisher::Publisher};
 use abstract_core::objects::{gov_type::GovernanceDetails, AssetEntry};
-use abstract_interface::ExecuteMsgFns;
 use calendar_app::{
     error::AppError,
     msg::{AppExecuteMsg, AppInstantiateMsg, ConfigResponse, Time},
@@ -8,7 +7,7 @@ use calendar_app::{
     *,
 };
 use chrono::{DateTime, Days, FixedOffset, NaiveDateTime, NaiveTime, TimeZone, Timelike};
-use cw_asset::AssetInfo;
+use cw_asset::AssetInfoUnchecked;
 // Use prelude to get all the necessary imports
 use cw_orch::{anyhow, prelude::*};
 
@@ -89,12 +88,8 @@ fn setup_with_time(
         .balance("sender1", coins(INITIAL_BALANCE, DENOM))
         .balance("sender2", coins(INITIAL_BALANCE, DENOM))
         .balance("sender", coins(INITIAL_BALANCE, DENOM))
+        .asset(DENOM, AssetInfoUnchecked::native(DENOM))
         .build()?;
-
-    client.name_service().update_asset_addresses(
-        vec![(DENOM.to_owned(), AssetInfo::native(DENOM).into())],
-        vec![],
-    )?;
 
     // Create account to install app onto as well as claim namespace.
     let publisher: Publisher<Mock> = client

--- a/modules/contracts/apps/calendar/tests/integration.rs
+++ b/modules/contracts/apps/calendar/tests/integration.rs
@@ -90,6 +90,7 @@ fn setup_with_time(
     // Create the mock
     let mock = Mock::new(&sender);
 
+    // set balances
     mock.set_balance(&Addr::unchecked("sender1"), coins(INITIAL_BALANCE, DENOM))?;
     mock.set_balance(&Addr::unchecked("sender2"), coins(INITIAL_BALANCE, DENOM))?;
     mock.set_balance(&Addr::unchecked("sender"), coins(INITIAL_BALANCE, DENOM))?;


### PR DESCRIPTION
Replaces the test setup using the internal types in the calendar module tests with the new abstract-client package as a way of dogfooding. It was a very easy change (almost drop-in) and revealed a few missing parts in the client, notably missing `DerefMut` for `Application` and a way of accessing `AnsHost` from client. It also revealed a way of prettying up the syntax by creating an `AbstractClientBuilder` to be used to initializing balances and `AnsHost` things, so that was also created here. 

### Checklist

- [ ] CI is green.
- [ ] Changelog updated.
