### PR TITLE
Add an `is_registered` and `assert_registred` to ANS API`

### DIFF
--- a/framework/docs/src/releases/v0.md
+++ b/framework/docs/src/releases/v0.md
@@ -6,6 +6,7 @@
 
 - `state.json` now included in binary in release mode, allowing using binaries on a different environment than it's been built.
 - `module_instantiate2_address_raw` for `AbstractClient`, allowing to install a different version than the dependency version.
+- Added assertion helper function `assert_registered` to the ANS client API.
 
 ### Changed
 

--- a/framework/docs/src/releases/v0.md
+++ b/framework/docs/src/releases/v0.md
@@ -6,7 +6,7 @@
 
 - `state.json` now included in binary in release mode, allowing using binaries on a different environment than it's been built.
 - `module_instantiate2_address_raw` for `AbstractClient`, allowing to install a different version than the dependency version.
-- Added assertion helper function `assert_registered` to the ANS client API.
+- Added helper functions `assert_registered` and `is_registered` to the ANS client API.
 
 ### Changed
 

--- a/framework/packages/abstract-sdk/src/ans_resolve.rs
+++ b/framework/packages/abstract-sdk/src/ans_resolve.rs
@@ -16,6 +16,10 @@ pub trait Resolve {
     type Output;
     /// Resolve an entry into its value.
     fn resolve(&self, querier: &QuerierWrapper, ans_host: &AnsHost) -> AnsHostResult<Self::Output>;
+    /// Check if the entry is registered in the ANS.
+    fn is_registered(&self, querier: &QuerierWrapper, ans_host: &AnsHost) -> bool {
+        self.resolve(querier, ans_host).is_ok()
+    }
 }
 
 impl Resolve for AssetEntry {
@@ -132,12 +136,6 @@ mod tests {
 
     use super::*;
 
-    fn assert_not_found<T: Debug>(res: AnsHostResult<T>) {
-        assert_that!(res)
-            .is_err()
-            .matches(|e| e.to_string().contains("not found"));
-    }
-
     fn default_test_querier() -> MockQuerier {
         MockQuerierBuilder::default()
             .with_fallback_raw_handler(|contract, _| match contract {
@@ -171,7 +169,36 @@ mod tests {
     {
         let res = test_resolve(&default_test_querier(), nonexistent);
 
-        assert_not_found(res);
+        assert_that!(res)
+            .is_err()
+            .matches(|e| e.to_string().contains("not found"));
+    }
+
+    mod is_registered {
+        use super::*;
+
+        #[test]
+        fn exists() {
+            let test_asset_entry = AssetEntry::new("aoeu");
+            let querier = MockQuerierBuilder::default()
+                .with_contract_map_entry(TEST_ANS_HOST, ASSET_ADDRESSES, (&test_asset_entry, AssetInfo::native("abc")))
+                .build();
+
+            let ans_host = mock_ans_host();
+
+            let is_registered = test_asset_entry.is_registered(&QuerierWrapper::new(&querier), &ans_host);
+            assert_that!(is_registered).is_true();
+        }
+
+        #[test]
+        fn does_not_exist() {
+            let not_exist_asset = AssetEntry::new("aoeu");
+            let querier = default_test_querier();
+            let wrapper = wrap_querier(&querier);
+
+            let is_registered = not_exist_asset.is_registered(&wrapper, &mock_ans_host());
+            assert_that!(is_registered).is_false();
+        }
     }
 
     mod asset_entry {

--- a/framework/packages/abstract-sdk/src/ans_resolve.rs
+++ b/framework/packages/abstract-sdk/src/ans_resolve.rs
@@ -1,10 +1,7 @@
 //! # AnsHost Entry
 //! An entry (value) in the ans_host key-value store.
 
-use abstract_core::objects::{
-    ans_host::{AnsHostError, AnsHostResult},
-    AnsEntryConvertor,
-};
+use abstract_core::objects::{ans_host::AnsHostResult, AnsEntryConvertor};
 use cosmwasm_std::{Addr, QuerierWrapper};
 use cw_asset::{Asset, AssetInfo};
 
@@ -20,18 +17,10 @@ pub trait Resolve {
     /// Resolve an entry into its value.
     fn resolve(&self, querier: &QuerierWrapper, ans_host: &AnsHost) -> AnsHostResult<Self::Output>;
     /// Check if the entry is registered in the ANS.
-    fn is_registered(
-        &self,
-        querier: &QuerierWrapper,
-        ans_host: &AnsHost,
-    ) -> Result<bool, AnsHostError> {
+    fn is_registered(&self, querier: &QuerierWrapper, ans_host: &AnsHost) -> bool {
         match self.resolve(querier, ans_host) {
-            Ok(_) => Ok(true),
-            Err(AnsHostError::QueryFailed {
-                method_name: _,
-                error: _,
-            }) => Ok(false),
-            Err(e) => Err(e),
+            Ok(_) => true,
+            Err(_) => false,
         }
     }
     /// Assert that a given entry is registered in the ANS.

--- a/framework/packages/abstract-sdk/src/ans_resolve.rs
+++ b/framework/packages/abstract-sdk/src/ans_resolve.rs
@@ -18,10 +18,7 @@ pub trait Resolve {
     fn resolve(&self, querier: &QuerierWrapper, ans_host: &AnsHost) -> AnsHostResult<Self::Output>;
     /// Check if the entry is registered in the ANS.
     fn is_registered(&self, querier: &QuerierWrapper, ans_host: &AnsHost) -> bool {
-        match self.resolve(querier, ans_host) {
-            Ok(_) => true,
-            Err(_) => false,
-        }
+        self.resolve(querier, ans_host).is_ok()
     }
     /// Assert that a given entry is registered in the ANS.
     fn assert_registered(&self, querier: &QuerierWrapper, ans_host: &AnsHost) -> AnsHostResult<()> {

--- a/framework/packages/abstract-sdk/src/base/features/abstract_name_service.rs
+++ b/framework/packages/abstract-sdk/src/base/features/abstract_name_service.rs
@@ -62,6 +62,23 @@ impl<'a, T: ModuleIdentification + AbstractNameService> AbstractNameServiceClien
             .resolve(&self.deps.querier, &self.host)
             .map_err(|error| self.wrap_query_error(error))
     }
+
+    /// Returns if the entry is registered on the ANS.
+    /// Will return an Err if the query failed for technical reasons (like a wrong address or state parsing error).
+    /// Will return true if found.
+    /// Will return false if not found.
+    pub fn is_registered(&self, entry: &impl Resolve) -> AbstractSdkResult<bool> {
+        entry
+            .is_registered(&self.deps.querier, &self.host)
+            .map_err(|error| self.wrap_query_error(error))
+    }
+    /// Assert that an entry is registered on the ANS. Will return an Err if the entry is not registered.
+    pub fn assert_registered(&self, entry: &impl Resolve) -> AbstractSdkResult<()> {
+        entry
+            .assert_registered(&self.deps.querier, &self.host)
+            .map_err(|error| self.wrap_query_error(error))
+    }
+
     /// Get AnsHost
     pub fn host(&self) -> &AnsHost {
         &self.host

--- a/framework/packages/abstract-sdk/src/base/features/abstract_name_service.rs
+++ b/framework/packages/abstract-sdk/src/base/features/abstract_name_service.rs
@@ -67,10 +67,8 @@ impl<'a, T: ModuleIdentification + AbstractNameService> AbstractNameServiceClien
     /// Will return an Err if the query failed for technical reasons (like a wrong address or state parsing error).
     /// Will return true if found.
     /// Will return false if not found.
-    pub fn is_registered(&self, entry: &impl Resolve) -> AbstractSdkResult<bool> {
-        entry
-            .is_registered(&self.deps.querier, &self.host)
-            .map_err(|error| self.wrap_query_error(error))
+    pub fn is_registered(&self, entry: &impl Resolve) -> bool {
+        entry.is_registered(&self.deps.querier, &self.host)
     }
     /// Assert that an entry is registered on the ANS. Will return an Err if the entry is not registered.
     pub fn assert_registered(&self, entry: &impl Resolve) -> AbstractSdkResult<()> {


### PR DESCRIPTION
Adds two helper methods to the ANS API to improve dev ex on contract instantiation. 

### Checklist

- [x] CI is green.
- [x] Changelog updated.
