### PR TITLE
Embed state.json in abstract-interface

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- `state.json` now included in binary in release mode, allowing using binaries on a different environment than it's been built.
+
 ### Changed
 
 ### Removed

--- a/framework/packages/abstract-interface/Cargo.toml
+++ b/framework/packages/abstract-interface/Cargo.toml
@@ -30,6 +30,9 @@ serde_json = "1.0.79"
 speculoos = { workspace = true }
 polytone = { workspace = true }
 
+# Embed state.json in binary in release mode
+rust-embed = { version = "8.2.0", features = ["include-exclude"] }
+
 # Keep these here
 module-factory = { package = "abstract-module-factory", path = "../../contracts/native/module-factory", default-features = false, version = "0.21.0" }
 ibc-client = { package = "abstract-ibc-client", path = "../../contracts/native/ibc-client", default-features = false, version = "0.21.0" }

--- a/framework/packages/abstract-interface/src/deployment.rs
+++ b/framework/packages/abstract-interface/src/deployment.rs
@@ -11,6 +11,23 @@ use crate::{
     AccountFactory, AnsHost, Manager, ModuleFactory, Proxy, VersionControl,
 };
 
+use rust_embed::RustEmbed;
+
+#[derive(RustEmbed)]
+// Can't use symlinks in debug mode 
+// https://github.com/pyrossh/rust-embed/pull/234
+#[folder = "../../../interchain/"]
+#[include = "state.json"]
+struct State;
+
+impl State {
+    pub fn load_state() -> serde_json::Value {
+        let state_file =
+            State::get("state.json").expect("Unable to read abstract-interface state.json");
+        serde_json::from_slice(&state_file.data).unwrap()
+    }
+}
+
 pub struct Abstract<Chain: CwEnv> {
     pub ans_host: AnsHost<Chain>,
     pub version_control: VersionControl<Chain>,
@@ -135,7 +152,8 @@ impl<Chain: CwEnv> Deploy<Chain> for Abstract<Chain> {
     fn load_from(chain: Chain) -> Result<Self, Self::Error> {
         let mut abstr = Self::new(chain);
         // We register all the contracts default state
-        abstr.set_contracts_state(None);
+        let state = State::load_state();
+        abstr.set_contracts_state(Some(state));
 
         // Check if abstract deployed, for successful load
         if let Err(CwOrchError::AddrNotInStore(_)) = abstr.version_control.address() {
@@ -239,5 +257,26 @@ impl<Chain: CwEnv> Abstract<Chain> {
                 ibc_client::contract::CONTRACT_VERSION.to_string(),
             ),
         ]
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::borrow::Cow;
+
+    use super::*;
+
+    #[test]
+    fn only_state_json_included() {
+        let files = State::iter().collect::<Vec<_>>();
+        assert_eq!(files, vec![Cow::Borrowed("state.json")])
+    }
+
+    #[test]
+    fn have_some_state() {
+        State::get("state.json").unwrap();
+        let state = State::load_state();
+        let vc_juno = &state["juno"]["juno-1"]["code_ids"].get(VERSION_CONTROL);
+        assert!(vc_juno.is_some());
     }
 }


### PR DESCRIPTION
This PR aims to include state.json in binaries in release mode
### Checklist

- [ ] CI is green.
- [x] Changelog updated.
