### PR TITLE
Fix local chain prefixes

### DIFF
--- a/framework/packages/abstract-core/src/registry.rs
+++ b/framework/packages/abstract-core/src/registry.rs
@@ -54,13 +54,18 @@ pub mod archway {
     pub const ARCHWAY: &[&str] = &[ARCHWAY_MAINNET, ARCHWAY_TESTNET];
 }
 
+pub mod local {
+    pub const MOCK_CHAIN: &str = "cosmos-testnet";
+    pub const LOCAL_CHAIN: &[&str] = &[MOCK_CHAIN];
+}
+
 pub use archway::ARCHWAY;
 pub use juno::JUNO;
 pub use kujira::KUJIRA;
+pub use local::LOCAL_CHAIN;
 pub use neutron::NEUTRON;
 pub use osmosis::OSMOSIS;
 pub use terra::TERRA;
-pub const MOCK_CHAIN: &str = "cosmos-testnet";
 
 /// Useful when deploying version control
 #[allow(unused)]


### PR DESCRIPTION
Adding back `LOCAL_CHAIN` that got removed in #317 and `AVAILABLE_CHAINS` with `local` feature failing in integrations now.
