### PR TITLE
Update doc links to show console.abstract.money instead of app

### DIFF
--- a/framework/docs/src/0_introduction.md
+++ b/framework/docs/src/0_introduction.md
@@ -52,6 +52,6 @@ Look at the
     <li><a href="https://github.com/AbstractSDK" target="_blank">Github</a></li>
     <li><a href="https://medium.com/@abstractmoney" target="_blank">Medium</a></li>
     <li><a href="https://docs.abstract.money/" target="_blank">Docs</a></li>
-    <li><a href="https://app.abstract.money" target="_blank">Account Console</a></li>
+    <li><a href="https://console.abstract.money" target="_blank">Account Console</a></li>
     <li><a href="https://api.abstract.money/" target="_blank">Graphql API Explorer</a></li>
 </ul>

--- a/framework/docs/src/3_framework/2_account_abstraction.md
+++ b/framework/docs/src/3_framework/2_account_abstraction.md
@@ -39,7 +39,7 @@ you an idea of how an App is created with the Abstract SDK:
 ```
 
 The code above defines an **Abstract App**. This app can be installed on any Abstract Account through
-the <a href="https://app.abstract.money/juno/modules" target="_blank">Abstract App
+the <a href="https://console.abstract.money" target="_blank">Abstract App
 store</a>, allowing developers to monetize their code.
 
 The customizable handlers that are used in the builder are functions similar to the native CosmWasm entry-point

--- a/framework/docs/src/3_framework/6_module_types.md
+++ b/framework/docs/src/3_framework/6_module_types.md
@@ -2,7 +2,7 @@
 
 As explained in the previous section, a _module_ is a smart-contract that **extends an Account's functionality**. You can explore
 all the available modules on the modules tab of your Account through
-the <a href="https://app.abstract.money/" target="_blank">web-app</a>.
+the <a href="https://console.abstract.money/modules" target="_blank">web-app</a>.
 
 <!-- ```admonish info
 In the previous sections we referred to these modules as "applications". We did this to simplify the mental framework of 
@@ -90,7 +90,7 @@ flowchart LR
 
 The following are sequence diagrams of the process of installing and uninstalling a module on an Abstract Account. As
 you can see, the process happens via the Manager, and it can be done by the Account owner through
-the [web-app](https://app.abstract.money/).
+the [web-app](https://console.abstract.money/).
 
 ```mermaid
 sequenceDiagram

--- a/framework/docs/src/4_get_started/7_module_deployment.md
+++ b/framework/docs/src/4_get_started/7_module_deployment.md
@@ -57,7 +57,6 @@ Abstract Version Control.
 
 ## Module Installation
 
-To install your module, go to the <a href="https://app.abstract.money" target="_blank">Abstract Account Dashboard</a>,
-go to your Account (or a new one) and click on the `Modules` tab. Here you will find a list of all the modules you have
+To install your module, go to the <a href="https://console.abstract.money" target="_blank">Abstract Account Dashboard</a>, enter the dev-mode by clicking Enter Dev Mode on Action tab, go to your Account (or a new one) and click on the `Modules` tab. Here you will find a list of all the modules you have
 registered on the Abstract Version Control. Click on the `Install` button next to your module and select the network you
 want to install it on. This will open a modal with the following fields:

--- a/framework/docs/src/5_platform/4_account_console.md
+++ b/framework/docs/src/5_platform/4_account_console.md
@@ -20,7 +20,7 @@ including:
 ## Accessing the Account Console
 
 You can access the Account Console where you can create an account, claim namespaces and more by
-visiting <a href="https://app.abstract.money/" target="_blank">app.abstract.money</a>. You will be able to select the
+visiting <a href="https://console.abstract.money/" target="_blank">console.abstract.money</a>. You will be able to select the
 network you want to connect to, and then proceed to create your Abstract Account.
 
 ## Account Management

--- a/modules/contracts/apps/calendar/examples/deploy.rs
+++ b/modules/contracts/apps/calendar/examples/deploy.rs
@@ -1,6 +1,6 @@
 //! Deploys the module to the Abstract platform by uploading it and registering it on the version control contract.
 //!
-//! This should be used for mainnet/testnet deployments in combination with our front-end at https://app.abstract.money
+//! This should be used for mainnet/testnet deployments in combination with our front-end at https://console.abstract.money
 //!
 //! **Requires you to have an account and namespace registered**
 //!
@@ -42,7 +42,7 @@ fn deploy(networks: Vec<ChainInfo>) -> anyhow::Result<()> {
         app.deploy(version, DeployStrategy::Try)?;
 
         // Create an account on our front-end to install the module!
-        // https://app.abstract.money
+        // https://console.abstract.money
     }
     Ok(())
 }


### PR DESCRIPTION
Updated links to use `console.abstract.money` and updated docs or links where it's outdated
### Checklist

- [x] CI is green.
- [x] Changelog updated.
