### PR TITLE
Removed custom Error on cw-staking and dex adapters

### DIFF
--- a/framework/packages/standards/dex/src/command.rs
+++ b/framework/packages/standards/dex/src/command.rs
@@ -1,5 +1,3 @@
-use std::error::Error;
-
 use abstract_adapter_utils::identity::Identify;
 use abstract_core::objects::{DexAssetPairing, PoolAddress, PoolReference, UniquePoolId};
 use abstract_sdk::{
@@ -20,7 +18,7 @@ pub type FeeOnInput = bool;
 /// ensures DEX adapters support the expected functionality.
 ///
 /// Implements the usual DEX operations.
-pub trait DexCommand<E: Error = DexError>: Identify {
+pub trait DexCommand: Identify {
     /// Return pool information for given assets pair
     fn pool_reference(
         &self,
@@ -57,7 +55,7 @@ pub trait DexCommand<E: Error = DexError>: Identify {
         ask_asset: AssetInfo,
         belief_price: Option<Decimal>,
         max_spread: Option<Decimal>,
-    ) -> Result<Vec<CosmosMsg>, E>;
+    ) -> Result<Vec<CosmosMsg>, DexError>;
 
     /// Implement your custom swap the DEX
     fn custom_swap(
@@ -78,7 +76,7 @@ pub trait DexCommand<E: Error = DexError>: Identify {
         pool_id: PoolAddress,
         offer_assets: Vec<Asset>,
         max_spread: Option<Decimal>,
-    ) -> Result<Vec<CosmosMsg>, E>;
+    ) -> Result<Vec<CosmosMsg>, DexError>;
 
     /// Provide symmetric liquidity where available depending on the DEX
     fn provide_liquidity_symmetric(
@@ -87,7 +85,7 @@ pub trait DexCommand<E: Error = DexError>: Identify {
         pool_id: PoolAddress,
         offer_asset: Asset,
         paired_assets: Vec<AssetInfo>,
-    ) -> Result<Vec<CosmosMsg>, E>;
+    ) -> Result<Vec<CosmosMsg>, DexError>;
 
     /// Withdraw liquidity from DEX
     fn withdraw_liquidity(
@@ -95,7 +93,7 @@ pub trait DexCommand<E: Error = DexError>: Identify {
         deps: Deps,
         pool_id: PoolAddress,
         lp_token: Asset,
-    ) -> Result<Vec<CosmosMsg>, E>;
+    ) -> Result<Vec<CosmosMsg>, DexError>;
 
     /// Simulate a swap in the DEX
     fn simulate_swap(
@@ -104,7 +102,7 @@ pub trait DexCommand<E: Error = DexError>: Identify {
         pool_id: PoolAddress,
         offer_asset: Asset,
         ask_asset: AssetInfo,
-    ) -> Result<(Return, Spread, Fee, FeeOnInput), E>;
+    ) -> Result<(Return, Spread, Fee, FeeOnInput), DexError>;
 
     /// Fetch data for execute methods
     fn fetch_data(

--- a/framework/packages/standards/staking/src/command.rs
+++ b/framework/packages/standards/staking/src/command.rs
@@ -1,5 +1,3 @@
-use std::error::Error;
-
 use abstract_core::objects::AnsAsset;
 use abstract_sdk::{
     core::objects::{AssetEntry, ContractEntry},
@@ -13,7 +11,7 @@ use crate::{
 };
 
 /// Trait that defines the staking commands for providers
-pub trait CwStakingCommand<E: Error = CwStakingError>: Identify {
+pub trait CwStakingCommand: Identify {
     /// Construct a staking contract entry from the staking token and the provider
     fn staking_entry(&self, staking_token: &AssetEntry) -> ContractEntry {
         ContractEntry {
@@ -53,7 +51,7 @@ pub trait CwStakingCommand<E: Error = CwStakingError>: Identify {
         deps: Deps,
         stake_request: Vec<AnsAsset>,
         unbonding_period: Option<cw_utils::Duration>,
-    ) -> Result<Vec<CosmosMsg>, E>;
+    ) -> Result<Vec<CosmosMsg>, CwStakingError>;
 
     /// Unstake the provided asset from the staking contract
     fn unstake(
@@ -61,16 +59,16 @@ pub trait CwStakingCommand<E: Error = CwStakingError>: Identify {
         deps: Deps,
         unstake_request: Vec<AnsAsset>,
         unbonding_period: Option<cw_utils::Duration>,
-    ) -> Result<Vec<CosmosMsg>, E>;
+    ) -> Result<Vec<CosmosMsg>, CwStakingError>;
 
     /// Claim rewards on the staking contract
-    fn claim_rewards(&self, deps: Deps) -> Result<Vec<CosmosMsg>, E>;
+    fn claim_rewards(&self, deps: Deps) -> Result<Vec<CosmosMsg>, CwStakingError>;
 
     /// Claim matured unbonding claims on the staking contract
-    fn claim(&self, deps: Deps) -> Result<Vec<CosmosMsg>, E>;
+    fn claim(&self, deps: Deps) -> Result<Vec<CosmosMsg>, CwStakingError>;
 
     /// Query information of the given for the given staking provider see [StakingInfoResponse]
-    fn query_info(&self, querier: &QuerierWrapper) -> Result<StakingInfoResponse, E>;
+    fn query_info(&self, querier: &QuerierWrapper) -> Result<StakingInfoResponse, CwStakingError>;
 
     /// Query the staked token balance of a given staker
     /// This will not return  the amount of tokens that are currently unbonding.
@@ -81,15 +79,18 @@ pub trait CwStakingCommand<E: Error = CwStakingError>: Identify {
         staker: Addr,
         stakes: Vec<AssetEntry>,
         unbonding_period: Option<cw_utils::Duration>,
-    ) -> Result<StakeResponse, E>;
+    ) -> Result<StakeResponse, CwStakingError>;
 
     /// Query information on unbonding positions for a given staker.
     fn query_unbonding(
         &self,
         querier: &QuerierWrapper,
         staker: Addr,
-    ) -> Result<UnbondingResponse, E>;
+    ) -> Result<UnbondingResponse, CwStakingError>;
 
     /// Query the information of the reward tokens
-    fn query_rewards(&self, querier: &QuerierWrapper) -> Result<RewardTokensResponse, E>;
+    fn query_rewards(
+        &self,
+        querier: &QuerierWrapper,
+    ) -> Result<RewardTokensResponse, CwStakingError>;
 }

--- a/integrations/wyndex-adapter/src/dex.rs
+++ b/integrations/wyndex-adapter/src/dex.rs
@@ -30,7 +30,7 @@ use ::{
 };
 
 #[cfg(feature = "full_integration")]
-impl DexCommand<DexError> for WynDex {
+impl DexCommand for WynDex {
     fn swap(
         &self,
         _deps: Deps,


### PR DESCRIPTION
This PR aims at removing the custom error types on Dex and Staking adapters.

This error type is not usable today because of the dex adapter and staking adapter contracts implementation. 
Especially those arguments fix the error to their defaults (DexError and CwStakingError) respectively : 

- https://github.com/AbstractSDK/abstract/blob/fix/adapter/modules/contracts/adapters/dex/src/adapter.rs#L34
- https://github.com/AbstractSDK/abstract/blob/fix/adapter/modules/contracts/adapters/cw-staking/src/adapter.rs#L24


### Checklist

- [ ] CI is green.
- [ ] Changelog updated.
