### PR TITLE
Duplex IBC for Accounts

### DIFF
--- a/framework/contracts/account/manager/src/commands.rs
+++ b/framework/contracts/account/manager/src/commands.rs
@@ -946,7 +946,7 @@ pub fn update_ibc_status(
         .add_message(proxy_callback_msg))
 }
 
-fn install_ibc_client(deps: DepsMut, proxy: Addr) -> Result<CosmosMsg, ManagerError> {
+pub fn install_ibc_client(deps: DepsMut, proxy: Addr) -> Result<CosmosMsg, ManagerError> {
     // retrieve the latest version
     let ibc_client_module =
         query_module(deps.as_ref(), ModuleInfo::from_id_latest(IBC_CLIENT)?, None)?;

--- a/framework/contracts/account/manager/src/contract.rs
+++ b/framework/contracts/account/manager/src/contract.rs
@@ -118,7 +118,8 @@ pub fn instantiate(
     }
 
     if msg.account_id.is_remote() {
-        install_ibc_client(deps.branch(), proxy_addr)?;
+        let install_client_msg = install_ibc_client(deps.branch(), proxy_addr)?;
+        response = response.add_message(install_client_msg);
     }
 
     // Register on manager if it's sub-account

--- a/interchain/interchain-tests/src/interchain_accounts.rs
+++ b/interchain/interchain-tests/src/interchain_accounts.rs
@@ -568,6 +568,7 @@ mod test {
                 }
             }
         );
+
         // We make sure the ibc client is installed on the remote account
         let installed_remote_modules = remote_abstract_account.manager.module_infos(None, None)?;
         assert!(installed_remote_modules

--- a/interchain/interchain-tests/src/interchain_accounts.rs
+++ b/interchain/interchain-tests/src/interchain_accounts.rs
@@ -96,7 +96,7 @@ mod test {
             ModuleAddressesResponse,
         },
         objects::{gov_type::GovernanceDetails, UncheckedChannelEntry},
-        ICS20, PROXY,
+        IBC_CLIENT, ICS20, PROXY,
     };
     use abstract_interface::AdapterDeployer;
     use abstract_interface::{AccountFactoryExecFns, AppDeployer, DeployStrategy, VCExecFns};
@@ -533,9 +533,9 @@ mod test {
         let (origin_account, remote_account_id) =
             create_test_remote_account(&abstr_origin, JUNO, STARGAZE, &mock_interchain, None)?;
 
+        // We assert the account was created with the right properties
         let remote_abstract_account =
             AbstractAccount::new(&abstr_remote, remote_account_id.clone());
-
         let manager_config = remote_abstract_account.manager.config()?;
         assert_eq!(
             manager_config,
@@ -568,6 +568,12 @@ mod test {
                 }
             }
         );
+        // We make sure the ibc client is installed on the remote account
+        let installed_remote_modules = remote_abstract_account.manager.module_infos(None, None)?;
+        assert!(installed_remote_modules
+            .module_infos
+            .iter()
+            .any(|m| m.id == IBC_CLIENT));
 
         // We try to execute a message from the proxy contract (account creation for instance)
 

--- a/interchain/interchain-tests/src/setup.rs
+++ b/interchain/interchain-tests/src/setup.rs
@@ -20,8 +20,27 @@ pub fn ibc_abstract_setup<Chain: IbcQueryHandler, IBC: InterchainEnv<Chain>>(
         Abstract::deploy_on(remote_chain.clone(), remote_chain.sender().to_string())?;
 
     // Deploying polytone on both chains
-    let origin_polytone = Polytone::deploy_on(origin_chain.clone(), None)?;
-    let remote_polytone = Polytone::deploy_on(remote_chain.clone(), None)?;
+    Polytone::deploy_on(origin_chain.clone(), None)?;
+    Polytone::deploy_on(remote_chain.clone(), None)?;
+
+    ibc_connect_polytone_and_abstract(interchain, origin_chain_id, remote_chain_id)?;
+
+    Ok((abstr_origin, abstr_remote))
+}
+
+pub fn ibc_connect_polytone_and_abstract<Chain: IbcQueryHandler, IBC: InterchainEnv<Chain>>(
+    interchain: &IBC,
+    origin_chain_id: &str,
+    remote_chain_id: &str,
+) -> AnyResult<()> {
+    let origin_chain = interchain.chain(origin_chain_id).unwrap();
+    let remote_chain = interchain.chain(remote_chain_id).unwrap();
+
+    let abstr_origin = Abstract::load_from(origin_chain.clone())?;
+    let abstr_remote = Abstract::load_from(remote_chain.clone())?;
+
+    let origin_polytone = Polytone::load_from(origin_chain.clone())?;
+    let remote_polytone = Polytone::load_from(remote_chain.clone())?;
 
     // Creating a connection between 2 polytone deployments
     interchain.create_contract_channel(
@@ -34,7 +53,7 @@ pub fn ibc_abstract_setup<Chain: IbcQueryHandler, IBC: InterchainEnv<Chain>>(
     // Create the connection between client and host
     abstract_ibc_connection_with(&abstr_origin, interchain, &abstr_remote, &origin_polytone)?;
 
-    Ok((abstr_origin, abstr_remote))
+    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR aims at allowing duplex communication for abstract IBC accounts (remote can also call the local account).

## Current Status

When the IBC host receives an IBC message, it appends the sending chain name to the account trace before proceeding with executing the sent action. 

## Major changes

When the IBC host receives an IBC message, it modifies the account trace in the following way before proceeding with executing the sent action : 
- If the account_id is remote and the last trace matches the current chain, we pop the chain name
- Otherwise, we just add the sending chain to the trace

## Outstanding problem

The IBC host needs to be a manager of the resulting abstract account to be able to execute messaes on their behalf. 
--> The IBC host should be an admin of the manager of all abstract accounts that have IBC enabled.

### Checklist

- [ ] CI is green.
- [ ] Changelog updated.
