### PR TITLE
install_app_with_dependencies on account builder

### DIFF
--- a/framework/packages/abstract-client/tests/integration.rs
+++ b/framework/packages/abstract-client/tests/integration.rs
@@ -1065,3 +1065,78 @@ fn auto_funds_work() -> anyhow::Result<()> {
     assert!(balance.is_zero());
     Ok(())
 }
+
+#[test]
+fn install_application_with_deps_on_account_builder() -> anyhow::Result<()> {
+    let client = AbstractClient::builder(Mock::new(&Addr::unchecked(OWNER))).build()?;
+
+    let app_publisher: Publisher<Mock> = client
+        .publisher_builder(Namespace::new(TEST_WITH_DEP_NAMESPACE)?)
+        .build()?;
+
+    let app_dependency_publisher: Publisher<Mock> = client
+        .publisher_builder(Namespace::new(TEST_NAMESPACE)?)
+        .build()?;
+
+    // Publish apps
+    app_dependency_publisher.publish_app::<MockAppI<Mock>>()?;
+    app_publisher.publish_app::<MockAppWithDepI<Mock>>()?;
+
+    let account = client
+        .account_builder()
+        .install_app_with_dependencies::<MockAppWithDepI<Mock>>(&MockInitMsg {}, Empty {})?
+        .build()?;
+
+    let modules = account.module_infos()?.module_infos;
+
+    // Check dependency
+    let dep_app = account.application::<MockAppI<_>>()?;
+    let something = dep_app.get_something()?;
+    assert_eq!(MockQueryResponse {}, something);
+
+    let app_info = modules
+        .iter()
+        .find(|module| module.id == MockAppI::<Mock>::module_id())
+        .expect("Dependency of an application not found");
+
+    assert_eq!(
+        *app_info,
+        ManagerModuleInfo {
+            id: MockAppI::<Mock>::module_id().to_owned(),
+            version: cw2::ContractVersion {
+                contract: MockAppI::<Mock>::module_id().to_owned(),
+                version: MockAppI::<Mock>::module_version().to_owned()
+            },
+            address: dep_app.address()?,
+        }
+    );
+
+    // Check app itself
+    let my_app = account.application::<MockAppWithDepI<_>>()?;
+
+    my_app
+        .call_as(&app_publisher.account().manager()?)
+        .do_something()?;
+
+    let something = my_app.get_something()?;
+
+    assert_eq!(MockQueryResponse {}, something);
+
+    let app_info = modules
+        .iter()
+        .find(|module| module.id == MockAppWithDepI::<Mock>::module_id())
+        .expect("Application not found");
+
+    assert_eq!(
+        *app_info,
+        ManagerModuleInfo {
+            id: MockAppWithDepI::<Mock>::module_id().to_owned(),
+            version: cw2::ContractVersion {
+                contract: MockAppWithDepI::<Mock>::module_id().to_owned(),
+                version: MockAppWithDepI::<Mock>::module_version().to_owned()
+            },
+            address: my_app.address()?,
+        }
+    );
+    Ok(())
+}


### PR DESCRIPTION
Added install app with depdendencies on AccountBuilder. Also cleaned some redundant trait bounds
### Checklist

- [ ] CI is green.
- [x] Changelog updated. (`- Installing apps and adapters for AbstractClient Account builder` is in the same patch, so I won't add new item)
