### PR TITLE
Update Native contract in version control

### DIFF
--- a/framework/packages/abstract-interface/src/migrate.rs
+++ b/framework/packages/abstract-interface/src/migrate.rs
@@ -148,10 +148,10 @@ impl<T: CwEnv> Abstract<T> {
                 ModuleInfo::from_id_latest(MODULE_FACTORY)?,
                 ModuleInfo::from_id_latest(VERSION_CONTROL)?,
                 ModuleInfo::from_id_latest(ANS_HOST)?,
-                ModuleInfo::from_id_latest(MANAGER)?,
-                ModuleInfo::from_id_latest(PROXY)?,
                 ModuleInfo::from_id_latest(IBC_CLIENT)?,
                 ModuleInfo::from_id_latest(IBC_HOST)?,
+                // ModuleInfo::from_id_latest(MANAGER)?,
+                // ModuleInfo::from_id_latest(PROXY)?,
             ])?
             .modules;
 
@@ -159,10 +159,32 @@ impl<T: CwEnv> Abstract<T> {
         let module_factory_module = modules[1].module.clone();
         let version_control_module = modules[2].module.clone();
         let ans_host_module = modules[3].module.clone();
-        let manager_module = modules[4].module.clone();
-        let proxy_module = modules[5].module.clone();
-        let ibc_client_module = modules[6].module.clone();
-        let ibc_host_module = modules[7].module.clone();
+        let ibc_client_module = modules[4].module.clone();
+        let ibc_host_module = modules[5].module.clone();
+        // let manager_module = modules[6].module.clone();
+        // let proxy_module = modules[7].module.clone();
+
+        let account_factory_cw2_v = contract_version(&self.account_factory)?.version;
+        let module_factory_cw2_v = contract_version(&self.module_factory)?.version;
+        let version_control_cw2_v = contract_version(&self.version_control)?.version;
+        let ans_host_cw2_v = contract_version(&self.ans_host)?.version;
+        let ibc_client_cw2_v = contract_version(&self.ibc.client)?.version;
+        let ibc_host_cw2_v = contract_version(&self.ibc.host)?.version;
+        // We might not have accounts
+        // let manager_cw2_v = contract_version(&self.account.manager)?.version;
+        // let proxy_cw2_v = contract_version(&self.account.proxy)?.version;
+
+        let versions = vec![
+            account_factory_cw2_v,
+            module_factory_cw2_v,
+            version_control_cw2_v,
+            ans_host_cw2_v,
+            ibc_client_cw2_v,
+            ibc_host_cw2_v,
+            // manager_cw2_v,
+            // proxy_cw2_v,
+        ];
+        panic!("{versions:?}");
 
         if ::account_factory::contract::CONTRACT_VERSION
             != account_factory_module.info.version.to_string()
@@ -198,20 +220,6 @@ impl<T: CwEnv> Abstract<T> {
             ));
         }
 
-        if ::manager::contract::CONTRACT_VERSION != manager_module.info.version.to_string() {
-            natives.push((
-                self.account.manager.as_instance(),
-                ::manager::contract::CONTRACT_VERSION.to_string(),
-            ));
-        }
-
-        if ::proxy::contract::CONTRACT_VERSION != proxy_module.info.version.to_string() {
-            natives.push((
-                self.account.proxy.as_instance(),
-                ::proxy::contract::CONTRACT_VERSION.to_string(),
-            ));
-        }
-
         if ::ibc_client::contract::CONTRACT_VERSION != ibc_client_module.info.version.to_string() {
             natives.push((
                 self.ibc.client.as_instance(),
@@ -225,6 +233,20 @@ impl<T: CwEnv> Abstract<T> {
                 ::ibc_host::contract::CONTRACT_VERSION.to_string(),
             ));
         }
+
+        // if ::manager::contract::CONTRACT_VERSION != manager_module.info.version.to_string() {
+        //     natives.push((
+        //         self.account.manager.as_instance(),
+        //         ::manager::contract::CONTRACT_VERSION.to_string(),
+        //     ));
+        // }
+
+        // if ::proxy::contract::CONTRACT_VERSION != proxy_module.info.version.to_string() {
+        //     natives.push((
+        //         self.account.proxy.as_instance(),
+        //         ::proxy::contract::CONTRACT_VERSION.to_string(),
+        //     ));
+        // }
 
         self.version_control.register_natives(natives)?;
         self.version_control.approve_any_abstract_modules()?;

--- a/framework/packages/abstract-interface/src/migrate.rs
+++ b/framework/packages/abstract-interface/src/migrate.rs
@@ -1,8 +1,8 @@
 use crate::{Abstract, AbstractIbc};
 use abstract_std::version_control::QueryMsgFns;
 use abstract_std::{
-    account_factory, ans_host, ibc_client, ibc_host, module_factory, objects::module::ModuleInfo,
-    version_control, MANAGER,
+    account_factory, ans_host, module_factory, objects::module::ModuleInfo, version_control,
+    MANAGER,
 };
 use abstract_std::{
     ACCOUNT_FACTORY, ANS_HOST, IBC_CLIENT, IBC_HOST, MODULE_FACTORY, PROXY, VERSION_CONTROL,
@@ -35,22 +35,19 @@ impl<T: CwEnv> Abstract<T> {
             .account
             .upload_and_register_if_needed(&self.version_control)?;
 
-        // Then ibc
-        let ibc = self.ibc.migrate_if_needed()?;
-
         self.version_control.approve_any_abstract_modules()?;
 
         Ok(account_factory.is_some()
             || module_factory.is_some()
             || version_control.is_some()
             || ans_host.is_some()
-            || account
-            || ibc)
+            || account)
     }
 
     /// Migrate the deployment based on version changes. If the registered contracts have the right version, we don't migrate them
     pub fn migrate_if_version_changed(&self) -> Result<bool, crate::AbstractInterfaceError> {
         let mut has_migrated = false;
+        let mut natives_to_register = vec![];
 
         if ::account_factory::contract::CONTRACT_VERSION
             != contract_version(&self.account_factory)?.version
@@ -61,6 +58,10 @@ impl<T: CwEnv> Abstract<T> {
             if migration_result.is_some() {
                 has_migrated = true;
             }
+            natives_to_register.push((
+                self.account_factory.as_instance(),
+                ::account_factory::contract::CONTRACT_VERSION.to_string(),
+            ));
         }
         if ::module_factory::contract::CONTRACT_VERSION
             != contract_version(&self.module_factory)?.version
@@ -71,6 +72,10 @@ impl<T: CwEnv> Abstract<T> {
             if migration_result.is_some() {
                 has_migrated = true;
             }
+            natives_to_register.push((
+                self.module_factory.as_instance(),
+                ::module_factory::contract::CONTRACT_VERSION.to_string(),
+            ));
         }
 
         if ::version_control::contract::CONTRACT_VERSION
@@ -82,6 +87,10 @@ impl<T: CwEnv> Abstract<T> {
             if migration_result.is_some() {
                 has_migrated = true;
             }
+            natives_to_register.push((
+                self.version_control.as_instance(),
+                ::version_control::contract::CONTRACT_VERSION.to_string(),
+            ));
         }
 
         if ::ans_host::contract::CONTRACT_VERSION != contract_version(&self.ans_host)?.version {
@@ -91,9 +100,13 @@ impl<T: CwEnv> Abstract<T> {
             if migration_result.is_some() {
                 has_migrated = true;
             }
+            natives_to_register.push((
+                self.ans_host.as_instance(),
+                ::ans_host::contract::CONTRACT_VERSION.to_string(),
+            ));
         }
 
-        let mut modules_to_register = Vec::with_capacity(2);
+        let mut accounts_to_register = Vec::with_capacity(2);
 
         // We need to check the version in version control for the account contracts
         let versions = self
@@ -107,7 +120,7 @@ impl<T: CwEnv> Abstract<T> {
         if ::manager::contract::CONTRACT_VERSION != versions[0].module.info.version.to_string()
             && self.account.manager.upload_if_needed()?.is_some()
         {
-            modules_to_register.push((
+            accounts_to_register.push((
                 self.account.manager.as_instance(),
                 ::manager::contract::CONTRACT_VERSION.to_string(),
             ));
@@ -116,22 +129,23 @@ impl<T: CwEnv> Abstract<T> {
         if ::proxy::contract::CONTRACT_VERSION != versions[1].module.info.version.to_string()
             && self.account.proxy.upload_if_needed()?.is_some()
         {
-            modules_to_register.push((
+            accounts_to_register.push((
                 self.account.proxy.as_instance(),
                 ::proxy::contract::CONTRACT_VERSION.to_string(),
             ));
         }
 
-        if !modules_to_register.is_empty() {
+        if !accounts_to_register.is_empty() {
             self.version_control
-                .register_account_mods(modules_to_register)?;
+                .register_account_mods(accounts_to_register)?;
             has_migrated = true
         }
 
-        if self.ibc.migrate_if_version_changed()? {
+        if self.ibc.deploy_if_version_changed(self)? {
             has_migrated = true
         }
 
+        self.version_control.register_natives(natives_to_register)?;
         self.version_control.approve_any_abstract_modules()?;
 
         Ok(has_migrated)
@@ -139,7 +153,7 @@ impl<T: CwEnv> Abstract<T> {
 
     /// Update native modules in version control  
     pub fn update_natives_in_version_control(&self) -> Result<(), crate::AbstractInterfaceError> {
-        let mut natives = vec![];
+        let mut natives_to_register = vec![];
 
         let modules = self
             .version_control
@@ -150,8 +164,6 @@ impl<T: CwEnv> Abstract<T> {
                 ModuleInfo::from_id_latest(ANS_HOST)?,
                 ModuleInfo::from_id_latest(IBC_CLIENT)?,
                 ModuleInfo::from_id_latest(IBC_HOST)?,
-                // ModuleInfo::from_id_latest(MANAGER)?,
-                // ModuleInfo::from_id_latest(PROXY)?,
             ])?
             .modules;
 
@@ -161,35 +173,28 @@ impl<T: CwEnv> Abstract<T> {
         let ans_host_module = modules[3].module.clone();
         let ibc_client_module = modules[4].module.clone();
         let ibc_host_module = modules[5].module.clone();
-        // let manager_module = modules[6].module.clone();
-        // let proxy_module = modules[7].module.clone();
 
-        let account_factory_cw2_v = contract_version(&self.account_factory)?.version;
-        let module_factory_cw2_v = contract_version(&self.module_factory)?.version;
-        let version_control_cw2_v = contract_version(&self.version_control)?.version;
-        let ans_host_cw2_v = contract_version(&self.ans_host)?.version;
-        let ibc_client_cw2_v = contract_version(&self.ibc.client)?.version;
-        let ibc_host_cw2_v = contract_version(&self.ibc.host)?.version;
-        // We might not have accounts
-        // let manager_cw2_v = contract_version(&self.account.manager)?.version;
-        // let proxy_cw2_v = contract_version(&self.account.proxy)?.version;
-
-        let versions = vec![
-            account_factory_cw2_v,
-            module_factory_cw2_v,
-            version_control_cw2_v,
-            ans_host_cw2_v,
-            ibc_client_cw2_v,
-            ibc_host_cw2_v,
-            // manager_cw2_v,
-            // proxy_cw2_v,
-        ];
-        panic!("{versions:?}");
+        // In case cw2 debugging required
+        // let account_factory_cw2_v = contract_version(&self.account_factory)?.version;
+        // let module_factory_cw2_v = contract_version(&self.module_factory)?.version;
+        // let version_control_cw2_v = contract_version(&self.version_control)?.version;
+        // let ans_host_cw2_v = contract_version(&self.ans_host)?.version;
+        // let ibc_client_cw2_v = contract_version(&self.ibc.client)?.version;
+        // let ibc_host_cw2_v = contract_version(&self.ibc.host)?.version;
+        // let versions = vec![
+        //     account_factory_cw2_v,
+        //     module_factory_cw2_v,
+        //     version_control_cw2_v,
+        //     ans_host_cw2_v,
+        //     ibc_client_cw2_v,
+        //     ibc_host_cw2_v,
+        // ];
+        // panic!("{versions:?}");
 
         if ::account_factory::contract::CONTRACT_VERSION
             != account_factory_module.info.version.to_string()
         {
-            natives.push((
+            natives_to_register.push((
                 self.account_factory.as_instance(),
                 ::account_factory::contract::CONTRACT_VERSION.to_string(),
             ));
@@ -198,7 +203,7 @@ impl<T: CwEnv> Abstract<T> {
         if ::module_factory::contract::CONTRACT_VERSION
             != module_factory_module.info.version.to_string()
         {
-            natives.push((
+            natives_to_register.push((
                 self.module_factory.as_instance(),
                 ::module_factory::contract::CONTRACT_VERSION.to_string(),
             ));
@@ -207,48 +212,34 @@ impl<T: CwEnv> Abstract<T> {
         if ::version_control::contract::CONTRACT_VERSION
             != version_control_module.info.version.to_string()
         {
-            natives.push((
+            natives_to_register.push((
                 self.version_control.as_instance(),
                 ::version_control::contract::CONTRACT_VERSION.to_string(),
             ));
         }
 
         if ::ans_host::contract::CONTRACT_VERSION != ans_host_module.info.version.to_string() {
-            natives.push((
+            natives_to_register.push((
                 self.ans_host.as_instance(),
                 ::ans_host::contract::CONTRACT_VERSION.to_string(),
             ));
         }
 
         if ::ibc_client::contract::CONTRACT_VERSION != ibc_client_module.info.version.to_string() {
-            natives.push((
+            natives_to_register.push((
                 self.ibc.client.as_instance(),
                 ::ibc_client::contract::CONTRACT_VERSION.to_string(),
             ));
         }
 
         if ::ibc_host::contract::CONTRACT_VERSION != ibc_host_module.info.version.to_string() {
-            natives.push((
+            natives_to_register.push((
                 self.ibc.host.as_instance(),
                 ::ibc_host::contract::CONTRACT_VERSION.to_string(),
             ));
         }
 
-        // if ::manager::contract::CONTRACT_VERSION != manager_module.info.version.to_string() {
-        //     natives.push((
-        //         self.account.manager.as_instance(),
-        //         ::manager::contract::CONTRACT_VERSION.to_string(),
-        //     ));
-        // }
-
-        // if ::proxy::contract::CONTRACT_VERSION != proxy_module.info.version.to_string() {
-        //     natives.push((
-        //         self.account.proxy.as_instance(),
-        //         ::proxy::contract::CONTRACT_VERSION.to_string(),
-        //     ));
-        // }
-
-        self.version_control.register_natives(natives)?;
+        self.version_control.register_natives(natives_to_register)?;
         self.version_control.approve_any_abstract_modules()?;
 
         Ok(())
@@ -270,39 +261,26 @@ fn contract_version<Chain: CwEnv, A: ContractInstance<Chain>>(
 }
 
 impl<Chain: CwEnv> AbstractIbc<Chain> {
-    /// Migrate the deployment based on the uploaded and local wasm files. If the remote wasm file is older, upload the contract and migrate to the new version.
-    pub fn migrate_if_needed(&self) -> Result<bool, crate::AbstractInterfaceError> {
-        let client = self
-            .client
-            .upload_and_migrate_if_needed(&ibc_client::MigrateMsg {})?;
-        let host = self
-            .host
-            .upload_and_migrate_if_needed(&ibc_host::MigrateMsg {})?;
-        Ok(client.is_some() || host.is_some())
-    }
-
-    /// Migrate the ibc based on version changes. If the registered contracts have the right version, we don't migrate them
-    pub fn migrate_if_version_changed(&self) -> Result<bool, crate::AbstractInterfaceError> {
-        let mut has_migrated = false;
-
-        if ::ibc_client::contract::CONTRACT_VERSION != contract_version(&self.client)?.version {
-            let migration_result = self
-                .client
-                .upload_and_migrate_if_needed(&ibc_client::MigrateMsg {})?;
-            if migration_result.is_some() {
-                has_migrated = true;
-            }
+    /// Deploy the ibc based on version changes. If the registered contracts have the right version, we don't deploy them
+    pub fn deploy_if_version_changed(
+        &self,
+        abstr: &Abstract<Chain>,
+    ) -> Result<bool, crate::AbstractInterfaceError> {
+        // IBC client and IBC host supposed to be versioned equally
+        if ::ibc_client::contract::CONTRACT_VERSION == contract_version(&self.client)?.version {
+            // No need to deploy
+            return Ok(false);
         }
 
-        if ::ibc_host::contract::CONTRACT_VERSION != contract_version(&self.host)?.version {
-            let migration_result = self
-                .host
-                .upload_and_migrate_if_needed(&ibc_host::MigrateMsg {})?;
-            if migration_result.is_some() {
-                has_migrated = true;
-            }
-        }
+        // Version changed we need to deploy new version
+        self.client
+            .upload_if_needed()?
+            .expect("IBC client wasm might be outdated");
+        self.host
+            .upload_if_needed()?
+            .expect("IBC host wasm might be outdated");
+        self.instantiate(abstr, &self.client.get_chain().sender())?;
 
-        Ok(has_migrated)
+        Ok(true)
     }
 }

--- a/interchain/scripts/src/bin/migrate.rs
+++ b/interchain/scripts/src/bin/migrate.rs
@@ -27,48 +27,47 @@ fn migrate(networks: Vec<ChainInfo>) -> anyhow::Result<()> {
 
         let deployment = Abstract::load_from(chain.clone())?;
 
-        // deployment.migrate_if_version_changed()?;
-        deployment.update_natives_in_version_control()?;
+        deployment.migrate_if_version_changed()?;
 
-        // // Deploy Adapters
-        // CwStakingAdapter::new(CW_STAKING_ADAPTER_ID, chain.clone()).deploy(
-        //     abstract_cw_staking::contract::CONTRACT_VERSION.parse()?,
-        //     Empty {},
-        //     DeployStrategy::Try,
-        // )?;
-        // DexAdapter::new(DEX_ADAPTER_ID, chain.clone()).deploy(
-        //     abstract_dex_adapter::contract::CONTRACT_VERSION.parse()?,
-        //     DexInstantiateMsg {
-        //         recipient_account: 0,
-        //         swap_fee: Decimal::permille(3),
-        //     },
-        //     DeployStrategy::Try,
-        // )?;
-        // MoneyMarketAdapter::new(MONEY_MARKET_ADAPTER_ID, chain.clone()).deploy(
-        //     abstract_money_market_adapter::contract::CONTRACT_VERSION.parse()?,
-        //     MoneyMarketInstantiateMsg {
-        //         recipient_account: 0,
-        //         fee: Decimal::permille(3),
-        //     },
-        //     DeployStrategy::Try,
-        // )?;
+        // Deploy Adapters
+        CwStakingAdapter::new(CW_STAKING_ADAPTER_ID, chain.clone()).deploy(
+            abstract_cw_staking::contract::CONTRACT_VERSION.parse()?,
+            Empty {},
+            DeployStrategy::Try,
+        )?;
+        DexAdapter::new(DEX_ADAPTER_ID, chain.clone()).deploy(
+            abstract_dex_adapter::contract::CONTRACT_VERSION.parse()?,
+            DexInstantiateMsg {
+                recipient_account: 0,
+                swap_fee: Decimal::permille(3),
+            },
+            DeployStrategy::Try,
+        )?;
+        MoneyMarketAdapter::new(MONEY_MARKET_ADAPTER_ID, chain.clone()).deploy(
+            abstract_money_market_adapter::contract::CONTRACT_VERSION.parse()?,
+            MoneyMarketInstantiateMsg {
+                recipient_account: 0,
+                fee: Decimal::permille(3),
+            },
+            DeployStrategy::Try,
+        )?;
 
-        // // Deploy apps
-        // Etf::new(ETF_APP_ID, chain.clone()).deploy(
-        //     etf_app::contract::CONTRACT_VERSION.parse()?,
-        //     DeployStrategy::Try,
-        // )?;
+        // Deploy apps
+        Etf::new(ETF_APP_ID, chain.clone()).deploy(
+            etf_app::contract::CONTRACT_VERSION.parse()?,
+            DeployStrategy::Try,
+        )?;
 
-        // DCA::new(DCA_APP_ID, chain.clone()).deploy(
-        //     dca_app::contract::DCA_APP_VERSION.parse()?,
-        //     DeployStrategy::Try,
-        // )?;
-        // Challenge::new(CHALLENGE_APP_ID, chain.clone()).deploy(
-        //     challenge_app::contract::CHALLENGE_APP_VERSION.parse()?,
-        //     DeployStrategy::Try,
-        // )?;
+        DCA::new(DCA_APP_ID, chain.clone()).deploy(
+            dca_app::contract::DCA_APP_VERSION.parse()?,
+            DeployStrategy::Try,
+        )?;
+        Challenge::new(CHALLENGE_APP_ID, chain.clone()).deploy(
+            challenge_app::contract::CHALLENGE_APP_VERSION.parse()?,
+            DeployStrategy::Try,
+        )?;
 
-        // deployment.version_control.approve_any_abstract_modules()?;
+        deployment.version_control.approve_any_abstract_modules()?;
     }
 
     Ok(())

--- a/interchain/scripts/src/bin/migrate.rs
+++ b/interchain/scripts/src/bin/migrate.rs
@@ -27,47 +27,48 @@ fn migrate(networks: Vec<ChainInfo>) -> anyhow::Result<()> {
 
         let deployment = Abstract::load_from(chain.clone())?;
 
-        deployment.migrate_if_version_changed()?;
+        // deployment.migrate_if_version_changed()?;
+        deployment.update_natives_in_version_control()?;
 
-        // Deploy Adapters
-        CwStakingAdapter::new(CW_STAKING_ADAPTER_ID, chain.clone()).deploy(
-            abstract_cw_staking::contract::CONTRACT_VERSION.parse()?,
-            Empty {},
-            DeployStrategy::Try,
-        )?;
-        DexAdapter::new(DEX_ADAPTER_ID, chain.clone()).deploy(
-            abstract_dex_adapter::contract::CONTRACT_VERSION.parse()?,
-            DexInstantiateMsg {
-                recipient_account: 0,
-                swap_fee: Decimal::permille(3),
-            },
-            DeployStrategy::Try,
-        )?;
-        MoneyMarketAdapter::new(MONEY_MARKET_ADAPTER_ID, chain.clone()).deploy(
-            abstract_money_market_adapter::contract::CONTRACT_VERSION.parse()?,
-            MoneyMarketInstantiateMsg {
-                recipient_account: 0,
-                fee: Decimal::permille(3),
-            },
-            DeployStrategy::Try,
-        )?;
+        // // Deploy Adapters
+        // CwStakingAdapter::new(CW_STAKING_ADAPTER_ID, chain.clone()).deploy(
+        //     abstract_cw_staking::contract::CONTRACT_VERSION.parse()?,
+        //     Empty {},
+        //     DeployStrategy::Try,
+        // )?;
+        // DexAdapter::new(DEX_ADAPTER_ID, chain.clone()).deploy(
+        //     abstract_dex_adapter::contract::CONTRACT_VERSION.parse()?,
+        //     DexInstantiateMsg {
+        //         recipient_account: 0,
+        //         swap_fee: Decimal::permille(3),
+        //     },
+        //     DeployStrategy::Try,
+        // )?;
+        // MoneyMarketAdapter::new(MONEY_MARKET_ADAPTER_ID, chain.clone()).deploy(
+        //     abstract_money_market_adapter::contract::CONTRACT_VERSION.parse()?,
+        //     MoneyMarketInstantiateMsg {
+        //         recipient_account: 0,
+        //         fee: Decimal::permille(3),
+        //     },
+        //     DeployStrategy::Try,
+        // )?;
 
-        // Deploy apps
-        Etf::new(ETF_APP_ID, chain.clone()).deploy(
-            etf_app::contract::CONTRACT_VERSION.parse()?,
-            DeployStrategy::Try,
-        )?;
+        // // Deploy apps
+        // Etf::new(ETF_APP_ID, chain.clone()).deploy(
+        //     etf_app::contract::CONTRACT_VERSION.parse()?,
+        //     DeployStrategy::Try,
+        // )?;
 
-        DCA::new(DCA_APP_ID, chain.clone()).deploy(
-            dca_app::contract::DCA_APP_VERSION.parse()?,
-            DeployStrategy::Try,
-        )?;
-        Challenge::new(CHALLENGE_APP_ID, chain.clone()).deploy(
-            challenge_app::contract::CHALLENGE_APP_VERSION.parse()?,
-            DeployStrategy::Try,
-        )?;
+        // DCA::new(DCA_APP_ID, chain.clone()).deploy(
+        //     dca_app::contract::DCA_APP_VERSION.parse()?,
+        //     DeployStrategy::Try,
+        // )?;
+        // Challenge::new(CHALLENGE_APP_ID, chain.clone()).deploy(
+        //     challenge_app::contract::CHALLENGE_APP_VERSION.parse()?,
+        //     DeployStrategy::Try,
+        // )?;
 
-        deployment.version_control.approve_any_abstract_modules()?;
+        // deployment.version_control.approve_any_abstract_modules()?;
     }
 
     Ok(())


### PR DESCRIPTION
This PR aims to add updating of native contracts in version control

- update_natives_in_version_control added to the `abstract_interface::Abstract` for registering new versions of native contracts in Version Control (useful for refreshing VC, did run this method on pion)
- Added registration migrated native contracts to Version Control in `migrate_if_version_changed` method
- IBC client and host now deployed instead of migration on version change

### Checklist

- [ ] CI is green.
- [ ] Changelog updated.
