### PR TITLE
Add an abstract_interface fetcher to AbstractClient

### DIFF
--- a/framework/packages/abstract-client/src/client.rs
+++ b/framework/packages/abstract-client/src/client.rs
@@ -113,7 +113,7 @@ impl<Chain: CwEnv> AbstractClient<Chain> {
     }
 
     /// Get the underlying [`Abstract`] infrastructure interface.
-    /// 
+    ///
     /// The returned object is a low-level interface to the Abstract deployment and contains all the contract interfaces that are used by the Abstract client.
     /// You can use this to do more advanced operations that are not directly supported by the Abstract client.
     pub fn abstract_interface(&self) -> &Abstract<Chain> {

--- a/framework/packages/abstract-client/src/client.rs
+++ b/framework/packages/abstract-client/src/client.rs
@@ -112,6 +112,14 @@ impl<Chain: CwEnv> AbstractClient<Chain> {
         &self.abstr.ans_host
     }
 
+    /// Get the underlying [`Abstract`] infrastructure interface.
+    /// 
+    /// The returned object is a low-level interface to the Abstract deployment and contains all the contract interfaces that are used by the Abstract client.
+    /// You can use this to do more advanced operations that are not directly supported by the Abstract client.
+    pub fn abstract_interface(&self) -> &Abstract<Chain> {
+        &self.abstr
+    }
+
     /// Return current block info see [`BlockInfo`].
     pub fn block_info(&self) -> AbstractClientResult<BlockInfo> {
         self.environment()

--- a/framework/packages/abstract-interface/src/deployment.rs
+++ b/framework/packages/abstract-interface/src/deployment.rs
@@ -11,6 +11,9 @@ use crate::{
     AccountFactory, AnsHost, Manager, ModuleFactory, Proxy, VersionControl,
 };
 
+/// A wrapper struct around all the Abstract contracts.
+/// 
+/// Can be used to deploy and retrieve the Abstract contracts to/from any environment.
 pub struct Abstract<Chain: CwEnv> {
     pub ans_host: AnsHost<Chain>,
     pub version_control: VersionControl<Chain>,

--- a/framework/packages/abstract-interface/src/deployment.rs
+++ b/framework/packages/abstract-interface/src/deployment.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 /// A wrapper struct around all the Abstract contracts.
-/// 
+///
 /// Can be used to deploy and retrieve the Abstract contracts to/from any environment.
 pub struct Abstract<Chain: CwEnv> {
     pub ans_host: AnsHost<Chain>,


### PR DESCRIPTION
As discussed there's no way to access the underlying Abstract interface wrapper from the AbstractClient. This makes it very hard to do more complex or low-level logic in some cases. Use of this function should be discouraged though, as most of the missing functionality could and should be present in the abstract-client itself