### PR TITLE
Add Circle Discord notification for failed WASM builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   codecov: codecov/codecov@3.2.2
+  discord: antonioned/discord@0.1.0
 
 parameters:
   GHA_Event:
@@ -129,3 +130,8 @@ jobs:
           name: Pass
           command: |
             echo "Pass"
+      - discord/status:
+          fail_only: false
+          failure_message: "**${CIRCLE_USERNAME}**'s build: **${CIRCLE_JOB}** failed."
+          webhook: "${DISCORD_STATUS_WEBHOOK}"
+          success_message: "**${CIRCLE_USERNAME}** deployed api to prod."

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,11 @@ jobs:
             git add modules/artifacts --force
             git commit -m 'Update WASM binaries [skip ci]'  
             git push origin $CIRCLE_BRANCH
+      - discord/status:
+          fail_only: false
+          failure_message: "**${CIRCLE_USERNAME}**'s WASM build failed. Please check why! 😭"
+          webhook: "${DISCORD_STATUS_WEBHOOK}"
+          success_message: "**${CIRCLE_USERNAME}** has successfully built WASM! 🎉"
 
   deploy:
     docker:
@@ -130,8 +135,3 @@ jobs:
           name: Pass
           command: |
             echo "Pass"
-      - discord/status:
-          fail_only: false
-          failure_message: "**${CIRCLE_USERNAME}**'s build: **${CIRCLE_JOB}** failed."
-          webhook: "${DISCORD_STATUS_WEBHOOK}"
-          success_message: "**${CIRCLE_USERNAME}** deployed api to prod."


### PR DESCRIPTION
Should help us catch intrusive dependencies earlier.
### Checklist

- [ ] CI is green.
- [ ] Changelog updated.
