### PR TITLE
Implement account fetcher method on AccountClient

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
   
 - Added a `.execute` method on the AuthZ API to execute `CosmosMsg` types on behalf of a granter.
+- Added a `.account_from` method on the `AbstractClient` for retrieving `Account`s.
 
 ### Changed
 

--- a/framework/packages/abstract-client/README.md
+++ b/framework/packages/abstract-client/README.md
@@ -102,7 +102,7 @@ let chain = Mock::new(&Addr::unchecked("sender"));
 let client: AbstractClient<Mock> = AbstractClient::builder(chain).build()?;
 
 // Build a Publisher
-let publisher: Publisher<Mock> = client.publisher_builder(Namespace::new("tester-dependency")?)
+let publisher: Publisher<Mock> = client.publisher_builder(Namespace::new("tester")?)
         .build()?;
 
 publisher.publish_app::<MockAppI<_>>()?;
@@ -111,6 +111,35 @@ publisher.publish_app::<MockAppI<_>>()?;
 let app: Application<Mock, MockAppI<Mock>> =
         publisher.account().install_app::<MockAppI<Mock>>(&MockInitMsg {}, &[])?;
 
+
+Ok::<(), abstract_client::AbstractClientError>(())
+```
+
+### Fetching an `Account`
+
+If you've previously created an `Account` and wish to retrieve it, you can use the `AbstractClient::account_from` function. This function accepts three different types of input:
+
+- `Namespace` - If the namespace is claimed, the function will return the `Account` that owns the namespace.
+- `AccountId` - If this `AccountId` exists, the function will return the `Account` with that `AccountId`.
+- App `Addr` - If there's an `App` installed on the account you can provide its `Addr` to retrieve the `Account` that it is installed on.
+
+```rust
+use cw_orch::prelude::*;
+use abstract_client::{AbstractClient, Namespace, Account};
+use abstract_app::mock::{mock_app_dependency::interface::MockAppI, MockInitMsg};
+
+let chain = Mock::new(&Addr::unchecked("sender"));
+
+// Construct the client
+let client: AbstractClient<Mock> = AbstractClient::builder(chain).build()?;
+
+let namespace = Namespace::new("some-namespace")?;
+
+// Build a new account.
+let account: Account<Mock> = client.account_builder().namespace(namespace.clone()).build()?;
+
+// Fetch the account
+let fetched_account: Account<Mock> = client.account_from(namespace)?;
 
 Ok::<(), abstract_client::AbstractClientError>(())
 ```

--- a/framework/packages/abstract-client/src/account.rs
+++ b/framework/packages/abstract-client/src/account.rs
@@ -19,6 +19,8 @@
 //! assert_eq!(alice_account.owner()?, client.sender());
 //! # Ok::<(), AbstractClientError>(())
 //! ```
+use std::fmt::{Debug, Display};
+
 use abstract_core::{
     manager::{
         state::AccountInfo, InfoResponse, ManagerModuleInfo, ModuleAddressesResponse,
@@ -151,7 +153,7 @@ impl<'a, Chain: CwEnv> AccountBuilder<'a, Chain> {
             // Check if namespace already claimed
             if let Some(ref namespace) = self.namespace {
                 let account_from_namespace_result: Option<Account<Chain>> =
-                    Account::from_namespace(
+                    Account::maybe_from_namespace(
                         self.abstr,
                         namespace.clone(),
                         self.install_on_sub_account,
@@ -228,7 +230,7 @@ impl<Chain: CwEnv> Account<Chain> {
         }
     }
 
-    pub(crate) fn from_namespace(
+    pub(crate) fn maybe_from_namespace(
         abstr: &Abstract<Chain>,
         namespace: Namespace,
         install_on_sub_account: bool,
@@ -567,5 +569,17 @@ impl<Chain: MutCwEnv> Account<Chain> {
             .add_balance(&self.proxy()?, amount.to_vec())
             .map_err(Into::into)
             .map_err(Into::into)
+    }
+}
+
+impl<Chain: CwEnv> Display for Account<Chain> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.abstr_account)
+    }
+}
+
+impl<Chain: CwEnv> Debug for Account<Chain> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.abstr_account)
     }
 }

--- a/framework/packages/abstract-client/src/client.rs
+++ b/framework/packages/abstract-client/src/client.rs
@@ -163,17 +163,17 @@ impl<Chain: CwEnv> AbstractClient<Chain> {
 
                 // Only return if the account can be retrieved without errors.
                 if let Some(account_from_namespace) = account_from_namespace_result {
-                    return Ok(account_from_namespace);
+                    Ok(account_from_namespace)
                 } else {
-                    return Err(AbstractClientError::NamespaceNotClaimed {
+                    Err(AbstractClientError::NamespaceNotClaimed {
                         namespace: namespace.to_string(),
-                    });
+                    })
                 }
             }
             AccountSource::AccountId(account_id) => {
                 let abstract_account: AbstractAccount<Chain> =
                     AbstractAccount::new(&self.abstr, account_id.clone());
-                return Ok(Account::new(abstract_account, true));
+                Ok(Account::new(abstract_account, true))
             }
             AccountSource::App(app) => {
                 // Query app for manager address and get AccountId from it.
@@ -195,7 +195,7 @@ impl<Chain: CwEnv> AbstractClient<Chain> {
                 // This function verifies the account-id is valid and returns an error if not.
                 let abstract_account: AbstractAccount<Chain> =
                     AbstractAccount::new(&self.abstr, manager_config.account_id);
-                return Ok(Account::new(abstract_account, true));
+                Ok(Account::new(abstract_account, true))
             }
         }
     }

--- a/framework/packages/abstract-client/src/client.rs
+++ b/framework/packages/abstract-client/src/client.rs
@@ -12,7 +12,7 @@
 //!
 //! ```
 //! # use abstract_client::AbstractClientError;
-//! use abstract_app::mock::interface::MockAppWithDepI;
+//! use abstract_app::mock::mock_app_dependency::interface::MockAppI;
 //! use cw_orch::prelude::*;
 //! use abstract_client::{AbstractClient, Publisher, Namespace};
 //!
@@ -24,7 +24,7 @@
 //!     .publisher_builder(namespace)
 //!     .build()?;
 //!
-//! publisher.publish_app::<MockAppWithDepI<Mock>>()?;
+//! publisher.publish_app::<MockAppI<Mock>>()?;
 //! # Ok::<(), AbstractClientError>(())
 //! ```
 

--- a/framework/packages/abstract-client/src/client.rs
+++ b/framework/packages/abstract-client/src/client.rs
@@ -30,11 +30,15 @@
 
 use abstract_core::objects::{namespace::Namespace, AccountId};
 use abstract_interface::{Abstract, AbstractAccount, AnsHost, ManagerQueryFns, VersionControl};
-use cosmwasm_std::{Addr, BlockInfo, Coin, Uint128};
-use cw_orch::{deploy::Deploy, prelude::CwEnv, state::StateInterface};
+use cosmwasm_std::{Addr, BlockInfo, Coin, Empty, Uint128};
+use cw_orch::{
+    contract::interface_traits::ContractInstance, deploy::Deploy, prelude::CwEnv,
+    state::StateInterface,
+};
 
 use crate::{
     account::{Account, AccountBuilder},
+    source::AccountSource,
     AbstractClientError, Environment, PublisherBuilder,
 };
 
@@ -125,7 +129,7 @@ impl<Chain: CwEnv> AbstractClient<Chain> {
         PublisherBuilder::new(AccountBuilder::new(&self.abstr), namespace)
     }
 
-    /// Publisher builder for creating a new Abstract [`Account`].
+    /// Builder for creating a new Abstract [`Account`].
     pub fn account_builder(&self) -> AccountBuilder<Chain> {
         AccountBuilder::new(&self.abstr)
     }
@@ -133,6 +137,67 @@ impl<Chain: CwEnv> AbstractClient<Chain> {
     /// Address of the sender
     pub fn sender(&self) -> Addr {
         self.environment().sender()
+    }
+
+    /// Fetch an [`Account`] from a given source.
+    ///
+    /// This method is used to retrieve an account from a given source. It will **not** create a new account if the source is invalid.
+    ///
+    /// Sources that can be used are:
+    /// - [`Namespace`]: Will retrieve the account from the namespace if it is already claimed.
+    /// - [`AccountId`]: Will retrieve the account from the account id.
+    /// - App [`Addr`]: Will retrieve the account from an app that is installed on it.
+    pub fn account_from<T: Into<AccountSource>>(
+        &self,
+        source: T,
+    ) -> AbstractClientResult<Account<Chain>> {
+        let source = source.into();
+        let chain = self.abstr.version_control.get_chain();
+
+        match source {
+            AccountSource::Namespace(namespace) => {
+                // if namespace, check if we need to claim or not.
+                // Check if namespace already claimed
+                let account_from_namespace_result: Option<Account<Chain>> =
+                    Account::maybe_from_namespace(&self.abstr, namespace.clone(), true)?;
+
+                // Only return if the account can be retrieved without errors.
+                if let Some(account_from_namespace) = account_from_namespace_result {
+                    return Ok(account_from_namespace);
+                } else {
+                    return Err(AbstractClientError::NamespaceNotClaimed {
+                        namespace: namespace.to_string(),
+                    });
+                }
+            }
+            AccountSource::AccountId(account_id) => {
+                let abstract_account: AbstractAccount<Chain> =
+                    AbstractAccount::new(&self.abstr, account_id.clone());
+                return Ok(Account::new(abstract_account, true));
+            }
+            AccountSource::App(app) => {
+                // Query app for manager address and get AccountId from it.
+                let app_config: abstract_core::app::AppConfigResponse = chain
+                    .query(
+                        &abstract_core::app::QueryMsg::<Empty>::Base(
+                            abstract_core::app::BaseQueryMsg::BaseConfig {},
+                        ),
+                        &app,
+                    )
+                    .map_err(Into::into)?;
+
+                let manager_config: abstract_core::manager::ConfigResponse = chain
+                    .query(
+                        &abstract_core::manager::QueryMsg::Config {},
+                        &app_config.manager_address,
+                    )
+                    .map_err(Into::into)?;
+                // This function verifies the account-id is valid and returns an error if not.
+                let abstract_account: AbstractAccount<Chain> =
+                    AbstractAccount::new(&self.abstr, manager_config.account_id);
+                return Ok(Account::new(abstract_account, true));
+            }
+        }
     }
 
     /// Retrieve denom balance for provided address

--- a/framework/packages/abstract-client/src/error.rs
+++ b/framework/packages/abstract-client/src/error.rs
@@ -28,4 +28,7 @@ pub enum AbstractClientError {
 
     #[error("Account is Renounced and does not have an owner.")]
     RenouncedAccount {},
+
+    #[error("Can't retrieve Account for unclaimed namespace \"{namespace}\".")]
+    NamespaceNotClaimed { namespace: String },
 }

--- a/framework/packages/abstract-client/src/lib.rs
+++ b/framework/packages/abstract-client/src/lib.rs
@@ -10,6 +10,7 @@ pub(crate) mod infrastructure;
 #[cfg(feature = "test-utils")]
 mod mut_client;
 mod publisher;
+pub(crate) mod source;
 
 // Re-export common used types
 pub use abstract_core::objects::{gov_type::GovernanceDetails, namespace::Namespace};

--- a/framework/packages/abstract-client/src/lib.rs
+++ b/framework/packages/abstract-client/src/lib.rs
@@ -23,3 +23,4 @@ pub use client::AbstractClient;
 pub use error::AbstractClientError;
 pub use infrastructure::Environment;
 pub use publisher::{Publisher, PublisherBuilder};
+pub use source::AccountSource;

--- a/framework/packages/abstract-client/src/source.rs
+++ b/framework/packages/abstract-client/src/source.rs
@@ -22,9 +22,3 @@ impl From<AccountId> for AccountSource {
         AccountSource::AccountId(account_id)
     }
 }
-
-impl From<Addr> for AccountSource {
-    fn from(addr: Addr) -> Self {
-        AccountSource::App(addr)
-    }
-}

--- a/framework/packages/abstract-client/src/source.rs
+++ b/framework/packages/abstract-client/src/source.rs
@@ -1,0 +1,30 @@
+use abstract_core::objects::{namespace::Namespace, AccountId};
+use cosmwasm_std::Addr;
+
+/// Represents the a route to fetch an account from.
+pub enum AccountSource {
+    /// Get the account from a registered [`Namespace`].
+    Namespace(Namespace),
+    /// Get the account from an [`AccountId`].
+    AccountId(AccountId),
+    /// Get the account from the address of an installed App.
+    App(Addr),
+}
+
+impl From<Namespace> for AccountSource {
+    fn from(namespace: Namespace) -> Self {
+        AccountSource::Namespace(namespace)
+    }
+}
+
+impl From<AccountId> for AccountSource {
+    fn from(account_id: AccountId) -> Self {
+        AccountSource::AccountId(account_id)
+    }
+}
+
+impl From<Addr> for AccountSource {
+    fn from(addr: Addr) -> Self {
+        AccountSource::App(addr)
+    }
+}

--- a/framework/packages/abstract-client/tests/integration.rs
+++ b/framework/packages/abstract-client/tests/integration.rs
@@ -24,7 +24,7 @@ use abstract_testing::{
 use cosmwasm_std::{coins, Addr, BankMsg, Coin, Empty, Uint128};
 use cw_asset::{AssetInfo, AssetInfoUnchecked};
 use cw_orch::{
-    contract::interface_traits::{CwOrchExecute, CwOrchQuery},
+    contract::interface_traits::{ContractInstance, CwOrchExecute, CwOrchQuery},
     prelude::{CallAs, Mock},
 };
 use cw_ownable::Ownership;
@@ -121,13 +121,28 @@ fn can_get_account_from_namespace() -> anyhow::Result<()> {
         .namespace(namespace.clone())
         .build()?;
 
-    let account_from_namespace: Account<Mock> = client
-        .account_builder()
-        .fetch_if_namespace_claimed(true)
-        .namespace(namespace)
-        .build()?;
+    // From namespace directly
+    let account_from_namespace: Account<Mock> = client.account_from(namespace)?;
 
     assert_eq!(account.info()?, account_from_namespace.info()?);
+    Ok(())
+}
+
+#[test]
+fn err_fetching_unclaimed_namespace() -> anyhow::Result<()> {
+    let client = AbstractClient::builder(Mock::new(&Addr::unchecked(OWNER))).build()?;
+
+    let namespace = Namespace::new("namespace")?;
+
+    let account_from_namespace_no_claim_res: Result<
+        Account<Mock>,
+        abstract_client::AbstractClientError,
+    > = client.account_from(namespace);
+
+    assert!(matches!(
+        account_from_namespace_no_claim_res.unwrap_err(),
+        abstract_client::AbstractClientError::NamespaceNotClaimed { .. }
+    ));
 
     Ok(())
 }
@@ -361,44 +376,37 @@ fn can_publish_and_install_adapter() -> anyhow::Result<()> {
 }
 
 #[test]
-fn cannot_create_same_account_twice_when_fetch_flag_is_disabled() -> anyhow::Result<()> {
+fn can_fetch_account_from_id() -> anyhow::Result<()> {
     let client = AbstractClient::builder(Mock::new(&Addr::unchecked(OWNER))).build()?;
 
-    let namespace = Namespace::new("namespace")?;
+    let account1 = client.account_builder().build()?;
 
-    // First call succeeds.
-    client
-        .account_builder()
-        .namespace(namespace.clone())
-        .build()?;
+    let account2 = client.account_from(account1.id()?)?;
 
-    // Second call fails
-    let result = client
-        .account_builder()
-        .fetch_if_namespace_claimed(false)
-        .namespace(namespace)
-        .build();
-    assert!(result.is_err());
+    assert_eq!(account1.info()?, account2.info()?);
 
     Ok(())
 }
 
 #[test]
-fn can_create_same_account_twice_when_fetch_flag_is_enabled() -> anyhow::Result<()> {
+fn can_fetch_account_from_app() -> anyhow::Result<()> {
     let client = AbstractClient::builder(Mock::new(&Addr::unchecked(OWNER))).build()?;
 
-    let namespace = Namespace::new("namespace")?;
+    let app_publisher: Publisher<Mock> = client
+        .publisher_builder(Namespace::new(TEST_NAMESPACE)?)
+        .build()?;
+
+    app_publisher.publish_app::<MockAppI<Mock>>()?;
 
     let account1 = client
         .account_builder()
-        .namespace(namespace.clone())
+        // Install apps in this account
+        .install_on_sub_account(false)
         .build()?;
 
-    let account2 = client
-        .account_builder()
-        .namespace(namespace)
-        .fetch_if_namespace_claimed(true)
-        .build()?;
+    let app = account1.install_app::<MockAppI<Mock>>(&MockInitMsg {}, &[])?;
+
+    let account2 = client.account_from(app.address()?)?;
 
     assert_eq!(account1.info()?, account2.info()?);
 

--- a/framework/packages/abstract-client/tests/integration.rs
+++ b/framework/packages/abstract-client/tests/integration.rs
@@ -8,7 +8,7 @@ use abstract_app::mock::{
 };
 use abstract_client::{
     builder::cw20_builder::{self, Cw20ExecuteMsgFns, Cw20QueryMsgFns},
-    AbstractClient, Account, Application, Publisher,
+    AbstractClient, Account, AccountSource, Application, Publisher,
 };
 use abstract_core::{
     manager::{
@@ -406,7 +406,7 @@ fn can_fetch_account_from_app() -> anyhow::Result<()> {
 
     let app = account1.install_app::<MockAppI<Mock>>(&MockInitMsg {}, &[])?;
 
-    let account2 = client.account_from(app.address()?)?;
+    let account2 = client.account_from(AccountSource::App(app.address()?))?;
 
     assert_eq!(account1.info()?, account2.info()?);
 

--- a/framework/packages/abstract-interface/src/account/mod.rs
+++ b/framework/packages/abstract-interface/src/account/mod.rs
@@ -13,7 +13,7 @@
 
 use abstract_core::{manager::ModuleInstallConfig, ABSTRACT_EVENT_TYPE};
 
-use crate::{Abstract, AdapterDeployer};
+use crate::{Abstract, AbstractInterfaceError, AdapterDeployer};
 
 mod manager;
 mod proxy;
@@ -190,14 +190,10 @@ impl<Chain: CwEnv> AbstractAccount<Chain> {
     {
         self.manager.register_remote_account(host_chain)
     }
-}
 
-use crate::AbstractInterfaceError;
-impl<T: CwEnv> AbstractAccount<T> {
-    /// Upload and register the account core contracts in the version control if they need to be updated
     pub fn upload_and_register_if_needed(
         &self,
-        version_control: &VersionControl<T>,
+        version_control: &VersionControl<Chain>,
     ) -> Result<bool, AbstractInterfaceError> {
         let mut modules_to_register = Vec::with_capacity(2);
 
@@ -223,5 +219,22 @@ impl<T: CwEnv> AbstractAccount<T> {
         };
 
         Ok(migrated)
+    }
+}
+
+impl<Chain: CwEnv> std::fmt::Display for AbstractAccount<Chain> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Account manager: {:?} ({:?}) proxy: {:?} ({:?})",
+            self.manager.id(),
+            self.manager
+                .addr_str()
+                .or_else(|_| Result::<_, CwOrchError>::Ok(String::from("unknown"))),
+            self.proxy.id(),
+            self.proxy
+                .addr_str()
+                .or_else(|_| Result::<_, CwOrchError>::Ok(String::from("unknown"))),
+        )
     }
 }


### PR DESCRIPTION
Implements an unified method for fetching an account. Also adds Display methods to the Account structures for err_unwrapping purposes.

`client.account_from( ... )` which accepts `Namespace`, `AccountId` and `Addr` of an App.