### PR TITLE
Add `AsRef<AbstractAccount>` for `abstract_client::Account`

### DIFF
--- a/framework/packages/abstract-client/src/account.rs
+++ b/framework/packages/abstract-client/src/account.rs
@@ -208,6 +208,12 @@ pub struct Account<Chain: CwEnv> {
     install_on_sub_account: bool,
 }
 
+impl<Chain: CwEnv> AsRef<AbstractAccount<Chain>> for Account<Chain> {
+    fn as_ref(&self) -> &AbstractAccount<Chain> {
+        &self.abstr_account
+    }
+}
+
 struct ParsedAccountCreationResponse {
     sub_account_id: u32,
     module_address: String,

--- a/framework/packages/abstract-client/tests/integration.rs
+++ b/framework/packages/abstract-client/tests/integration.rs
@@ -799,3 +799,17 @@ fn doc_example_test() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn can_get_abstract_account_from_client_account() -> anyhow::Result<()> {
+    let sender: Addr = Addr::unchecked("sender");
+    let env: Mock = Mock::new(&sender);
+
+    // Build the client
+    let client: AbstractClient<Mock> = AbstractClient::builder(env).build()?;
+
+    let account = client.account_builder().build()?;
+    let abstract_account: &abstract_interface::AbstractAccount<Mock> = account.as_ref();
+    assert_eq!(abstract_account.id()?, AccountId::local(1));
+    Ok(())
+}


### PR DESCRIPTION
This PR aims to add `AsRef<AbstractAccount>` implementation for `abstract_client::Account` to allow passing it in places such as: https://docs.rs/abstract-interface/latest/abstract_interface/struct.VersionControl.html#method.register_base
### Checklist

- [x] CI is green.
- [x] Changelog updated.
