### PR TITLE
Create sub accounts with expected account + Abstract Client updates for expected account_id 

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `unchecked_account_id` method on version control.
 - Ability to provide expected local AccountId
 - Reinstallation of the same version of an app is now disabled
+- Added method to assign expected `.account_id` for Abstract Client Account builder
+- `.next_local_account_id` for `AbstractClient` to query next local account sequence
 
 ### Changed
 

--- a/framework/contracts/account/manager/src/commands.rs
+++ b/framework/contracts/account/manager/src/commands.rs
@@ -278,6 +278,7 @@ pub fn create_sub_account(
     base_asset: Option<AssetEntry>,
     namespace: Option<String>,
     install_modules: Vec<ModuleInstallConfig>,
+    account_id: Option<u32>,
 ) -> ManagerResult {
     // only owner can create a subaccount
     assert_admin_right(deps.as_ref(), &msg_info.sender)?;
@@ -294,7 +295,7 @@ pub fn create_sub_account(
         base_asset,
         namespace,
         install_modules,
-        account_id: None,
+        account_id: account_id.map(AccountId::local),
     };
 
     let account_factory_addr = query_module(

--- a/framework/contracts/account/manager/src/contract.rs
+++ b/framework/contracts/account/manager/src/contract.rs
@@ -167,6 +167,7 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> M
                     base_asset,
                     namespace,
                     install_modules,
+                    account_id,
                 } => create_sub_account(
                     deps,
                     info,
@@ -177,6 +178,7 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> M
                     base_asset,
                     namespace,
                     install_modules,
+                    account_id,
                 ),
                 ExecuteMsg::Upgrade { modules } => upgrade_modules(deps, env, info, modules),
                 ExecuteMsg::UpdateInfo {

--- a/framework/contracts/account/manager/tests/adapters.rs
+++ b/framework/contracts/account/manager/tests/adapters.rs
@@ -528,6 +528,7 @@ fn subaccount_adapter_ownership() -> AResult {
         None,
         None,
         None,
+        None,
         &[],
     )?;
 

--- a/framework/contracts/account/manager/tests/apps.rs
+++ b/framework/contracts/account/manager/tests/apps.rs
@@ -143,6 +143,7 @@ fn subaccount_app_ownership() -> AResult {
         None,
         None,
         None,
+        None,
         &[],
     )?;
 

--- a/framework/contracts/account/manager/tests/proxy.rs
+++ b/framework/contracts/account/manager/tests/proxy.rs
@@ -372,6 +372,7 @@ fn renounce_cleans_namespace() -> AResult {
             namespace: Some("bar".to_owned()),
             base_asset: None,
             install_modules: vec![],
+            account_id: None,
         },
         GovernanceDetails::Monarchy {
             monarch: sender.to_string(),

--- a/framework/contracts/account/manager/tests/subaccount.rs
+++ b/framework/contracts/account/manager/tests/subaccount.rs
@@ -23,6 +23,7 @@ fn creating_on_subaccount_should_succeed() -> AResult {
         None,
         None,
         None,
+        None,
         &[],
     )?;
     let sub_accounts = account.manager.sub_account_ids(None, None)?;
@@ -46,6 +47,7 @@ fn updating_on_subaccount_should_succeed() -> AResult {
     account.manager.create_sub_account(
         vec![],
         "My subaccount".to_string(),
+        None,
         None,
         None,
         None,
@@ -78,6 +80,7 @@ fn proxy_updating_on_subaccount_should_succeed() -> AResult {
     account.manager.create_sub_account(
         vec![],
         "My subaccount".to_string(),
+        None,
         None,
         None,
         None,
@@ -116,6 +119,7 @@ fn recursive_updating_on_subaccount_should_succeed() -> AResult {
         None,
         None,
         None,
+        None,
         &[],
     )?;
 
@@ -126,6 +130,7 @@ fn recursive_updating_on_subaccount_should_succeed() -> AResult {
     account_contracts.0.create_sub_account(
         vec![],
         "My subsubaccount".to_string(),
+        None,
         None,
         None,
         None,
@@ -158,6 +163,7 @@ fn installed_app_updating_on_subaccount_should_succeed() -> AResult {
     account.manager.create_sub_account(
         vec![],
         "My subaccount".to_string(),
+        None,
         None,
         None,
         None,
@@ -217,6 +223,7 @@ fn sub_account_move_ownership() -> AResult {
     account.manager.create_sub_account(
         vec![],
         "My subaccount".to_string(),
+        None,
         None,
         None,
         None,
@@ -297,6 +304,7 @@ fn sub_account_move_ownership_to_sub_account() -> AResult {
         None,
         None,
         None,
+        None,
         &[],
     )?;
     let sub_account = AbstractAccount::new(&deployment, AccountId::local(2));
@@ -307,6 +315,7 @@ fn sub_account_move_ownership_to_sub_account() -> AResult {
     new_account.manager.create_sub_account(
         vec![],
         "My second subaccount".to_string(),
+        None,
         None,
         None,
         None,
@@ -373,6 +382,7 @@ fn account_move_ownership_to_falsy_sub_account() -> AResult {
     account.manager.create_sub_account(
         vec![],
         "My subaccount".to_string(),
+        None,
         None,
         None,
         None,
@@ -488,6 +498,7 @@ fn top_level_owner() -> AResult {
         None,
         None,
         None,
+        None,
         &[],
     )?;
     let response = account.manager.sub_account_ids(None, None)?;
@@ -509,6 +520,7 @@ fn cant_renounce_with_sub_accounts() -> AResult {
     account.manager.create_sub_account(
         vec![],
         "My subaccount".to_string(),
+        None,
         None,
         None,
         None,
@@ -537,6 +549,7 @@ fn can_renounce_sub_accounts() -> AResult {
     account.manager.create_sub_account(
         vec![],
         "My subaccount".to_string(),
+        None,
         None,
         None,
         None,

--- a/framework/contracts/account/manager/tests/upgrades.rs
+++ b/framework/contracts/account/manager/tests/upgrades.rs
@@ -401,6 +401,7 @@ fn create_account_with_installed_module() -> AResult {
             namespace: Some(String::from(TEST_NAMESPACE)),
             base_asset: None,
             install_modules: vec![],
+            account_id: None,
         },
         GovernanceDetails::Monarchy {
             monarch: sender.to_string(),
@@ -440,6 +441,7 @@ fn create_account_with_installed_module() -> AResult {
                         Some(to_json_binary(&MockInitMsg {})?),
                     ),
                 ],
+                account_id: None,
             },
             GovernanceDetails::Monarchy {
                 monarch: sender.to_string(),
@@ -502,6 +504,7 @@ fn create_account_with_installed_module_and_monetization() -> AResult {
             namespace: Some(String::from(TEST_NAMESPACE)),
             base_asset: None,
             install_modules: vec![],
+            account_id: None,
         },
         GovernanceDetails::Monarchy {
             monarch: sender.to_string(),
@@ -590,6 +593,7 @@ fn create_account_with_installed_module_and_monetization() -> AResult {
                         Some(to_json_binary(&MockInitMsg {})?),
                     ),
                 ],
+                account_id: None,
             },
             GovernanceDetails::Monarchy {
                 monarch: sender.to_string(),
@@ -646,6 +650,7 @@ fn create_account_with_installed_module_and_monetization_should_fail() -> AResul
             namespace: Some(String::from(TEST_NAMESPACE)),
             base_asset: None,
             install_modules: vec![],
+            account_id: None,
         },
         GovernanceDetails::Monarchy {
             monarch: sender.to_string(),
@@ -723,6 +728,7 @@ fn create_account_with_installed_module_and_monetization_should_fail() -> AResul
                     Some(to_json_binary(&MockInitMsg {})?),
                 ),
             ],
+            account_id: None,
         },
         GovernanceDetails::Monarchy {
             monarch: sender.to_string(),
@@ -761,6 +767,7 @@ fn create_account_with_installed_module_and_init_funds() -> AResult {
             namespace: Some(String::from(TEST_NAMESPACE)),
             base_asset: None,
             install_modules: vec![],
+            account_id: None,
         },
         GovernanceDetails::Monarchy {
             monarch: sender.to_string(),
@@ -872,6 +879,7 @@ fn create_account_with_installed_module_and_init_funds() -> AResult {
                         Some(to_json_binary(&MockInitMsg {})?),
                     ),
                 ],
+                account_id: None,
             },
             GovernanceDetails::Monarchy {
                 monarch: sender.to_string(),

--- a/framework/contracts/native/account-factory/tests/create_account.rs
+++ b/framework/contracts/native/account-factory/tests/create_account.rs
@@ -292,6 +292,7 @@ fn create_one_account_with_base_asset() -> AResult {
             namespace: None,
             base_asset: Some(AssetEntry::new(asset_name)),
             install_modules: vec![],
+            account_id: None,
         },
         GovernanceDetails::Monarchy {
             monarch: sender.to_string(),

--- a/framework/packages/abstract-client/src/account.rs
+++ b/framework/packages/abstract-client/src/account.rs
@@ -84,6 +84,7 @@ pub struct AccountBuilder<'a, Chain: CwEnv> {
     funds: AccountCreationFunds,
     fetch_if_namespace_claimed: bool,
     install_on_sub_account: bool,
+    expected_local_account_id: Option<u32>,
 }
 
 /// Creation funds
@@ -108,6 +109,7 @@ impl<'a, Chain: CwEnv> AccountBuilder<'a, Chain> {
             funds: AccountCreationFunds::Coins(Coins::default()),
             fetch_if_namespace_claimed: true,
             install_on_sub_account: true,
+            expected_local_account_id: None,
         }
     }
 
@@ -231,6 +233,13 @@ impl<'a, Chain: CwEnv> AccountBuilder<'a, Chain> {
         Ok(self)
     }
 
+    /// Assign expected local account_id on creation.
+    /// The tx will error if this does not match the account-id at runtime. Useful for instantiate2 address prediction.
+    pub fn account_id(&mut self, local_account_id: u32) -> &mut Self {
+        self.expected_local_account_id = Some(local_account_id);
+        self
+    }
+
     /// Builds the [`Account`].
     pub fn build(&self) -> AbstractClientResult<Account<Chain>> {
         if self.fetch_if_namespace_claimed {
@@ -306,6 +315,7 @@ impl<'a, Chain: CwEnv> AccountBuilder<'a, Chain> {
             namespace: self.namespace.as_ref().map(ToString::to_string),
             base_asset: self.base_asset.clone(),
             install_modules,
+            account_id: self.expected_local_account_id,
         };
         let abstract_account = if let Some(owner_account) = self.owner_account {
             owner_account
@@ -675,6 +685,7 @@ impl<Chain: CwEnv> Account<Chain> {
         let sub_account_response = self.abstr_account.manager.create_sub_account(
             modules,
             "Sub Account".to_owned(),
+            None,
             None,
             None,
             None,

--- a/framework/packages/abstract-client/src/client.rs
+++ b/framework/packages/abstract-client/src/client.rs
@@ -29,7 +29,7 @@
 //! ```
 
 use abstract_core::objects::{namespace::Namespace, AccountId};
-use abstract_interface::{Abstract, AbstractAccount, AnsHost, ManagerQueryFns, VersionControl};
+use abstract_interface::{Abstract, AbstractAccount, AccountFactoryQueryFns, AnsHost, ManagerQueryFns, VersionControl};
 use cosmwasm_std::{Addr, BlockInfo, Coin, Empty, Uint128};
 use cw_orch::{
     contract::interface_traits::ContractInstance, deploy::Deploy, prelude::CwEnv,
@@ -273,6 +273,12 @@ impl<Chain: CwEnv> AbstractClient<Chain> {
             }
         }
         Ok(last_account.map(|(_, account)| account))
+    }
+
+    /// Get next local account id sequence
+    pub fn next_local_account_id(&self) -> AbstractClientResult<u32> {
+        let sequence = self.abstr.account_factory.config()?.local_account_sequence;
+        Ok(sequence)
     }
 }
 

--- a/framework/packages/abstract-client/src/client.rs
+++ b/framework/packages/abstract-client/src/client.rs
@@ -29,7 +29,9 @@
 //! ```
 
 use abstract_core::objects::{namespace::Namespace, AccountId};
-use abstract_interface::{Abstract, AbstractAccount, AccountFactoryQueryFns, AnsHost, ManagerQueryFns, VersionControl};
+use abstract_interface::{
+    Abstract, AbstractAccount, AccountFactoryQueryFns, AnsHost, ManagerQueryFns, VersionControl,
+};
 use cosmwasm_std::{Addr, BlockInfo, Coin, Empty, Uint128};
 use cw_orch::{
     contract::interface_traits::ContractInstance, deploy::Deploy, prelude::CwEnv,

--- a/framework/packages/abstract-client/tests/integration.rs
+++ b/framework/packages/abstract-client/tests/integration.rs
@@ -1140,3 +1140,59 @@ fn install_application_with_deps_on_account_builder() -> anyhow::Result<()> {
     );
     Ok(())
 }
+
+#[test]
+fn create_account_with_expected_account_id() -> anyhow::Result<()> {
+    let chain = Mock::new(&Addr::unchecked(OWNER));
+    let client = AbstractClient::builder(chain).build()?;
+
+    // Check it fails on wrong account_id
+    let next_id = client.next_local_account_id()?;
+    let err = client.account_builder().account_id(10).build().unwrap_err();
+    let AbstractClientError::Interface(abstract_interface::AbstractInterfaceError::Orch(err)) = err
+    else {
+        panic!("Expected cw-orch error")
+    };
+    let err: account_factory::error::AccountFactoryError = err.downcast().unwrap();
+    assert_eq!(
+        err,
+        account_factory::error::AccountFactoryError::ExpectedAccountIdFailed {
+            predicted: AccountId::local(10),
+            actual: AccountId::local(next_id)
+        }
+    );
+
+    // Can create if right id
+    let account = client.account_builder().account_id(next_id).build()?;
+
+    // Check it fails on wrong account_id for sub-accounts
+    let next_id = client.next_local_account_id()?;
+    let err = client
+        .account_builder()
+        .sub_account(&account)
+        .account_id(0)
+        .build()
+        .unwrap_err();
+    let AbstractClientError::Interface(abstract_interface::AbstractInterfaceError::Orch(err)) = err
+    else {
+        panic!("Expected cw-orch error")
+    };
+    let err: account_factory::error::AccountFactoryError = err.downcast().unwrap();
+    assert_eq!(
+        err,
+        account_factory::error::AccountFactoryError::ExpectedAccountIdFailed {
+            predicted: AccountId::local(0),
+            actual: AccountId::local(next_id)
+        }
+    );
+
+    // Can create sub-account if right id
+    let sub_account = client
+        .account_builder()
+        .sub_account(&account)
+        .account_id(next_id)
+        .build()?;
+    let sub_accounts = account.sub_accounts()?;
+    assert_eq!(sub_accounts[0].id()?, sub_account.id()?);
+    Ok(())
+}

--- a/framework/packages/abstract-core/src/core/manager.rs
+++ b/framework/packages/abstract-core/src/core/manager.rs
@@ -212,6 +212,10 @@ pub enum ExecuteMsg {
         namespace: Option<String>,
         // Provide list of module to install after sub-account creation
         install_modules: Vec<ModuleInstallConfig>,
+        /// If `None`, will create a new local account without asserting account-id.
+        ///
+        /// When provided: Signals the expected local Account Id. The tx will error if this does not match the account-id at runtime. Useful for instantiate2 address prediction.
+        account_id: Option<u32>,
     },
     /// Update info
     UpdateInfo {

--- a/framework/packages/abstract-integration-tests/src/account_factory.rs
+++ b/framework/packages/abstract-integration-tests/src/account_factory.rs
@@ -57,6 +57,7 @@ pub fn create_one_account_with_namespace_fee<T: MutCwEnv>(mut chain: T) -> AResu
             namespace: Some(namespace_to_claim.to_string()),
             base_asset: None,
             install_modules: vec![],
+            account_id: None,
         },
         GovernanceDetails::Monarchy {
             monarch: sender.to_string(),

--- a/framework/packages/abstract-integration-tests/src/manager.rs
+++ b/framework/packages/abstract-integration-tests/src/manager.rs
@@ -72,6 +72,7 @@ pub fn create_sub_account_with_modules_installed<T: CwEnv>(chain: T) -> AResult 
             namespace: Some(String::from(TEST_NAMESPACE)),
             base_asset: None,
             install_modules: vec![],
+            account_id: None,
         },
         GovernanceDetails::Monarchy {
             monarch: sender.to_string(),
@@ -102,6 +103,7 @@ pub fn create_sub_account_with_modules_installed<T: CwEnv>(chain: T) -> AResult 
             ),
         ],
         String::from("sub_account"),
+        None,
         None,
         Some(String::from("account_description")),
         None,
@@ -163,6 +165,7 @@ pub fn create_account_with_installed_module_monetization_and_init_funds<T: MutCw
             namespace: Some(String::from(TEST_NAMESPACE)),
             base_asset: None,
             install_modules: vec![],
+            account_id: None,
         },
         GovernanceDetails::Monarchy {
             monarch: sender.to_string(),
@@ -273,6 +276,7 @@ pub fn create_account_with_installed_module_monetization_and_init_funds<T: MutCw
                         Some(to_json_binary(&MockInitMsg {})?),
                     ),
                 ],
+                account_id: None,
             },
             GovernanceDetails::Monarchy {
                 monarch: sender.to_string(),
@@ -480,6 +484,7 @@ pub fn account_move_ownership_to_sub_account<T: CwEnv<Sender = Addr>>(chain: T) 
     account.manager.create_sub_account(
         vec![],
         "My subaccount".to_string(),
+        None,
         None,
         None,
         None,

--- a/framework/packages/abstract-interface/src/account/mod.rs
+++ b/framework/packages/abstract-interface/src/account/mod.rs
@@ -202,6 +202,7 @@ impl<Chain: CwEnv> AbstractAccount<Chain> {
             namespace,
             base_asset,
             install_modules,
+            account_id,
         } = account_details;
 
         let result = self.manager.execute(
@@ -212,6 +213,7 @@ impl<Chain: CwEnv> AbstractAccount<Chain> {
                 base_asset,
                 namespace,
                 install_modules,
+                account_id,
             },
             funds,
         )?;

--- a/framework/packages/abstract-interface/src/native/account_factory.rs
+++ b/framework/packages/abstract-interface/src/native/account_factory.rs
@@ -4,7 +4,7 @@ pub use abstract_core::account_factory::{
 use abstract_core::{
     account_factory::*,
     manager::ModuleInstallConfig,
-    objects::{gov_type::GovernanceDetails, AssetEntry},
+    objects::{gov_type::GovernanceDetails, AccountId, AssetEntry},
 };
 use cw_orch::{interface, prelude::*};
 
@@ -19,6 +19,7 @@ pub struct AccountDetails {
     pub namespace: Option<String>,
     pub base_asset: Option<AssetEntry>,
     pub install_modules: Vec<ModuleInstallConfig>,
+    pub account_id: Option<u32>,
 }
 
 #[interface(InstantiateMsg, ExecuteMsg, QueryMsg, MigrateMsg)]
@@ -60,6 +61,7 @@ impl<Chain: CwEnv> AccountFactory<Chain> {
             namespace,
             base_asset,
             install_modules,
+            account_id,
         } = account_details;
 
         let result = self.execute(
@@ -68,7 +70,7 @@ impl<Chain: CwEnv> AccountFactory<Chain> {
                 name,
                 link,
                 description,
-                account_id: None,
+                account_id: account_id.map(AccountId::local),
                 namespace,
                 base_asset,
                 install_modules,


### PR DESCRIPTION
This PR adds:
- Added expected `account_id` field for `create_sub_account` action
- `account_id` for AbstractClient account builder
- `next_account_id` for AbstractClient account builder
### Checklist

- [x] CI is green.
- [x] Changelog updated.
