### PR TITLE
Added Returns inside docs for contract apis

### DIFF
--- a/framework/packages/abstract-app/src/lib.rs
+++ b/framework/packages/abstract-app/src/lib.rs
@@ -208,7 +208,7 @@ pub mod mock {
     }
 
     /// Instantiate the contract with the default [`TEST_MODULE_FACTORY`].
-    /// This will set the [`TEST_MANAGER`] as the admin.
+    /// This will set the [`abstract_testing::addresses::TEST_MANAGER`] as the admin.
     pub fn mock_init() -> MockDeps {
         let mut deps = mock_dependencies();
         let info = mock_info(TEST_MODULE_FACTORY, &[]);

--- a/framework/packages/abstract-client/src/builder.rs
+++ b/framework/packages/abstract-client/src/builder.rs
@@ -36,7 +36,8 @@ impl<Chain: CwEnv> AbstractClient<Chain> {
     }
 }
 
-/// A builder for setting up tests for `Abstract` in a [`cw_orch::prelude::Mock`] environment.
+/// A builder for setting up tests for `Abstract` in an environment where Abstract isn't deployed yet.
+/// Example: [`Mock`](cw_orch::prelude::Mock) or a local [`Daemon`](cw_orch::prelude::Daemon).
 pub struct AbstractClientBuilder<Chain: CwEnv> {
     chain: Chain,
     contracts: Vec<(UncheckedContractEntry, String)>,
@@ -158,7 +159,7 @@ pub mod cw20_builder {
 
     use crate::client::AbstractClientResult;
 
-    /// A builder for creating and deploying `Cw20` contract in a [`cw_orch::prelude::Mock`] environment.
+    /// A builder for creating and deploying `Cw20` contract in a [`CwEnv`](cw_orch::prelude::CwEnv) environment.
     pub struct Cw20Builder<Chain: CwEnv> {
         chain: Chain,
         name: String,

--- a/framework/packages/abstract-client/src/builder.rs
+++ b/framework/packages/abstract-client/src/builder.rs
@@ -36,7 +36,7 @@ impl<Chain: CwEnv> AbstractClient<Chain> {
     }
 }
 
-/// A builder for setting up tests for `Abstract` in a [`Mock`] environment.
+/// A builder for setting up tests for `Abstract` in a [`cw_orch::prelude::Mock`] environment.
 pub struct AbstractClientBuilder<Chain: CwEnv> {
     chain: Chain,
     contracts: Vec<(UncheckedContractEntry, String)>,
@@ -158,7 +158,7 @@ pub mod cw20_builder {
 
     use crate::client::AbstractClientResult;
 
-    /// A builder for creating and deploying `Cw20` contract in a [`Mock`] environment.
+    /// A builder for creating and deploying `Cw20` contract in a [`cw_orch::prelude::Mock`] environment.
     pub struct Cw20Builder<Chain: CwEnv> {
         chain: Chain,
         name: String,

--- a/framework/packages/abstract-client/src/client.rs
+++ b/framework/packages/abstract-client/src/client.rs
@@ -122,7 +122,7 @@ impl<Chain: CwEnv> AbstractClient<Chain> {
             .map_err(|e| AbstractClientError::CwOrch(e.into()))
     }
 
-    /// Publisher builder for creating new [`Publisher`] Abstract Account
+    /// Publisher builder for creating new [`crate::Publisher`] Abstract Account
     /// To publish any modules your account requires to have claimed a namespace.
     pub fn publisher_builder(&self, namespace: Namespace) -> PublisherBuilder<Chain> {
         PublisherBuilder::new(AccountBuilder::new(&self.abstr), namespace)

--- a/framework/packages/abstract-client/src/client.rs
+++ b/framework/packages/abstract-client/src/client.rs
@@ -122,7 +122,7 @@ impl<Chain: CwEnv> AbstractClient<Chain> {
             .map_err(|e| AbstractClientError::CwOrch(e.into()))
     }
 
-    /// Publisher builder for creating new [`crate::Publisher`] Abstract Account
+    /// Publisher builder for creating new [`Publisher`](crate::Publisher) Abstract Account
     /// To publish any modules your account requires to have claimed a namespace.
     pub fn publisher_builder(&self, namespace: Namespace) -> PublisherBuilder<Chain> {
         PublisherBuilder::new(AccountBuilder::new(&self.abstr), namespace)

--- a/framework/packages/abstract-core/src/adapter.rs
+++ b/framework/packages/abstract-core/src/adapter.rs
@@ -132,6 +132,7 @@ pub enum BaseQueryMsg {
     #[returns(AuthorizedAddressesResponse)]
     AuthorizedAddresses { proxy_address: String },
     /// Returns module data
+    /// Returns [`ModuleDataResponse`].
     #[returns(ModuleDataResponse)]
     ModuleData {},
 }

--- a/framework/packages/abstract-core/src/app.rs
+++ b/framework/packages/abstract-core/src/app.rs
@@ -82,12 +82,15 @@ pub enum BaseQueryMsg {
     #[returns(AppConfigResponse)]
     BaseConfig {},
     /// Returns the admin.
+    /// Returns [`AdminResponse`]
     #[returns(AdminResponse)]
     BaseAdmin {},
     /// Returns module data
+    /// Returns [`ModuleDataResponse`]
     #[returns(ModuleDataResponse)]
     ModuleData {},
     /// Returns top level owner
+    /// Returns [`TopLevelOwnerResponse`]
     #[returns(TopLevelOwnerResponse)]
     TopLevelOwner {},
 }

--- a/framework/packages/abstract-core/src/core/manager.rs
+++ b/framework/packages/abstract-core/src/core/manager.rs
@@ -255,11 +255,13 @@ pub enum QueryMsg {
     /// Returns [`InfoResponse`]
     #[returns(InfoResponse)]
     Info {},
+    /// Returns [`SubAccountIdsResponse`]
     #[returns(SubAccountIdsResponse)]
     SubAccountIds {
         start_after: Option<u32>,
         limit: Option<u8>,
     },
+    /// Returns [`crate::objects::nested_admin::TopLevelOwnerResponse`]
     #[returns(crate::objects::nested_admin::TopLevelOwnerResponse)]
     TopLevelOwner {},
 }

--- a/framework/packages/abstract-core/src/core/manager.rs
+++ b/framework/packages/abstract-core/src/core/manager.rs
@@ -96,6 +96,7 @@ pub mod state {
 
 use self::state::AccountInfo;
 use crate::manager::state::SuspensionStatus;
+use crate::objects::nested_admin::TopLevelOwnerResponse;
 use crate::objects::AssetEntry;
 use crate::objects::{account::AccountId, gov_type::GovernanceDetails, module::ModuleInfo};
 use cosmwasm_schema::QueryResponses;
@@ -261,8 +262,8 @@ pub enum QueryMsg {
         start_after: Option<u32>,
         limit: Option<u8>,
     },
-    /// Returns [`crate::objects::nested_admin::TopLevelOwnerResponse`]
-    #[returns(crate::objects::nested_admin::TopLevelOwnerResponse)]
+    /// Returns [`TopLevelOwnerResponse`]
+    #[returns(TopLevelOwnerResponse)]
     TopLevelOwner {},
 }
 

--- a/framework/packages/abstract-core/src/native/account_factory.rs
+++ b/framework/packages/abstract-core/src/native/account_factory.rs
@@ -29,7 +29,7 @@ pub mod state {
         pub ibc_host: Option<Addr>,
     }
 
-    /// Account Factory context for post-[`crate::abstract_manager`] [`crate::abstract_proxy`] creation
+    /// Account Factory context for post-[`crate::manager`] [`crate::proxy`] creation
     #[derive(Serialize, Deserialize, Clone, Debug)]
     pub struct Context {
         pub account_base: AccountBase,

--- a/framework/packages/abstract-core/src/native/account_factory.rs
+++ b/framework/packages/abstract-core/src/native/account_factory.rs
@@ -113,6 +113,7 @@ pub enum ExecuteMsg {
 #[derive(QueryResponses)]
 #[cfg_attr(feature = "interface", derive(cw_orch::QueryFns))]
 pub enum QueryMsg {
+    /// Returns [`ConfigResponse`]
     #[returns(ConfigResponse)]
     Config {},
 }

--- a/framework/packages/abstract-core/src/native/ibc_client.rs
+++ b/framework/packages/abstract-core/src/native/ibc_client.rs
@@ -140,18 +140,23 @@ pub enum IbcClientCallback {
 #[cfg_attr(feature = "interface", derive(cw_orch::QueryFns))]
 #[derive(QueryResponses)]
 pub enum QueryMsg {
+    /// Queries the ownership of the ibc client contract
+    /// Returns [`cw_ownable::Ownership<Addr>`]
     #[returns(cw_ownable::Ownership<Addr> )]
     Ownership {},
 
-    // Returns config
-    #[returns(HostResponse)]
+    /// Returns config
+    /// Returns [`ConfigResponse`]
+    #[returns(ConfigResponse)]
     Config {},
 
-    // Returns config
+    /// Returns the host information associated with a specific chain-name (e.g. osmosis, juno)
+    /// Returns [`HostResponse`]
     #[returns(HostResponse)]
     Host { chain_name: String },
 
     // Shows all open channels (incl. remote info)
+    /// Returns [`ListAccountsResponse`]
     #[returns(ListAccountsResponse)]
     ListAccounts {
         start: Option<(AccountId, String)>,
@@ -159,24 +164,29 @@ pub enum QueryMsg {
     },
 
     // Get channel info for one chain
+    /// Returns [`AccountResponse`]
     #[returns(AccountResponse)]
     Account {
         chain: String,
         account_id: AccountId,
     },
     // get the hosts
+    /// Returns [`ListRemoteHostsResponse`]
     #[returns(ListRemoteHostsResponse)]
     ListRemoteHosts {},
 
     // get the IBC execution proxies
+    /// Returns [`ListRemoteProxiesResponse`]
     #[returns(ListRemoteProxiesResponse)]
     ListRemoteProxies {},
 
     // get the IBC execution proxies based on the account id passed
+    /// Returns [`ListRemoteProxiesResponse`]
     #[returns(ListRemoteProxiesResponse)]
     ListRemoteProxiesByAccountId { account_id: AccountId },
 
     // get the IBC counterparts connected to this abstract client
+    /// Returns [`ListIbcInfrastructureResponse`]
     #[returns(ListIbcInfrastructureResponse)]
     ListIbcInfrastructures {},
 }

--- a/framework/packages/abstract-core/src/native/ibc_host.rs
+++ b/framework/packages/abstract-core/src/native/ibc_host.rs
@@ -134,20 +134,22 @@ pub enum ExecuteMsg {
 #[derive(QueryResponses)]
 #[cfg_attr(feature = "interface", derive(cw_orch::QueryFns))]
 pub enum QueryMsg {
+    /// Queries the ownership of the ibc client contract
+    /// Returns [`cw_ownable::Ownership<Addr>`]
     #[returns(cw_ownable::Ownership<Addr> )]
     Ownership {},
     /// Returns [`ConfigResponse`].
     #[returns(ConfigResponse)]
     Config {},
-    /// Returns [`ClientProxiesResponse`].
     /// Lists all the polytone proxy contracts and their respective client chain registered with the host.
+    /// Returns [`ClientProxiesResponse`].
     #[returns(ClientProxiesResponse)]
     ClientProxies {
         start_after: Option<String>,
         limit: Option<u32>,
     },
-    /// Returns [`ClientProxyResponse`].
     /// Returns the polytone proxy contract address for a specific client chain.
+    /// Returns [`ClientProxyResponse`].
     #[returns(ClientProxyResponse)]
     ClientProxy { chain: String },
 }

--- a/framework/packages/abstract-core/src/native/version_control.rs
+++ b/framework/packages/abstract-core/src/native/version_control.rs
@@ -116,7 +116,6 @@ pub enum ExecuteMsg {
     ProposeModules { modules: Vec<ModuleMapEntry> },
     /// Sets the metadata configuration for a module.
     /// Only callable by namespace admin
-    /// Using Version::Latest in the [`module`] variable sets the default metadata for the module
     UpdateModuleConfiguration {
         module_name: String,
         namespace: Namespace,

--- a/framework/packages/abstract-core/src/objects/entry/asset_entry.rs
+++ b/framework/packages/abstract-core/src/objects/entry/asset_entry.rs
@@ -25,7 +25,6 @@ impl AssetEntry {
 
     /// Retrieve the source chain of the asset
     /// Example: osmosis>juno>crab returns osmosis
-    /// Returns string to remain consistent with [`Self::asset_name`]
     pub fn src_chain(&self) -> AbstractResult<String> {
         let mut split = self.0.splitn(2, CHAIN_DELIMITER);
 

--- a/framework/packages/abstract-core/src/objects/module.rs
+++ b/framework/packages/abstract-core/src/objects/module.rs
@@ -52,7 +52,7 @@ const MAX_LENGTH: usize = 64;
 
 /// Validate attributes of a [`ModuleInfo`].
 /// We use the same conventions as Rust package names.
-/// See https://github.com/rust-lang/api-guidelines/discussions/29
+/// See <https://github.com/rust-lang/api-guidelines/discussions/29>
 pub fn validate_name(name: &str) -> AbstractResult<()> {
     if name.is_empty() {
         return Err(AbstractError::FormattingError {

--- a/framework/packages/abstract-core/src/objects/version_control.rs
+++ b/framework/packages/abstract-core/src/objects/version_control.rs
@@ -51,7 +51,8 @@ pub enum VersionControlError {
 pub type VersionControlResult<T> = Result<T, VersionControlError>;
 
 /// Store the Version Control contract.
-/// Implements [`AbstractRegistryAccess`]
+#[allow(rustdoc::broken_intra_doc_links)]
+/// Implements [`AbstractRegistryAccess`] (defined in abstract-sdk)
 #[cosmwasm_schema::cw_serde]
 pub struct VersionControlContract {
     /// Address of the version control contract

--- a/framework/packages/abstract-sdk/README.md
+++ b/framework/packages/abstract-sdk/README.md
@@ -125,7 +125,7 @@ The available base contracts are:
 | [Adapter](https://crates.io/crates/abstract-adapter)       | ❌          | ✅           |
 
 Each base supports a set of endpoints that can accept custom handlers. These handlers can be added to the base using a static builder pattern.
-All the available endpoints are discussed [here](crate::base::endpoints).
+All the available endpoints are discussed [here](crate::base).
 
 ## Usage
 

--- a/framework/packages/standards/dex/src/msg.rs
+++ b/framework/packages/standards/dex/src/msg.rs
@@ -128,6 +128,7 @@ pub enum DexAction {
 #[cfg_attr(feature = "interface", impl_into(QueryMsg))]
 pub enum DexQueryMsg {
     /// Simulate a swap between two assets
+    /// Returns [`SimulateSwapResponse`]
     #[returns(SimulateSwapResponse)]
     SimulateSwap {
         /// The asset to offer
@@ -138,6 +139,7 @@ pub enum DexQueryMsg {
         dex: Option<DexName>,
     },
     /// Endpoint can be used by front-end to easily interact with contracts.
+    /// Returns [`GenerateMessagesResponse`]
     #[returns(GenerateMessagesResponse)]
     GenerateMessages {
         /// Execute message to generate messages for

--- a/framework/packages/standards/staking/src/msg.rs
+++ b/framework/packages/standards/staking/src/msg.rs
@@ -72,6 +72,7 @@ pub enum StakingAction {
 /// Query messages for the staking adapter
 pub enum StakingQueryMsg {
     /// Get the staking info for a given provider
+    /// Returns [`StakingInfoResponse`]
     #[returns(StakingInfoResponse)]
     Info {
         /// Name of the provider
@@ -80,6 +81,7 @@ pub enum StakingQueryMsg {
         staking_tokens: Vec<AssetEntry>,
     },
     /// Get the staked amount for a given provider, staking token, staker address and unbonding period
+    /// Returns [`StakeResponse`]
     #[returns(StakeResponse)]
     Staked {
         /// Name of the provider
@@ -92,6 +94,7 @@ pub enum StakingQueryMsg {
         unbonding_period: Option<Duration>,
     },
     /// Get the unbonding entries for a given provider, staking token and staker address
+    /// Returns [`UnbondingResponse`]
     #[returns(UnbondingResponse)]
     Unbonding {
         /// Name of the provider
@@ -102,6 +105,7 @@ pub enum StakingQueryMsg {
         staker_address: String,
     },
     /// Get the reward tokens for a given provider and staking token
+    /// Returns [`RewardTokensResponse`]
     #[returns(RewardTokensResponse)]
     RewardTokens {
         /// Name of the provider

--- a/interchain/tests/src/interchain_accounts.rs
+++ b/interchain/tests/src/interchain_accounts.rs
@@ -98,8 +98,6 @@ mod test {
     use abstract_interface::{ManagerExecFns, ManagerQueryFns};
     use abstract_testing::addresses::TEST_MODULE_ID;
     use abstract_testing::addresses::TEST_NAMESPACE;
-    use abstract_testing::prelude::TEST_MODULE_ID;
-    use abstract_testing::prelude::TEST_NAMESPACE;
     use abstract_testing::prelude::TEST_VERSION;
     use cosmwasm_std::Uint128;
     use cosmwasm_std::{to_json_binary, wasm_execute};

--- a/modules/contracts/apps/calendar/src/msg.rs
+++ b/modules/contracts/apps/calendar/src/msg.rs
@@ -105,9 +105,11 @@ pub enum CalendarExecuteMsg {
 #[derive(QueryResponses)]
 pub enum CalendarQueryMsg {
     /// Returns the config.
+    /// Returns [`ConfigResponse`]
     #[returns(ConfigResponse)]
     Config {},
     /// Returns the meetings for a given day.
+    /// Returns [`MeetingsResponse`]
     #[returns(MeetingsResponse)]
     Meetings { day_datetime: Int64 },
 }

--- a/modules/contracts/apps/challenge/src/msg.rs
+++ b/modules/contracts/apps/challenge/src/msg.rs
@@ -86,12 +86,14 @@ pub enum ChallengeExecuteMsg {
 #[derive(QueryResponses)]
 pub enum ChallengeQueryMsg {
     /// Get challenge info, will return null if there was no challenge by Id
+    /// Returns [`ChallengeResponse`]
     #[returns(ChallengeResponse)]
     Challenge {
         /// Id of requested challenge
         challenge_id: u64,
     },
     /// Get list of challenges
+    /// Returns [`ChallengesResponse`]
     #[returns(ChallengesResponse)]
     Challenges {
         /// start after challenge Id
@@ -100,12 +102,14 @@ pub enum ChallengeQueryMsg {
         limit: Option<u64>,
     },
     /// List of friends by Id
+    /// Returns [`FriendsResponse`]
     #[returns(FriendsResponse)]
     Friends {
         /// Id of requested challenge
         challenge_id: u64,
     },
     /// Get vote of friend
+    /// Returns [`VoteResponse`]
     #[returns(VoteResponse)]
     Vote {
         /// Addr of the friend
@@ -117,6 +121,7 @@ pub enum ChallengeQueryMsg {
         proposal_id: Option<u64>,
     },
     /// Get votes of challenge
+    /// Returns [`VotesResponse`]
     #[returns(VotesResponse)]
     Votes {
         /// Id of requested challenge
@@ -130,6 +135,7 @@ pub enum ChallengeQueryMsg {
         limit: Option<u64>,
     },
     /// Get results of previous votes for this challenge
+    /// Returns [`ProposalsResponse`]
     #[returns(ProposalsResponse)]
     Proposals {
         /// Challenge Id for previous votes

--- a/modules/contracts/apps/croncat/src/msg.rs
+++ b/modules/contracts/apps/croncat/src/msg.rs
@@ -61,9 +61,11 @@ pub enum AppExecuteMsg {
 #[derive(QueryResponses)]
 pub enum AppQueryMsg {
     /// Get config
+    /// Returns [`ConfigResponse`]
     #[returns(ConfigResponse)]
     Config {},
     /// Get active tasks
+    /// Returns [`ActiveTasksResponse`]
     #[returns(ActiveTasksResponse)]
     ActiveTasks {
         /// The addr and task tag to start listing after.
@@ -75,6 +77,7 @@ pub enum AppQueryMsg {
         checked: Option<bool>,
     },
     /// Get active tasks by creator
+    /// Returns [`ActiveTasksByCreatorResponse`]
     #[returns(ActiveTasksByCreatorResponse)]
     ActiveTasksByCreator {
         /// The addr of creator of tasks
@@ -88,6 +91,7 @@ pub enum AppQueryMsg {
         checked: Option<bool>,
     },
     /// Get task info
+    /// Returns [`croncat_sdk_tasks::types::TaskResponse`]
     #[returns(croncat_sdk_tasks::types::TaskResponse)]
     TaskInfo {
         /// The addr of creator of tasks
@@ -96,6 +100,7 @@ pub enum AppQueryMsg {
         task_tag: String,
     },
     /// Get task balance
+    /// Returns [`croncat_sdk_manager::types::TaskBalanceResponse`]
     #[returns(croncat_sdk_manager::types::TaskBalanceResponse)]
     TaskBalance {
         /// The addr of creator of tasks
@@ -105,6 +110,7 @@ pub enum AppQueryMsg {
     },
     /// Get croncat manager address of task
     /// Used to verify sender
+    /// Returns [`Addr`]
     #[returns(Addr)]
     ManagerAddr {
         /// The addr of creator of tasks

--- a/modules/contracts/apps/dca/src/msg.rs
+++ b/modules/contracts/apps/dca/src/msg.rs
@@ -116,9 +116,11 @@ pub enum DCAExecuteMsg {
 #[derive(QueryResponses)]
 pub enum DCAQueryMsg {
     /// Get config of the DCA app
+    /// Returns [`ConfigResponse`]
     #[returns(ConfigResponse)]
     Config {},
     /// Get DCA Entry
+    /// Returns [`DCAResponse`]
     #[returns(DCAResponse)]
     DCA {
         /// Id of the DCA

--- a/modules/contracts/apps/payment/src/msg.rs
+++ b/modules/contracts/apps/payment/src/msg.rs
@@ -44,8 +44,10 @@ pub enum AppExecuteMsg {
 #[cfg_attr(feature = "interface", impl_into(QueryMsg))]
 #[derive(QueryResponses)]
 pub enum AppQueryMsg {
+    /// Returns [`ConfigResponse`]
     #[returns(ConfigResponse)]
     Config {},
+    /// Returns [`TipperResponse`]
     #[returns(TipperResponse)]
     Tipper {
         address: String,
@@ -53,8 +55,10 @@ pub enum AppQueryMsg {
         limit: Option<u32>,
         at_height: Option<u64>,
     },
+    /// Returns [`TipCountResponse`]
     #[returns(TipCountResponse)]
     TipCount {},
+    /// Returns [`TippersCountResponse`]
     #[returns(TippersCountResponse)]
     ListTippersCount {
         start_after: Option<String>,

--- a/modules/contracts/apps/subscription/src/msg.rs
+++ b/modules/contracts/apps/subscription/src/msg.rs
@@ -104,21 +104,26 @@ pub enum SubscriptionExecuteMsg {
 #[derive(QueryResponses)]
 pub enum SubscriptionQueryMsg {
     /// Get state of subscriptions and contributors
+    /// Returns [`StateResponse`]
     #[returns(StateResponse)]
     State {},
     /// Get config of subscriptions and contributors
+    /// Returns [`SubscriptionConfig`]
     #[returns(SubscriptionConfig)]
     Config {},
     /// Get minimum of one month's worth to (re)-subscribe.
+    /// Returns [`SubscriptionFeeResponse`]
     #[returns(SubscriptionFeeResponse)]
     Fee {},
     /// Get state of the subscriber
+    /// Returns [`SubscriberResponse`]
     #[returns(SubscriberResponse)]
     Subscriber {
         /// Address of subscriber  
         addr: String,
     },
     /// Get list of subscribers
+    /// Returns [`SubscribersResponse`]
     #[returns(SubscribersResponse)]
     Subscribers {
         /// Start after subscriber address


### PR DESCRIPTION
This PR aims at adding documentation links to all abstract contract APIs

## TODO

- [x] Do the same for apps and adapters.
- [x] Correct cargo doc warnings

### Checklist

- [ ] CI is green.
- [ ] Changelog updated.
