### PR TITLE
Fix migrate messages from broken template

### DIFF
--- a/modules/CHANGELOG.md
+++ b/modules/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Etf fee distribution fixed
+- Replaced empty enum migrate messages with empty structs
 
 ## [0.21.0] - 2024-02-20
 

--- a/modules/contracts/apps/calendar/src/msg.rs
+++ b/modules/contracts/apps/calendar/src/msg.rs
@@ -115,7 +115,7 @@ pub enum CalendarQueryMsg {
 }
 
 #[cosmwasm_schema::cw_serde]
-pub enum CalendarMigrateMsg {}
+pub struct CalendarMigrateMsg {}
 
 #[cosmwasm_schema::cw_serde]
 pub struct ConfigResponse {

--- a/modules/contracts/apps/croncat/Cargo.toml
+++ b/modules/contracts/apps/croncat/Cargo.toml
@@ -52,6 +52,7 @@ cw20 = { version = "0.16.0" }
 
 cw-controllers = { workspace = true }
 cw-storage-plus = { workspace = true }
+cw-utils = { workspace = true }
 thiserror = { workspace = true }
 schemars = { workspace = true }
 cw-asset = { workspace = true }

--- a/modules/contracts/apps/croncat/src/error.rs
+++ b/modules/contracts/apps/croncat/src/error.rs
@@ -5,6 +5,7 @@ use cosmwasm_std::StdError;
 use croncat_integration_utils::error::CronCatContractError;
 use cw_asset::AssetError;
 use cw_controllers::AdminError;
+use cw_utils::ParseReplyError;
 use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq)]
@@ -29,6 +30,9 @@ pub enum AppError {
 
     #[error("{0}")]
     CronCatContractError(#[from] CronCatContractError),
+
+    #[error("{0}")]
+    ParseReplyError(#[from] ParseReplyError),
 
     #[error("Unable to get croncat version")]
     UnknownVersion {},

--- a/modules/contracts/apps/croncat/src/replies/execute.rs
+++ b/modules/contracts/apps/croncat/src/replies/execute.rs
@@ -2,25 +2,39 @@ use abstract_sdk::{
     features::{AbstractResponse, AccountIdentification},
     Execution,
 };
-use cosmwasm_std::{wasm_execute, CosmosMsg, DepsMut, Env, Reply};
-use croncat_integration_utils::reply_handler::reply_handle_croncat_task_creation;
+use cosmwasm_std::{
+    from_json, wasm_execute, CosmosMsg, DepsMut, Env, Reply, StdError, SubMsgResponse, SubMsgResult,
+};
 use croncat_sdk_manager::msg::ManagerExecuteMsg;
 
 use crate::{
     contract::{CroncatApp, CroncatResult},
+    error::AppError,
     state::{ACTIVE_TASKS, REMOVED_TASK_MANAGER_ADDR, TEMP_TASK_KEY},
     utils::user_balance_nonempty,
 };
 
 pub fn create_task_reply(deps: DepsMut, _env: Env, app: CroncatApp, reply: Reply) -> CroncatResult {
-    let (task, bin) = reply_handle_croncat_task_creation(reply)?;
+    let SubMsgResult::Ok(SubMsgResponse { data: Some(b), .. }) = reply.result else {
+        return Err(AppError::Std(StdError::generic_err(
+            "Failed to create a task",
+        )));
+    };
+
+    let proxy_execution_response = cw_utils::parse_execute_response_data(&b)?
+        .data
+        .unwrap_or_default();
+    let task_bin = cw_utils::parse_execute_response_data(&proxy_execution_response.0)?
+        .data
+        .unwrap_or_default();
+    let task: croncat_integration_utils::CronCatTaskExecutionInfo = from_json(&task_bin)?;
     let key = TEMP_TASK_KEY.load(deps.storage)?;
     ACTIVE_TASKS.save(deps.storage, key, &(task.task_hash.clone(), task.version))?;
 
     Ok(app
         .response("create_task_reply")
         .add_attribute("task_hash", task.task_hash)
-        .set_data(bin))
+        .set_data(task_bin))
 }
 
 pub fn task_remove_reply(

--- a/modules/contracts/apps/payment/src/msg.rs
+++ b/modules/contracts/apps/payment/src/msg.rs
@@ -67,7 +67,7 @@ pub enum AppQueryMsg {
 }
 
 #[cosmwasm_schema::cw_serde]
-pub enum AppMigrateMsg {}
+pub struct AppMigrateMsg {}
 
 #[cosmwasm_schema::cw_serde]
 pub struct Cw20TipMsg {}


### PR DESCRIPTION
Empty enum migrate message got transferred from template over few other modules, followup fix on https://github.com/AbstractSDK/app-template/pull/54
### Checklist

- [x] CI is green.
- [x] Changelog updated.
