### PR TITLE
Switch framework coverage to use circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,14 @@ workflows:
     when:
       equal: ["modules_coverage", << pipeline.parameters.GHA_Meta >>]
     jobs:
-      - coverage
+      - modules-coverage
+
+  framework-coverage:
+    when:
+      equal: ["framework_coverage", << pipeline.parameters.GHA_Meta >>]
+    jobs:
+      - framework-coverage
+
 
   modules-tests:
     when:
@@ -207,7 +214,7 @@ jobs:
             - framework/target/debug/deps
           key: cargocache-v2-deploy-rust:1.72.0-{{ checksum "framework/Cargo.lock" }}
 
-  coverage:
+  modules-coverage:
     docker:
       - image: cimg/rust:1.72.0
     resource_class: xlarge
@@ -238,6 +245,39 @@ jobs:
             - modules/target/debug/build
             - modules/target/debug/deps
           key: cargocache-v2-deploy-rust:1.72.0-{{ checksum "modules/Cargo.lock" }}
+
+  framework-coverage:
+    docker:
+      - image: cimg/rust:1.72.0
+    resource_class: xlarge
+    steps:
+      - setup_remote_docker:
+          version: 20.10.14
+      - checkout
+      - run:
+          name: Generate lockfile
+          command: |
+            set -e
+            if [ ! -f framework/Cargo.lock ]; then
+              (cd framework ; cargo generate-lockfile)
+            fi
+      - restore_cache:
+          keys:
+            - cargocache-v2-coverage-rust:1.72.0-{{ checksum "framework/Cargo.lock" }}
+      - run:
+          name: Run tests with coverage for framework
+          command: |
+            ./scripts/framework-coverage.sh
+      - codecov/upload:
+          file: ./framework/lcov.info
+      - save_cache:
+          paths:
+            - ~/.cargo/registry
+            - framework/target/debug/.fingerprint
+            - framework/target/debug/build
+            - framework/target/debug/deps
+          key: cargocache-v2-deploy-rust:1.72.0-{{ checksum "framework/Cargo.lock" }}
+
 
   pass:
     docker:

--- a/.github/workflows/framework-test.yml
+++ b/.github/workflows/framework-test.yml
@@ -44,36 +44,23 @@ jobs:
       - name: cargo test --locked
         working-directory: ./framework
         run: cargo test --locked --all-features --all-targets
+
   coverage:
     runs-on: ubuntu-latest
-    name: ubuntu / stable / coverage
     steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: true
-      - uses: webfactory/ssh-agent@v0.8.0
-        with:
-          ssh-private-key: |
-            ${{ secrets.SSH_PRIVATE_KEY_MULTI_TEST }}
-            ${{ secrets.SSH_PRIVATE_KEY_CW_ORCH_INTERCHAIN }}
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.3
-        with:
-          version: "v0.4.2"
-      - name: Install stable
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: llvm-tools-preview
-      - name: cargo install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
-      - name: cargo generate-lockfile
-        if: hashFiles('Cargo.lock') == ''
-        working-directory: ./framework
-        run: cargo generate-lockfile
-      - name: cargo llvm-cov
-        working-directory: ./framework
-        run: cargo llvm-cov --locked --all-features --lcov --output-path lcov.info
-      - name: Upload to codecov.io
-        uses: codecov/codecov-action@v3
-        with:
-          fail_ci_if_error: true
+      - name: tickle coverage
+        env:
+          CCI_TOKEN: ${{ secrets.CCI_TOKEN }}
+          CIRCLE_BRANCH: ${{ github.head_ref }}
+        run: |
+          echo $CIRCLE_BRANCH;
+          curl -X POST \
+          -H "Circle-Token: ${CCI_TOKEN}" \
+          -H 'Content-Type: application/json' \
+          -H 'Accept: application/json' \
+          -d "{
+            \"branch\": \"${CIRCLE_BRANCH}\",
+            \"parameters\": {
+              \"GHA_Meta\": \"framework_coverage\"
+            }
+          }" https://circleci.com/api/v2/project/gh/AbstractSDK/abstract/pipeline

--- a/scripts/framework-coverage.sh
+++ b/scripts/framework-coverage.sh
@@ -1,0 +1,18 @@
+# go into the directory we want to compile
+cd ./framework
+
+# Install cargo-llvm-cov for coverage generation
+# Get host target
+host=$(rustc -Vv | grep host | sed 's/host: //')
+# # Download binary and install to $HOME/.cargo/bin
+curl -LsSf https://github.com/taiki-e/cargo-llvm-cov/releases/latest/download/cargo-llvm-cov-$host.tar.gz | tar xzf - -C $HOME/.cargo/bin
+
+# Create lock file if it does not exist
+if [ ! -f Cargo.lock ]; then
+  cargo generate-lockfile
+fi
+
+cargo llvm-cov --locked --lcov --output-path lcov.info
+
+# print the result.
+ls -la .


### PR DESCRIPTION
See title. 
This is required because the github runners have too little resources.

### Checklist

- [ ] CI is green.
- [ ] Changelog updated.
