### PR TITLE
Added multiple messages to ibc action to allow for serial execution

### DIFF
--- a/framework/contracts/native/ibc-client/src/contract.rs
+++ b/framework/contracts/native/ibc-client/src/contract.rs
@@ -485,11 +485,11 @@ mod tests {
             let msg = ExecuteMsg::RemoteAction {
                 host_chain: chain_name.to_string(),
                 action: HostAction::Dispatch {
-                    manager_msg: manager::ExecuteMsg::UpdateInfo {
+                    manager_msgs: vec![manager::ExecuteMsg::UpdateInfo {
                         name: None,
                         description: None,
                         link: None,
-                    },
+                    }],
                 },
                 callback_info: None,
             };
@@ -555,11 +555,11 @@ mod tests {
             )?;
 
             let action = HostAction::Dispatch {
-                manager_msg: manager::ExecuteMsg::UpdateInfo {
+                manager_msgs: vec![manager::ExecuteMsg::UpdateInfo {
                     name: None,
                     description: None,
                     link: None,
-                },
+                }],
             };
 
             let msg = ExecuteMsg::RemoteAction {
@@ -618,11 +618,11 @@ mod tests {
             )?;
 
             let action = HostAction::Dispatch {
-                manager_msg: manager::ExecuteMsg::UpdateInfo {
+                manager_msgs: vec![manager::ExecuteMsg::UpdateInfo {
                     name: None,
                     description: None,
                     link: None,
-                },
+                }],
             };
 
             let callback_info = CallbackInfo {

--- a/framework/contracts/native/ibc-host/src/account_commands.rs
+++ b/framework/contracts/native/ibc-host/src/account_commands.rs
@@ -80,18 +80,22 @@ pub fn receive_register(
 pub fn receive_dispatch(
     _deps: DepsMut,
     account: AccountBase,
-    manager_msg: manager::ExecuteMsg,
+    manager_msgs: Vec<manager::ExecuteMsg>,
 ) -> HostResult {
     // execute the message on the manager
-    let manager_call_msg = wasm_execute(account.manager, &manager_msg, vec![])?;
+    let msgs = manager_msgs
+        .into_iter()
+        .map(|msg| wasm_execute(&account.manager, &msg, vec![]))
+        .collect::<Result<Vec<_>, _>>()?;
 
-    // We want to forward the data that this execution gets
-    let submsg = SubMsg::reply_on_success(manager_call_msg, RESPONSE_REPLY_ID);
+    let response = Response::new().add_attribute("action", "receive_dispatch");
 
-    // Polytone handles all the necessary
-    Ok(Response::new()
-        .add_submessage(submsg)
-        .add_attribute("action", "receive_dispatch"))
+    // If there is only one executed message, we want to forward the data that this execution gets
+    Ok(if msgs.len() == 1 {
+        response.add_submessage(SubMsg::reply_on_success(msgs[0].clone(), RESPONSE_REPLY_ID))
+    } else {
+        response.add_messages(msgs)
+    })
 }
 
 /// processes PacketMsg::SendAllBack variant

--- a/framework/contracts/native/ibc-host/src/endpoints/packet.rs
+++ b/framework/contracts/native/ibc-host/src/endpoints/packet.rs
@@ -54,8 +54,8 @@ pub fn handle_host_action(
             // If this account already exists, we can propagate the action
             if let Ok(account) = account_commands::get_account(deps.as_ref(), &account_id) {
                 match action {
-                    HostAction::Dispatch { manager_msg } => {
-                        receive_dispatch(deps, account, manager_msg)
+                    HostAction::Dispatch { manager_msgs } => {
+                        receive_dispatch(deps, account, manager_msgs)
                     }
                     HostAction::Helpers(helper_action) => match helper_action {
                         HelperAction::SendAllBack => {

--- a/framework/contracts/native/ibc-host/tests/integration.rs
+++ b/framework/contracts/native/ibc-host/tests/integration.rs
@@ -284,11 +284,11 @@ fn account_action() -> anyhow::Result<()> {
         .ibc_execute(
             AccountId::local(account_sequence),
             HostAction::Dispatch {
-                manager_msg: abstract_core::manager::ExecuteMsg::ProposeOwner {
+                manager_msgs: vec![abstract_core::manager::ExecuteMsg::ProposeOwner {
                     owner: GovernanceDetails::Monarchy {
                         monarch: mock.addr_make("new_owner").to_string(),
                     },
-                },
+                }],
             },
             proxy_addr.to_string(),
         )
@@ -336,11 +336,11 @@ fn execute_action_with_account_creation() -> anyhow::Result<()> {
         .ibc_execute(
             AccountId::local(account_sequence),
             HostAction::Dispatch {
-                manager_msg: abstract_core::manager::ExecuteMsg::ProposeOwner {
+                manager_msgs: vec![abstract_core::manager::ExecuteMsg::ProposeOwner {
                     owner: GovernanceDetails::Monarchy {
                         monarch: mock.addr_make("new_owner").to_string(),
                     },
-                },
+                }],
             },
             mock.addr_make("proxy_address").to_string(),
         )

--- a/framework/packages/abstract-core/src/native/ibc_host.rs
+++ b/framework/packages/abstract-core/src/native/ibc_host.rs
@@ -90,7 +90,7 @@ pub enum HelperAction {
 #[cosmwasm_schema::cw_serde]
 pub enum HostAction {
     Dispatch {
-        manager_msg: manager::ExecuteMsg,
+        manager_msgs: Vec<manager::ExecuteMsg>,
     },
     /// Can't be called by an account directly. These are permissioned messages that only the IBC Client is allowed to call by itself.
     Internal(InternalAction),

--- a/framework/packages/abstract-interface/src/account/manager.rs
+++ b/framework/packages/abstract-interface/src/account/manager.rs
@@ -214,7 +214,9 @@ impl<Chain: CwEnv> Manager<Chain> {
         let msg = abstract_core::proxy::ExecuteMsg::IbcAction {
             msgs: vec![abstract_core::ibc_client::ExecuteMsg::RemoteAction {
                 host_chain: host_chain.into(),
-                action: HostAction::Dispatch { manager_msg: msg },
+                action: HostAction::Dispatch {
+                    manager_msgs: vec![msg],
+                },
                 callback_info,
             }],
         };
@@ -234,10 +236,10 @@ impl<Chain: CwEnv> Manager<Chain> {
             msgs: vec![abstract_core::ibc_client::ExecuteMsg::RemoteAction {
                 host_chain: host_chain.into(),
                 action: HostAction::Dispatch {
-                    manager_msg: ExecuteMsg::ExecOnModule {
+                    manager_msgs: vec![ExecuteMsg::ExecOnModule {
                         module_id: module_id.to_string(),
                         exec_msg: msg,
-                    },
+                    }],
                 },
                 callback_info,
             }],

--- a/framework/packages/abstract-sdk/src/apis/ibc.rs
+++ b/framework/packages/abstract-sdk/src/apis/ibc.rs
@@ -124,12 +124,12 @@ impl<'a, T: IbcInterface> IbcClient<'a, T> {
         self.host_action(
             host_chain,
             HostAction::Dispatch {
-                manager_msg: abstract_core::manager::ExecuteMsg::InstallModules {
+                manager_msgs: vec![abstract_core::manager::ExecuteMsg::InstallModules {
                     modules: vec![ModuleInstallConfig::new(
                         module,
                         Some(to_json_binary(&init_msg)?),
                     )],
-                },
+                }],
             },
             None,
         )
@@ -144,9 +144,9 @@ impl<'a, T: IbcInterface> IbcClient<'a, T> {
         self.host_action(
             host_chain,
             HostAction::Dispatch {
-                manager_msg: abstract_core::manager::ExecuteMsg::InstallModules {
+                manager_msgs: vec![abstract_core::manager::ExecuteMsg::InstallModules {
                     modules: vec![ModuleInstallConfig::new(module, None)],
-                },
+                }],
             },
             None,
         )
@@ -162,10 +162,10 @@ impl<'a, T: IbcInterface> IbcClient<'a, T> {
         self.host_action(
             host_chain,
             HostAction::Dispatch {
-                manager_msg: abstract_core::manager::ExecuteMsg::ExecOnModule {
+                manager_msgs: vec![abstract_core::manager::ExecuteMsg::ExecOnModule {
                     module_id,
                     exec_msg: to_json_binary(exec_msg)?,
-                },
+                }],
             },
             None,
         )
@@ -229,9 +229,9 @@ mod test {
         let msg = client.host_action(
             TEST_HOST_CHAIN.into(),
             HostAction::Dispatch {
-                manager_msg: abstract_core::manager::ExecuteMsg::UpdateStatus {
+                manager_msgs: vec![abstract_core::manager::ExecuteMsg::UpdateStatus {
                     is_suspended: None,
-                },
+                }],
             },
             None,
         );
@@ -243,9 +243,9 @@ mod test {
                 msgs: vec![IbcClientMsg::RemoteAction {
                     host_chain: TEST_HOST_CHAIN.into(),
                     action: HostAction::Dispatch {
-                        manager_msg: abstract_core::manager::ExecuteMsg::UpdateStatus {
+                        manager_msgs: vec![abstract_core::manager::ExecuteMsg::UpdateStatus {
                             is_suspended: None,
-                        },
+                        }],
                     },
                     callback_info: None,
                 }],
@@ -272,9 +272,9 @@ mod test {
         let actual = client.host_action(
             TEST_HOST_CHAIN.into(),
             HostAction::Dispatch {
-                manager_msg: abstract_core::manager::ExecuteMsg::UpdateStatus {
+                manager_msgs: vec![abstract_core::manager::ExecuteMsg::UpdateStatus {
                     is_suspended: None,
-                },
+                }],
             },
             Some(expected_callback.clone()),
         );
@@ -287,9 +287,9 @@ mod test {
                 msgs: vec![IbcClientMsg::RemoteAction {
                     host_chain: TEST_HOST_CHAIN.into(),
                     action: HostAction::Dispatch {
-                        manager_msg: abstract_core::manager::ExecuteMsg::UpdateStatus {
+                        manager_msgs: vec![abstract_core::manager::ExecuteMsg::UpdateStatus {
                             is_suspended: None,
-                        },
+                        }],
                     },
                     callback_info: Some(expected_callback),
                 }],

--- a/interchain/interchain-tests/src/interchain_accounts.rs
+++ b/interchain/interchain-tests/src/interchain_accounts.rs
@@ -773,11 +773,11 @@ mod test {
                 account_id: remote_account_id,
                 proxy_address: origin_account.proxy.address()?.to_string(),
                 action: HostAction::Dispatch {
-                    manager_msg: ManagerExecuteMsg::UpdateInfo {
+                    manager_msgs: vec![ManagerExecuteMsg::UpdateInfo {
                         name: Some("name".to_owned()),
                         description: Some("description".to_owned()),
                         link: Some("link".to_owned()),
-                    },
+                    }],
                 },
             },
             None,

--- a/modules/contracts/adapters/cw-staking/src/handlers/execute.rs
+++ b/modules/contracts/adapters/cw-staking/src/handlers/execute.rs
@@ -78,7 +78,7 @@ fn handle_ibc_request(
     // construct the action to be called on the host
     // construct the action to be called on the host
     let host_action = abstract_sdk::core::ibc_host::HostAction::Dispatch {
-        manager_msg: abstract_core::manager::ExecuteMsg::ExecOnModule {
+        manager_msgs: vec![abstract_core::manager::ExecuteMsg::ExecOnModule {
             module_id: CW_STAKING_ADAPTER_ID.to_string(),
             exec_msg: to_json_binary::<ExecuteMsg>(
                 &StakingExecuteMsg {
@@ -87,7 +87,7 @@ fn handle_ibc_request(
                 }
                 .into(),
             )?,
-        },
+        }],
     };
 
     // If the calling entity is a contract, we provide a callback on successful cross-chain-staking

--- a/modules/contracts/adapters/dex/src/handlers/execute.rs
+++ b/modules/contracts/adapters/dex/src/handlers/execute.rs
@@ -153,7 +153,7 @@ fn handle_ibc_request(
     let ics20_transfer_msg = ibc_client.ics20_transfer(host_chain.to_string(), coins)?;
     // construct the action to be called on the host
     let host_action = abstract_sdk::core::ibc_host::HostAction::Dispatch {
-        manager_msg: abstract_core::manager::ExecuteMsg::ExecOnModule {
+        manager_msgs: vec![abstract_core::manager::ExecuteMsg::ExecOnModule {
             module_id: DEX_ADAPTER_ID.to_string(),
             exec_msg: to_json_binary::<ExecuteMsg>(
                 &DexExecuteMsg::RawAction {
@@ -162,7 +162,7 @@ fn handle_ibc_request(
                 }
                 .into(),
             )?,
-        },
+        }],
     };
 
     // If the calling entity is a contract, we provide a callback on successful swap


### PR DESCRIPTION
This PR aims at introducing the possiblity to send multiple manager messages in a single ibc packet. THis allows for sequential execution of remote IBC messages (when order matters). There is 2 parts to this PR : 
1. Allow for multiple messages inside 1 action
2. Remove the possiblity to send multiple IBCClient messages in one message on the Proxy Contract

### Checklist

- [ ] CI is green.
- [ ] Changelog updated.
