### PR TITLE
Fix abstract app and abstract adapter packages compilation

### DIFF
--- a/framework/packages/abstract-adapter/Cargo.toml
+++ b/framework/packages/abstract-adapter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "abstract-adapter"
-version = "0.22.1"
+version = "0.22.2"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }

--- a/framework/packages/abstract-adapter/src/msgs.rs
+++ b/framework/packages/abstract-adapter/src/msgs.rs
@@ -30,13 +30,13 @@ macro_rules! adapter_msg_types {
     ($adapter_type:ty, $adapter_execute_msg: ty, $adapter_query_msg: ty) => {
         /// Top-level Abstract Adapter instantiate message. This is the message that is passed to the `instantiate` entrypoint of the smart-contract.
         pub type InstantiateMsg =
-            <$adapter_type as ::abstract_sdk::base::InstantiateEndpoint>::InstantiateMsg;
+            <$adapter_type as $crate::sdk::base::InstantiateEndpoint>::InstantiateMsg;
         /// Top-level Abstract Adapter execute message. This is the message that is passed to the `execute` entrypoint of the smart-contract.
-        pub type ExecuteMsg = <$adapter_type as ::abstract_sdk::base::ExecuteEndpoint>::ExecuteMsg;
+        pub type ExecuteMsg = <$adapter_type as $crate::sdk::base::ExecuteEndpoint>::ExecuteMsg;
         /// Top-level Abstract Adapter query message. This is the message that is passed to the `query` entrypoint of the smart-contract.
-        pub type QueryMsg = <$adapter_type as ::abstract_sdk::base::QueryEndpoint>::QueryMsg;
+        pub type QueryMsg = <$adapter_type as $crate::sdk::base::QueryEndpoint>::QueryMsg;
 
-        impl ::abstract_std::adapter::AdapterExecuteMsg for $adapter_execute_msg {}
-        impl ::abstract_std::adapter::AdapterQueryMsg for $adapter_query_msg {}
+        impl $crate::std::adapter::AdapterExecuteMsg for $adapter_execute_msg {}
+        impl $crate::std::adapter::AdapterQueryMsg for $adapter_query_msg {}
     };
 }

--- a/framework/packages/abstract-app/Cargo.toml
+++ b/framework/packages/abstract-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "abstract-app"
-version = "0.22.1"
+version = "0.22.2"
 edition = { workspace = true }
 license = { workspace = true }
 description = "base app contract implementation"

--- a/framework/packages/abstract-app/src/lib.rs
+++ b/framework/packages/abstract-app/src/lib.rs
@@ -16,7 +16,8 @@ pub type AppResult<C = cosmwasm_std::Empty> = Result<cosmwasm_std::Response<C>, 
 pub use abstract_std as std;
 // re-export objects specifically
 pub use abstract_sdk as sdk;
-pub use std::objects;
+
+pub use crate::std::objects;
 pub mod traits {
     pub use abstract_sdk::{features::*, prelude::*};
 }

--- a/framework/packages/abstract-interface/src/native/ans_host.rs
+++ b/framework/packages/abstract-interface/src/native/ans_host.rs
@@ -1,5 +1,3 @@
-use std::env;
-
 pub use abstract_std::ans_host::ExecuteMsgFns;
 use abstract_std::{
     ans_host::*,


### PR DESCRIPTION
app-template fails to compile abstract-app and abstract-adapter. This PR fixes it

Will do patch release for those packages as soon as it's approved and merged
### Checklist

- [x] CI is green.
- [x] Changelog updated.
