### PR TITLE
Remove manager checks in adapters `fetch_data`

### DIFF
--- a/framework/packages/standards/dex/src/command.rs
+++ b/framework/packages/standards/dex/src/command.rs
@@ -6,7 +6,7 @@ use abstract_sdk::{
     core::objects::AssetEntry,
     feature_objects::{AnsHost, VersionControlContract},
 };
-use cosmwasm_std::{CosmosMsg, Decimal, Deps, Uint128};
+use cosmwasm_std::{Addr, CosmosMsg, Decimal, Deps, Uint128};
 use cw_asset::{Asset, AssetInfo};
 
 use crate::error::DexError;
@@ -110,7 +110,7 @@ pub trait DexCommand<E: Error = DexError>: Identify {
     fn fetch_data(
         &mut self,
         _deps: Deps,
-        _sender: cosmwasm_std::Addr,
+        _sender: Addr,
         _version_control_contract: VersionControlContract,
         _ans_host: AnsHost,
         _pool_id: UniquePoolId,

--- a/framework/packages/standards/dex/src/command.rs
+++ b/framework/packages/standards/dex/src/command.rs
@@ -110,7 +110,7 @@ pub trait DexCommand<E: Error = DexError>: Identify {
     fn fetch_data(
         &mut self,
         _deps: Deps,
-        _sender: Addr,
+        _addr_as_sender: Addr,
         _version_control_contract: VersionControlContract,
         _ans_host: AnsHost,
         _pool_id: UniquePoolId,

--- a/framework/packages/standards/dex/src/msg.rs
+++ b/framework/packages/standards/dex/src/msg.rs
@@ -160,7 +160,7 @@ pub enum DexQueryMsg {
         /// Execute message to generate messages for
         message: DexExecuteMsg,
         /// Sender Addr generate messages for
-        sender: String,
+        addr_as_sender: String,
     },
     /// Fee info for using the different dex actions
     #[returns(DexFeesResponse)]

--- a/framework/packages/standards/dex/src/msg.rs
+++ b/framework/packages/standards/dex/src/msg.rs
@@ -159,8 +159,8 @@ pub enum DexQueryMsg {
     GenerateMessages {
         /// Execute message to generate messages for
         message: DexExecuteMsg,
-        /// Proxy Addr generate messages for
-        proxy_addr: String,
+        /// Sender Addr generate messages for
+        sender: String,
     },
     /// Fee info for using the different dex actions
     #[returns(DexFeesResponse)]

--- a/framework/packages/standards/staking/src/command.rs
+++ b/framework/packages/standards/staking/src/command.rs
@@ -41,7 +41,7 @@ pub trait CwStakingCommand<E: Error = CwStakingError>: Identify {
         &mut self,
         deps: Deps,
         env: Env,
-        info: Option<cosmwasm_std::MessageInfo>,
+        sender: Option<Addr>,
         ans_host: &AnsHost,
         version_control_contract: VersionControlContract,
         staking_assets: Vec<AssetEntry>,

--- a/framework/packages/standards/staking/src/command.rs
+++ b/framework/packages/standards/staking/src/command.rs
@@ -41,7 +41,7 @@ pub trait CwStakingCommand<E: Error = CwStakingError>: Identify {
         &mut self,
         deps: Deps,
         env: Env,
-        sender: Option<Addr>,
+        addr_as_sender: Option<Addr>,
         ans_host: &AnsHost,
         version_control_contract: VersionControlContract,
         staking_assets: Vec<AssetEntry>,

--- a/integrations/Cargo.toml
+++ b/integrations/Cargo.toml
@@ -64,17 +64,18 @@ abstract-dex-standard = { version = "0.20.0" }
 abstract-staking-standard = { version = "0.20.0" }
 
 # TODO: REMOVE As soon as new dex-standard published
-# [patch.crates-io]
-# abstract-dex-standard = { path = "../framework/packages/standards/dex" }
-# abstract-adapter = { path = "../framework/packages/abstract-adapter" }
-# abstract-app = { path = "../framework/packages/abstract-app" }
-# abstract-interface = { path = "../framework/packages/abstract-interface" }
-# abstract-sdk = { path = "../framework/packages/abstract-sdk" }
-# abstract-testing = { path = "../framework/packages/abstract-testing" }
-# abstract-core = { path = "../framework/packages/abstract-core" }
-# abstract-macros = { path = "../framework/packages/abstract-macros" }
-# abstract-adapter-utils = { path = "../framework/packages/standards/utils" }
-# abstract-staking-standard = { path = "../framework/packages/standards/staking" }
+[patch.crates-io]
+cw-orch = { git = "https://github.com/AbstractSDK/cw-orchestrator", branch = "fix/savings-app-fixes" }
+abstract-dex-standard = { path = "../framework/packages/standards/dex" }
+abstract-adapter = { path = "../framework/packages/abstract-adapter" }
+abstract-app = { path = "../framework/packages/abstract-app" }
+abstract-interface = { path = "../framework/packages/abstract-interface" }
+abstract-sdk = { path = "../framework/packages/abstract-sdk" }
+abstract-testing = { path = "../framework/packages/abstract-testing" }
+abstract-core = { path = "../framework/packages/abstract-core" }
+abstract-macros = { path = "../framework/packages/abstract-macros" }
+abstract-adapter-utils = { path = "../framework/packages/standards/utils" }
+abstract-staking-standard = { path = "../framework/packages/standards/staking" }
 
 # Backup release profile, will result in warnings during optimization
 [profile.release]

--- a/integrations/Cargo.toml
+++ b/integrations/Cargo.toml
@@ -65,7 +65,7 @@ abstract-staking-standard = { version = "0.20.0" }
 
 # TODO: REMOVE As soon as new dex-standard published
 [patch.crates-io]
-cw-orch = { git = "https://github.com/AbstractSDK/cw-orchestrator", branch = "fix/savings-app-fixes" }
+# cw-orch = { git = "https://github.com/AbstractSDK/cw-orchestrator", branch = "fix/savings-app-fixes" }
 abstract-dex-standard = { path = "../framework/packages/standards/dex" }
 abstract-adapter = { path = "../framework/packages/abstract-adapter" }
 abstract-app = { path = "../framework/packages/abstract-app" }

--- a/integrations/astroport-adapter/src/staking.rs
+++ b/integrations/astroport-adapter/src/staking.rs
@@ -57,7 +57,7 @@ impl CwStakingCommand for Astroport {
         &mut self,
         deps: Deps,
         _env: Env,
-        _sender: Option<Addr>,
+        _addr_as_sender: Option<Addr>,
         ans_host: &AnsHost,
         _version_control_contract: VersionControlContract,
         lp_tokens: Vec<AssetEntry>,

--- a/integrations/astroport-adapter/src/staking.rs
+++ b/integrations/astroport-adapter/src/staking.rs
@@ -57,7 +57,7 @@ impl CwStakingCommand for Astroport {
         &mut self,
         deps: Deps,
         _env: Env,
-        _info: Option<cosmwasm_std::MessageInfo>,
+        _sender: Option<Addr>,
         ans_host: &AnsHost,
         _version_control_contract: VersionControlContract,
         lp_tokens: Vec<AssetEntry>,

--- a/integrations/astrovault-adapter/src/dex.rs
+++ b/integrations/astrovault-adapter/src/dex.rs
@@ -195,14 +195,14 @@ impl DexCommand for Astrovault {
     fn fetch_data(
         &mut self,
         deps: Deps,
-        sender: Addr,
+        addr_as_sender: Addr,
         _version_control_contract: VersionControlContract,
         ans_host: AnsHost,
         pool_id: UniquePoolId,
     ) -> Result<(), DexError> {
         let pool_metadata = ans_host.query_pool_metadata(&deps.querier, pool_id)?;
         self.pool_type = Some(pool_metadata.pool_type);
-        self.addr_as_sender = Some(sender);
+        self.addr_as_sender = Some(addr_as_sender);
         Ok(())
     }
 

--- a/integrations/astrovault-adapter/src/dex.rs
+++ b/integrations/astrovault-adapter/src/dex.rs
@@ -7,7 +7,7 @@ use crate::{ASTROVAULT, AVAILABLE_CHAINS};
 #[derive(Default)]
 pub struct Astrovault {
     pub pool_type: Option<PoolType>,
-    pub proxy_addr: Option<Addr>,
+    pub sender: Option<Addr>,
 }
 
 impl Identify for Astrovault {
@@ -202,7 +202,7 @@ impl DexCommand for Astrovault {
     ) -> Result<(), DexError> {
         let pool_metadata = ans_host.query_pool_metadata(&deps.querier, pool_id)?;
         self.pool_type = Some(pool_metadata.pool_type);
-        self.proxy_addr = Some(sender);
+        self.sender = Some(sender);
         Ok(())
     }
 
@@ -493,7 +493,7 @@ impl DexCommand for Astrovault {
                 ),
             )?,
             PoolType::Stable => {
-                let address = self.proxy_addr.clone().unwrap().into_string();
+                let address = self.sender.clone().unwrap().into_string();
                 let lp_addr = match &lp_token.info {
                     AssetInfoBase::Cw20(lp_addr) => lp_addr,
                     _ => unreachable!(),
@@ -710,7 +710,7 @@ mod tests {
             ARCHWAY_1.into(),
             Astrovault {
                 pool_type: Some(pool_type),
-                proxy_addr: Some(Addr::unchecked(
+                sender: Some(Addr::unchecked(
                     "archway1u76c96fgq9st8wme0f88w8hh57y78juy5cfm49",
                 )),
             },

--- a/integrations/astrovault-adapter/src/dex.rs
+++ b/integrations/astrovault-adapter/src/dex.rs
@@ -7,7 +7,7 @@ use crate::{ASTROVAULT, AVAILABLE_CHAINS};
 #[derive(Default)]
 pub struct Astrovault {
     pub pool_type: Option<PoolType>,
-    pub sender: Option<Addr>,
+    pub addr_as_sender: Option<Addr>,
 }
 
 impl Identify for Astrovault {
@@ -202,7 +202,7 @@ impl DexCommand for Astrovault {
     ) -> Result<(), DexError> {
         let pool_metadata = ans_host.query_pool_metadata(&deps.querier, pool_id)?;
         self.pool_type = Some(pool_metadata.pool_type);
-        self.sender = Some(sender);
+        self.addr_as_sender = Some(sender);
         Ok(())
     }
 
@@ -493,7 +493,7 @@ impl DexCommand for Astrovault {
                 ),
             )?,
             PoolType::Stable => {
-                let address = self.sender.clone().unwrap().into_string();
+                let address = self.addr_as_sender.clone().unwrap().into_string();
                 let lp_addr = match &lp_token.info {
                     AssetInfoBase::Cw20(lp_addr) => lp_addr,
                     _ => unreachable!(),
@@ -710,7 +710,7 @@ mod tests {
             ARCHWAY_1.into(),
             Astrovault {
                 pool_type: Some(pool_type),
-                sender: Some(Addr::unchecked(
+                addr_as_sender: Some(Addr::unchecked(
                     "archway1u76c96fgq9st8wme0f88w8hh57y78juy5cfm49",
                 )),
             },

--- a/integrations/astrovault-adapter/src/staking.rs
+++ b/integrations/astrovault-adapter/src/staking.rs
@@ -6,7 +6,7 @@ use crate::{ASTROVAULT, AVAILABLE_CHAINS};
 
 #[derive(Clone, Debug, Default)]
 pub struct Astrovault {
-    pub sender: Option<Addr>,
+    pub addr_as_sender: Option<Addr>,
     pub version_control_contract: Option<VersionControlContract>,
     pub tokens: Vec<AstrovaultTokenContext>,
 }
@@ -63,13 +63,13 @@ impl CwStakingCommand for Astrovault {
         &mut self,
         deps: Deps,
         _env: Env,
-        sender: Option<Addr>,
+        addr_as_sender: Option<Addr>,
         ans_host: &AnsHost,
         version_control_contract: VersionControlContract,
         lp_tokens: Vec<AssetEntry>,
     ) -> Result<(), CwStakingError> {
         self.version_control_contract = Some(version_control_contract);
-        self.sender = sender;
+        self.addr_as_sender = addr_as_sender;
         self.tokens = lp_tokens
             .into_iter()
             .map(|entry| {

--- a/integrations/astrovault-adapter/src/staking.rs
+++ b/integrations/astrovault-adapter/src/staking.rs
@@ -6,7 +6,7 @@ use crate::{ASTROVAULT, AVAILABLE_CHAINS};
 
 #[derive(Clone, Debug, Default)]
 pub struct Astrovault {
-    pub local_proxy_addr: Option<Addr>,
+    pub sender: Option<Addr>,
     pub version_control_contract: Option<VersionControlContract>,
     pub tokens: Vec<AstrovaultTokenContext>,
 }
@@ -35,7 +35,7 @@ use ::{
         core::objects::{AnsAsset, AssetEntry},
         feature_objects::AnsHost,
         features::AbstractRegistryAccess,
-        AccountVerification, Resolve,
+        Resolve,
     },
     abstract_staking_standard::msg::{
         Claim, RewardTokensResponse, StakeResponse, StakingInfo, StakingInfoResponse,
@@ -63,16 +63,13 @@ impl CwStakingCommand for Astrovault {
         &mut self,
         deps: Deps,
         _env: Env,
-        info: Option<cosmwasm_std::MessageInfo>,
+        sender: Option<Addr>,
         ans_host: &AnsHost,
         version_control_contract: VersionControlContract,
         lp_tokens: Vec<AssetEntry>,
     ) -> Result<(), CwStakingError> {
         self.version_control_contract = Some(version_control_contract);
-        let base = info
-            .map(|i| self.account_registry(deps)?.assert_manager(&i.sender))
-            .transpose()?;
-        self.local_proxy_addr = base.map(|b| b.proxy);
+        self.sender = sender;
         self.tokens = lp_tokens
             .into_iter()
             .map(|entry| {

--- a/integrations/bundles/wyndex/Cargo.toml
+++ b/integrations/bundles/wyndex/Cargo.toml
@@ -14,11 +14,6 @@ wyndex-pair = { git = "https://github.com/cosmorama/wynddex.git", tag = "v1.1.2"
 wyndex-stake = { git = "https://github.com/cosmorama/wynddex.git", tag = "v1.1.2" }
 wyndex = { git = "https://github.com/cosmorama/wynddex.git", tag = "v1.1.2" }
 cw-controllers = "1.0.1"
-# TODO: remove when we update cw-orch to 0.17
-cw-multi-test = { version = "0.16.5", features = [
-  "stargate",
-  "cosmwasm_1_3",
-], package = "abstract-cw-multi-test" }
 
 abstract-core = { workspace = true, features = ["interface"] }
 abstract-interface = { workspace = true, features = ["integration"] }

--- a/integrations/bundles/wyndex/src/lib.rs
+++ b/integrations/bundles/wyndex/src/lib.rs
@@ -12,7 +12,7 @@ use abstract_core::{
 use abstract_interface::{Abstract, AbstractInterfaceError};
 use cosmwasm_std::{coin, Addr, Decimal, Empty, Uint128};
 use cw20::Cw20Coin;
-use cw_orch::{deploy::Deploy, prelude::*};
+use cw_orch::prelude::*;
 use cw_plus_interface::cw20_base::Cw20Base as AbstractCw20Base;
 use wyndex::{
     asset::{AssetInfo, AssetInfoExt},

--- a/integrations/bundles/wyndex/src/suite.rs
+++ b/integrations/bundles/wyndex/src/suite.rs
@@ -5,9 +5,12 @@ use anyhow::Result as AnyResult;
 use cosmwasm_schema::serde::Serialize;
 use cosmwasm_std::{coin, to_json_binary, Addr, Coin, Decimal, Uint128};
 use cw20::{BalanceResponse, Cw20ExecuteMsg, Cw20QueryMsg};
-use cw_controllers::{Claim, ClaimsResponse};
-use cw_multi_test::{App, AppResponse, BankSudo, ContractWrapper, Executor, SudoMsg};
 use cw_orch::prelude::*;
+
+use cw_controllers::{Claim, ClaimsResponse};
+use cw_orch::mock::cw_multi_test::{
+    App, AppResponse, BankSudo, ContractWrapper, Executor, SudoMsg,
+};
 use wyndex::{
     asset::{Asset, AssetInfo, AssetInfoValidated},
     factory::{

--- a/integrations/bundles/wyndex/tests/abstract.rs
+++ b/integrations/bundles/wyndex/tests/abstract.rs
@@ -1,12 +1,8 @@
-use cosmwasm_std::Addr;
-
 mod abstrct {
     use abstract_interface::Abstract;
-    use cosmwasm_std::Empty;
-    use cw_orch::{deploy::Deploy, mock::Mock};
+    use cosmwasm_std::{Addr, Empty};
+    use cw_orch::prelude::*;
     use wyndex_bundle::{WynDex, WYNDEX_OWNER};
-
-    use super::*;
 
     #[test]
     fn deploy() {

--- a/integrations/kujira-adapter/src/staking.rs
+++ b/integrations/kujira-adapter/src/staking.rs
@@ -48,7 +48,7 @@ impl CwStakingCommand for Kujira {
         &mut self,
         deps: Deps,
         _env: Env,
-        _sender: Option<Addr>,
+        _addr_as_sender: Option<Addr>,
         ans_host: &AnsHost,
         _version_control_contract: VersionControlContract,
         lp_tokens: Vec<AssetEntry>,

--- a/integrations/kujira-adapter/src/staking.rs
+++ b/integrations/kujira-adapter/src/staking.rs
@@ -48,7 +48,7 @@ impl CwStakingCommand for Kujira {
         &mut self,
         deps: Deps,
         _env: Env,
-        _info: Option<cosmwasm_std::MessageInfo>,
+        _sender: Option<Addr>,
         ans_host: &AnsHost,
         _version_control_contract: VersionControlContract,
         lp_tokens: Vec<AssetEntry>,

--- a/integrations/osmosis-adapter/Cargo.toml
+++ b/integrations/osmosis-adapter/Cargo.toml
@@ -16,7 +16,7 @@ full_integration = [
 ]
 
 [dependencies]
-osmosis-std = { version = "=0.19.1", optional = true }
+osmosis-std = { version = "0.21.0", optional = true }
 
 cosmwasm-std = { workspace = true, features = ["stargate"] }
 abstract-staking-standard = { workspace = true }

--- a/integrations/osmosis-adapter/src/staking.rs
+++ b/integrations/osmosis-adapter/src/staking.rs
@@ -7,7 +7,7 @@ use crate::{AVAILABLE_CHAINS, OSMOSIS};
 #[derive(Default)]
 pub struct Osmosis {
     pub version_control_contract: Option<VersionControlContract>,
-    pub local_proxy_addr: Option<Addr>,
+    pub sender: Option<Addr>,
     pub tokens: Vec<OsmosisTokenContext>,
 }
 
@@ -34,8 +34,9 @@ pub mod fns {
             ans_host::AnsHost, AnsAsset, AnsEntryConvertor, AssetEntry, PoolReference, PoolType,
         },
         features::AbstractRegistryAccess,
-        AbstractSdkError, AccountVerification,
+        AbstractSdkError,
     };
+
     use abstract_staking_standard::{
         msg::{
             Claim, RewardTokensResponse, StakeResponse, StakingInfo, StakingInfoResponse,
@@ -45,9 +46,7 @@ pub mod fns {
     };
     // const FORTEEN_DAYS: i64 = 60 * 60 * 24 * 14;
     use cosmwasm_std::Env;
-    use cosmwasm_std::{
-        Coin, CosmosMsg, Deps, MessageInfo, QuerierWrapper, StdError, StdResult, Uint128,
-    };
+    use cosmwasm_std::{Coin, CosmosMsg, Deps, QuerierWrapper, StdError, StdResult, Uint128};
     use cw_asset::AssetInfoBase;
     use cw_utils::Expiration;
     use osmosis_std::{
@@ -142,18 +141,14 @@ pub mod fns {
             &mut self,
             deps: cosmwasm_std::Deps,
             _env: Env,
-            info: Option<MessageInfo>,
+            sender: Option<Addr>,
             ans_host: &AnsHost,
             version_control_contract: VersionControlContract,
             staking_assets: Vec<AssetEntry>,
         ) -> Result<(), CwStakingError> {
             self.version_control_contract = Some(version_control_contract);
-            let account_registry = self.account_registry(deps)?;
 
-            let base = info
-                .map(|i| account_registry.assert_manager(&i.sender))
-                .transpose()?;
-            self.local_proxy_addr = base.map(|b| b.proxy);
+            self.sender = sender;
 
             self.tokens =
                 self.query_pool_tokens_via_ans(&deps.querier, ans_host, staking_assets)?;
@@ -179,7 +174,7 @@ pub mod fns {
                 })
                 .collect();
             let lock_tokens_msg = MsgLockTokens {
-                owner: self.local_proxy_addr.as_ref().unwrap().to_string(),
+                owner: self.sender.as_ref().unwrap().to_string(),
                 duration: to_osmo_duration(unbonding_period)?,
                 coins: lock_coins,
             };
@@ -198,7 +193,7 @@ pub mod fns {
                 .zip(self.tokens.iter())
                 .map(|(unstake, token)| {
                     MsgBeginUnlocking {
-                        owner: self.local_proxy_addr.as_ref().unwrap().to_string(),
+                        owner: self.sender.as_ref().unwrap().to_string(),
                         id: token.pool_id,
                         coins: vec![Coin {
                             denom: token.lp_token.clone(),
@@ -216,7 +211,7 @@ pub mod fns {
         fn claim(&self, _deps: Deps) -> Result<Vec<CosmosMsg>, CwStakingError> {
             // Withdraw all
             let msg = MsgBeginUnlockingAll {
-                owner: self.local_proxy_addr.as_ref().unwrap().to_string(),
+                owner: self.sender.as_ref().unwrap().to_string(),
             };
             Ok(vec![msg.into()])
         }

--- a/integrations/wyndex-adapter/src/staking.rs
+++ b/integrations/wyndex-adapter/src/staking.rs
@@ -61,7 +61,7 @@ impl CwStakingCommand for WynDex {
         &mut self,
         deps: Deps,
         _env: cosmwasm_std::Env,
-        _info: Option<cosmwasm_std::MessageInfo>,
+        _sender: Option<Addr>,
         ans_host: &AnsHost,
         _version_control_contract: VersionControlContract,
         lp_tokens: Vec<AssetEntry>,

--- a/integrations/wyndex-adapter/src/staking.rs
+++ b/integrations/wyndex-adapter/src/staking.rs
@@ -61,7 +61,7 @@ impl CwStakingCommand for WynDex {
         &mut self,
         deps: Deps,
         _env: cosmwasm_std::Env,
-        _sender: Option<Addr>,
+        _addr_as_sender: Option<Addr>,
         ans_host: &AnsHost,
         _version_control_contract: VersionControlContract,
         lp_tokens: Vec<AssetEntry>,

--- a/modules/CHANGELOG.md
+++ b/modules/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   
 ### Changed
 
+- Generate message now accepts `sender` instead of `proxy_addr`, allowing use of non-abstract addresses
+
 ### Removed
 
 ### Fixed
+
+- Removed checks for manager in `fetch_data` for dex adapters, to allow using adapter requests by authorized addresses

--- a/modules/contracts/adapters/cw-staking/src/adapter.rs
+++ b/modules/contracts/adapters/cw-staking/src/adapter.rs
@@ -1,10 +1,12 @@
+use abstract_core::version_control::AccountBase;
+
 use abstract_sdk::{
     core::objects::AssetEntry,
     features::{AbstractNameService, AbstractRegistryAccess},
     Execution,
 };
 use abstract_staking_standard::{msg::StakingAction, CwStakingCommand, CwStakingError};
-use cosmwasm_std::{DepsMut, Env, MessageInfo, SubMsg};
+use cosmwasm_std::{DepsMut, Env, SubMsg};
 
 impl<T> CwStakingAdapter for T where T: AbstractNameService + AbstractRegistryAccess + Execution {}
 
@@ -17,7 +19,7 @@ pub trait CwStakingAdapter: AbstractNameService + AbstractRegistryAccess + Execu
         &self,
         deps: DepsMut,
         env: Env,
-        info: MessageInfo,
+        target_account: AccountBase,
         action: StakingAction,
         mut provider: Box<dyn CwStakingCommand>,
     ) -> Result<SubMsg, CwStakingError> {
@@ -26,7 +28,7 @@ pub trait CwStakingAdapter: AbstractNameService + AbstractRegistryAccess + Execu
         provider.fetch_data(
             deps.as_ref(),
             env,
-            Some(info),
+            Some(target_account.proxy),
             &self.ans_host(deps.as_ref())?,
             self.abstract_registry(deps.as_ref())?,
             staking_asset,

--- a/modules/contracts/adapters/cw-staking/src/handlers/execute.rs
+++ b/modules/contracts/adapters/cw-staking/src/handlers/execute.rs
@@ -1,9 +1,8 @@
-use abstract_core::{ibc::CallbackInfo, objects::chain_name::ChainName};
-use abstract_sdk::{
-    feature_objects::AnsHost,
-    features::{AbstractNameService, AbstractResponse},
-    IbcInterface, Resolve,
-};
+use abstract_core::ibc::CallbackInfo;
+use abstract_core::objects::chain_name::ChainName;
+use abstract_sdk::feature_objects::AnsHost;
+use abstract_sdk::features::{AbstractNameService, AbstractResponse, AccountIdentification};
+use abstract_sdk::{IbcInterface, Resolve};
 use abstract_staking_standard::msg::{
     ExecuteMsg, ProviderName, StakingAction, StakingExecuteMsg, IBC_STAKING_PROVIDER_ID,
 };
@@ -42,15 +41,22 @@ pub fn execute_handler(
 fn handle_local_request(
     deps: DepsMut,
     env: Env,
-    info: MessageInfo,
+    _info: MessageInfo,
     adapter: CwStakingContract,
     action: StakingAction,
     provider_name: String,
 ) -> StakingResult {
     let provider = resolver::resolve_local_provider(&provider_name)?;
+    let target_account = adapter.account_base(deps.as_ref())?;
     Ok(adapter
         .custom_response("handle_local_request", vec![("provider", provider_name)])
-        .add_submessage(adapter.resolve_staking_action(deps, env, info, action, provider)?))
+        .add_submessage(adapter.resolve_staking_action(
+            deps,
+            env,
+            target_account,
+            action,
+            provider,
+        )?))
 }
 
 /// Handle a request that needs to be executed on a remote chain

--- a/modules/contracts/adapters/dex/src/api.rs
+++ b/modules/contracts/adapters/dex/src/api.rs
@@ -115,7 +115,7 @@ impl<'a, T: DexInterface> Dex<'a, T> {
 
 impl<'a, T: DexInterface> Dex<'a, T> {
     /// Do a query in the DEX
-    fn query<R: DeserializeOwned>(&self, query_msg: DexQueryMsg) -> AbstractSdkResult<R> {
+    pub fn query<R: DeserializeOwned>(&self, query_msg: DexQueryMsg) -> AbstractSdkResult<R> {
         let adapters = self.base.adapters(self.deps);
         adapters.query(DEX_ADAPTER_ID, query_msg)
     }
@@ -153,7 +153,7 @@ impl<'a, T: DexInterface> Dex<'a, T> {
                     belief_price,
                 },
             },
-            proxy_addr: sender_receiver.into(),
+            sender: sender_receiver.into(),
         })?;
         Ok(response)
     }

--- a/modules/contracts/adapters/dex/src/api.rs
+++ b/modules/contracts/adapters/dex/src/api.rs
@@ -141,7 +141,7 @@ impl<'a, T: DexInterface> Dex<'a, T> {
         ask_asset: AssetEntry,
         max_spread: Option<Decimal>,
         belief_price: Option<Decimal>,
-        sender_receiver: impl Into<String>,
+        addr_as_sender: impl Into<String>,
     ) -> AbstractSdkResult<SimulateSwapResponse> {
         let response: SimulateSwapResponse = self.query(DexQueryMsg::GenerateMessages {
             message: DexExecuteMsg::Action {
@@ -153,7 +153,7 @@ impl<'a, T: DexInterface> Dex<'a, T> {
                     belief_price,
                 },
             },
-            sender: sender_receiver.into(),
+            addr_as_sender: addr_as_sender.into(),
         })?;
         Ok(response)
     }

--- a/modules/contracts/adapters/dex/src/handlers/query.rs
+++ b/modules/contracts/adapters/dex/src/handlers/query.rs
@@ -28,7 +28,10 @@ pub fn query_handler(
             ask_asset,
             dex,
         } => simulate_swap(deps, env, adapter, offer_asset, ask_asset, dex.unwrap()),
-        DexQueryMsg::GenerateMessages { message, sender } => {
+        DexQueryMsg::GenerateMessages {
+            message,
+            addr_as_sender,
+        } => {
             match message {
                 DexExecuteMsg::Action { dex, action } => {
                     let (local_dex_name, is_over_ibc) = is_over_ibc(env, &dex)?;
@@ -37,9 +40,13 @@ pub fn query_handler(
                         return Err(DexError::IbcMsgQuery);
                     }
                     let exchange = exchange_resolver::resolve_exchange(&local_dex_name)?;
-                    let sender = deps.api.addr_validate(&sender)?;
+                    let addr_as_sender = deps.api.addr_validate(&addr_as_sender)?;
                     let (messages, _) = crate::adapter::DexAdapter::resolve_dex_action(
-                        adapter, deps, sender, action, exchange,
+                        adapter,
+                        deps,
+                        addr_as_sender,
+                        action,
+                        exchange,
                     )?;
                     to_json_binary(&GenerateMessagesResponse { messages }).map_err(Into::into)
                 }

--- a/modules/contracts/adapters/dex/src/handlers/query.rs
+++ b/modules/contracts/adapters/dex/src/handlers/query.rs
@@ -28,10 +28,7 @@ pub fn query_handler(
             ask_asset,
             dex,
         } => simulate_swap(deps, env, adapter, offer_asset, ask_asset, dex.unwrap()),
-        DexQueryMsg::GenerateMessages {
-            message,
-            proxy_addr,
-        } => {
+        DexQueryMsg::GenerateMessages { message, sender } => {
             match message {
                 DexExecuteMsg::Action { dex, action } => {
                     let (local_dex_name, is_over_ibc) = is_over_ibc(env, &dex)?;
@@ -40,7 +37,7 @@ pub fn query_handler(
                         return Err(DexError::IbcMsgQuery);
                     }
                     let exchange = exchange_resolver::resolve_exchange(&local_dex_name)?;
-                    let sender = deps.api.addr_validate(&proxy_addr)?;
+                    let sender = deps.api.addr_validate(&sender)?;
                     let (messages, _) = crate::adapter::DexAdapter::resolve_dex_action(
                         adapter, deps, sender, action, exchange,
                     )?;

--- a/modules/contracts/adapters/dex/src/lib.rs
+++ b/modules/contracts/adapters/dex/src/lib.rs
@@ -7,7 +7,6 @@ pub mod state;
 pub mod msg {
     pub use abstract_dex_standard::msg::*;
 }
-
 pub use abstract_dex_standard::DEX_ADAPTER_ID;
 
 // Export interface for use in SDK modules
@@ -20,15 +19,18 @@ pub mod host_exchange {
 
 #[cfg(feature = "interface")]
 pub mod interface {
+    use crate::{contract::DEX_ADAPTER, msg::*, DEX_ADAPTER_ID};
     use abstract_core::{
         adapter::{self},
         objects::{AnsAsset, AssetEntry},
     };
-    use abstract_interface::{AbstractAccount, AbstractInterfaceError, AdapterDeployer};
+    use abstract_interface::{AbstractAccount, AbstractInterfaceError};
+    use abstract_interface::{AdapterDeployer, RegisteredModule};
+    use abstract_sdk::base::Handler;
+    use abstract_sdk::features::ModuleIdentification;
     use cosmwasm_std::{Decimal, Empty};
-    use cw_orch::{build::BuildPostfix, interface, prelude::*};
-
-    use crate::{msg::*, DEX_ADAPTER_ID};
+    use cw_orch::{build::BuildPostfix, interface};
+    use cw_orch::{contract::Contract, prelude::*};
 
     #[interface(InstantiateMsg, ExecuteMsg, QueryMsg, Empty)]
     pub struct DexAdapter<Chain>;
@@ -82,6 +84,39 @@ pub mod interface {
                 .manager
                 .execute_on_module(DEX_ADAPTER_ID, swap_msg)?;
             Ok(())
+        }
+    }
+
+    impl<Chain: CwEnv> RegisteredModule for DexAdapter<Chain> {
+        type InitMsg = <crate::contract::DexAdapter as Handler>::CustomInitMsg;
+
+        fn module_id<'a>() -> &'a str {
+            DEX_ADAPTER.module_id()
+        }
+
+        fn module_version<'a>() -> &'a str {
+            DEX_ADAPTER.version()
+        }
+    }
+
+    impl<Chain: CwEnv> From<Contract<Chain>> for DexAdapter<Chain> {
+        fn from(contract: Contract<Chain>) -> Self {
+            Self(contract)
+        }
+    }
+
+    impl<Chain: cw_orch::environment::CwEnv> abstract_interface::DependencyCreation
+        for DexAdapter<Chain>
+    {
+        type DependenciesConfig = cosmwasm_std::Empty;
+
+        fn dependency_install_configs(
+            _configuration: Self::DependenciesConfig,
+        ) -> Result<
+            Vec<abstract_core::manager::ModuleInstallConfig>,
+            abstract_interface::AbstractInterfaceError,
+        > {
+            Ok(vec![])
         }
     }
 }


### PR DESCRIPTION
This PR aims to remove check for manager in `fetch_data` to allow querying `generate_message` non-proxy accounts as well as executing actions by authorized addresses. Originated from #214
### Checklist

- [x] CI is green.
- [x] Changelog updated.
