### PR TITLE
Remove useless MessageInfo field inside the ibccallback handler

### DIFF
--- a/framework/docs/src/releases/v0.md
+++ b/framework/docs/src/releases/v0.md
@@ -42,6 +42,7 @@
 ### Removed
 
 - Accounts with local sequence 0..2147483648 cannot be predicted
+- Ibc Callback handler no longer includes `MessageInfo` as sender is always ibc_client and funds are empty
 
 ### Fixed
 

--- a/framework/packages/abstract-adapter/src/lib.rs
+++ b/framework/packages/abstract-adapter/src/lib.rs
@@ -129,7 +129,7 @@ pub mod mock {
             })
             .with_sudo(|_, _, _, _| Ok(Response::new().set_data("mock_sudo".as_bytes())))
             .with_receive(|_, _, _, _, _| Ok(Response::new().set_data("mock_receive".as_bytes())))
-            .with_ibc_callback(|deps, _, _, _, _, _| {
+            .with_ibc_callback(|deps, _, _, _, _| {
                 IBC_CALLBACK_RECEIVED.save(deps.storage, &true).unwrap();
                 Ok(Response::new().set_data("mock_callback".as_bytes()))
             })

--- a/framework/packages/abstract-adapter/src/state.rs
+++ b/framework/packages/abstract-adapter/src/state.rs
@@ -191,7 +191,7 @@ mod tests {
             .with_query(|_, _, _, _| cosmwasm_std::to_json_binary("mock_query").map_err(Into::into))
             .with_sudo(|_, _, _, _| Ok(Response::new().set_data("mock_sudo".as_bytes())))
             .with_receive(|_, _, _, _, _| Ok(Response::new().set_data("mock_receive".as_bytes())))
-            .with_ibc_callback(|_, _, _, _, _, _| {
+            .with_ibc_callback(|_, _, _, _, _| {
                 Ok(Response::new().set_data("mock_callback".as_bytes()))
             })
             .with_replies(&[(1u64, |_, _, _, msg| {

--- a/framework/packages/abstract-app/src/lib.rs
+++ b/framework/packages/abstract-app/src/lib.rs
@@ -152,7 +152,7 @@ pub mod mock {
             })
             .with_sudo(|_, _, _, _| Ok(Response::new().set_data("mock_sudo".as_bytes())))
             .with_receive(|_, _, _, _, _| Ok(Response::new().set_data("mock_receive".as_bytes())))
-            .with_ibc_callback(|deps, _, _, _, _, _| {
+            .with_ibc_callback(|deps, _, _, _, _| {
                 IBC_CALLBACK_RECEIVED.save(deps.storage, &true).unwrap();
 
                 Ok(Response::new().add_attribute("mock_callback", "executed"))

--- a/framework/packages/abstract-app/src/state.rs
+++ b/framework/packages/abstract-app/src/state.rs
@@ -190,7 +190,7 @@ mod tests {
             .with_query(|_, _, _, _| cosmwasm_std::to_json_binary("mock_query").map_err(Into::into))
             .with_sudo(|_, _, _, _| Ok(Response::new().set_data("mock_sudo".as_bytes())))
             .with_receive(|_, _, _, _, _| Ok(Response::new().set_data("mock_receive".as_bytes())))
-            .with_ibc_callback(|_, _, _, _, _, _| {
+            .with_ibc_callback(|_, _, _, _, _| {
                 Ok(Response::new().set_data("mock_callback".as_bytes()))
             })
             .with_replies(&[(1u64, |_, _, _, msg| {

--- a/framework/packages/abstract-sdk/src/base/contract_base.rs
+++ b/framework/packages/abstract-sdk/src/base/contract_base.rs
@@ -34,7 +34,7 @@ pub type QueryHandlerFn<Module, CustomQueryMsg, Error> =
 // ANCHOR: ibc
 /// Function signature for an IBC callback handler.
 pub type IbcCallbackHandlerFn<Module, Error> =
-    fn(DepsMut, Env, MessageInfo, Module, Callback, IbcResult) -> Result<Response, Error>;
+    fn(DepsMut, Env, Module, Callback, IbcResult) -> Result<Response, Error>;
 // ANCHOR_END: ibc
 
 // ANCHOR: module_ibc
@@ -377,7 +377,7 @@ mod test {
     #[test]
     fn test_with_ibc_callback_handlers() {
         const HANDLER: IbcCallbackHandlerFn<MockModule, MockError> =
-            |_, _, _, _, _, _| Ok(Response::default().add_attribute("test", "ibc"));
+            |_, _, _, _, _| Ok(Response::default().add_attribute("test", "ibc"));
         let contract = MockAppContract::new("test_contract", "0.1.0", ModuleMetadata::default())
             .with_ibc_callback(HANDLER);
 

--- a/framework/packages/abstract-sdk/src/base/endpoints/ibc_callback.rs
+++ b/framework/packages/abstract-sdk/src/base/endpoints/ibc_callback.rs
@@ -46,6 +46,6 @@ pub trait IbcCallbackEndpoint: Handler {
                     self.module_id().to_string(),
                 ))?;
 
-        ibc_callback_handler(deps, env, info, self, msg.callback, msg.result)
+        ibc_callback_handler(deps, env, self, msg.callback, msg.result)
     }
 }

--- a/interchain/interchain-tests/src/module_to_module_interactions.rs
+++ b/interchain/interchain-tests/src/module_to_module_interactions.rs
@@ -249,7 +249,7 @@ pub const fn mock_app(id: &'static str, version: &'static str) -> MockAppContrac
         })
         .with_sudo(|_, _, _, _| Ok(Response::new().set_data("mock_sudo".as_bytes())))
         .with_receive(|_, _, _, _, _| Ok(Response::new().set_data("mock_receive".as_bytes())))
-        .with_ibc_callback(|deps, _, _, _, callback, result| {
+        .with_ibc_callback(|deps, _, _, callback, result| {
             eprintln!("{:?}", result);
             match &result {
                 IbcResult::Query {


### PR DESCRIPTION
See ABS-426
### Checklist

- [x] CI is green.
- [x] Changelog updated.
