### PR TITLE
Avoid parsing result when receiving response data in Proxy

### DIFF
--- a/framework/contracts/account/proxy/src/reply.rs
+++ b/framework/contracts/account/proxy/src/reply.rs
@@ -1,14 +1,14 @@
-use cosmwasm_std::Reply;
+use cosmwasm_std::{Reply, StdError};
 
 use crate::contract::{ProxyResponse, ProxyResult};
 
 /// Add the message's data to the response
 pub fn forward_response_data(result: Reply) -> ProxyResult {
     // get the result from the reply
-    let resp = cw_utils::parse_reply_execute_data(result)?;
+    let res = result.result.into_result().map_err(StdError::generic_err)?;
 
     // log and add data if needed
-    let resp = if let Some(data) = resp.data {
+    let resp = if let Some(data) = res.data {
         ProxyResponse::new(
             "forward_response_data_reply",
             vec![("response_data", "true")],


### PR DESCRIPTION
This PR fixed the behavior of the proxy when the client asked for data forwarding


Closes ABS-361


## Checklist

- [x] CI is green.
- [x] Changelog updated.
