### PR TITLE
Rename `ChainName` to `TruncatedChainId`

### DIFF
--- a/framework/contracts/native/ans-host/src/queries.rs
+++ b/framework/contracts/native/ans-host/src/queries.rs
@@ -305,7 +305,7 @@ mod test {
     };
     use abstract_std::{
         ans_host::*,
-        objects::{chain_name::ChainName, pool_id::PoolAddressBase, PoolType},
+        objects::{pool_id::PoolAddressBase, truncated_chain_id::TruncatedChainId, PoolType},
     };
     use abstract_testing::OWNER;
     use cosmwasm_std::{
@@ -409,7 +409,7 @@ mod test {
             .map(|input| {
                 (
                     ChannelEntry {
-                        connected_chain: ChainName::from_string(
+                        connected_chain: TruncatedChainId::from_string(
                             input.0.to_string().to_ascii_lowercase(),
                         )
                         .unwrap(),
@@ -426,8 +426,10 @@ mod test {
         let channel_entry: Vec<ChannelEntry> = input
             .into_iter()
             .map(|input| ChannelEntry {
-                connected_chain: ChainName::from_string(input.0.to_string().to_ascii_lowercase())
-                    .unwrap(),
+                connected_chain: TruncatedChainId::from_string(
+                    input.0.to_string().to_ascii_lowercase(),
+                )
+                .unwrap(),
                 protocol: input.1.to_string().to_ascii_lowercase(),
             })
             .collect();
@@ -837,7 +839,7 @@ mod test {
         // Filter for entries after `Foo` - Alphabetically
         let msg = QueryMsg::ChannelList {
             start_after: Some(ChannelEntry {
-                connected_chain: ChainName::from_str("foo").unwrap(),
+                connected_chain: TruncatedChainId::from_str("foo").unwrap(),
                 protocol: "foo1".to_string(),
             }),
             limit: Some(42_u8),

--- a/framework/contracts/native/ibc-client/src/commands.rs
+++ b/framework/contracts/native/ibc-client/src/commands.rs
@@ -14,8 +14,8 @@ use abstract_std::{
     ibc_host::{self, HostAction, InternalAction},
     manager::{self, ModuleInstallConfig},
     objects::{
-        chain_name::ChainName, module::ModuleInfo, module_reference::ModuleReference, AccountId,
-        AssetEntry, ChannelEntry,
+        module::ModuleInfo, module_reference::ModuleReference,
+        truncated_chain_id::TruncatedChainId, AccountId, AssetEntry, ChannelEntry,
     },
     version_control::AccountBase,
     IBC_CLIENT, ICS20,
@@ -68,7 +68,7 @@ pub fn execute_register_infrastructure(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
-    host_chain: ChainName,
+    host_chain: TruncatedChainId,
     host: String,
     note: String,
 ) -> IbcClientResult {
@@ -117,7 +117,7 @@ pub fn execute_register_infrastructure(
 pub fn execute_remove_host(
     deps: DepsMut,
     info: MessageInfo,
-    host_chain: ChainName,
+    host_chain: TruncatedChainId,
 ) -> IbcClientResult {
     host_chain.verify()?;
 
@@ -137,7 +137,7 @@ fn send_remote_host_action(
     deps: Deps,
     account_id: AccountId,
     account: AccountBase,
-    host_chain: ChainName,
+    host_chain: TruncatedChainId,
     action: HostAction,
     callback_request: Option<CallbackRequest>,
 ) -> IbcClientResult<CosmosMsg<Empty>> {
@@ -177,7 +177,7 @@ pub fn execute_send_packet(
     deps: DepsMut,
     _env: Env,
     info: MessageInfo,
-    host_chain: ChainName,
+    host_chain: TruncatedChainId,
     action: HostAction,
 ) -> IbcClientResult {
     host_chain.verify()?;
@@ -221,7 +221,7 @@ pub fn execute_send_module_to_module_packet(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
-    host_chain: ChainName,
+    host_chain: TruncatedChainId,
     target_module: ModuleInfo,
     msg: Binary,
     callback: Option<Callback>,
@@ -322,7 +322,7 @@ pub fn execute_send_query(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
-    host_chain: ChainName,
+    host_chain: TruncatedChainId,
     queries: Vec<QueryRequest<ModuleQuery>>,
     callback: Callback,
 ) -> IbcClientResult {
@@ -366,7 +366,7 @@ pub fn execute_register_account(
     deps: DepsMut,
     info: MessageInfo,
     env: Env,
-    host_chain: ChainName,
+    host_chain: TruncatedChainId,
     base_asset: Option<AssetEntry>,
     namespace: Option<String>,
     install_modules: Vec<ModuleInstallConfig>,
@@ -414,7 +414,7 @@ pub fn execute_send_funds(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
-    host_chain: ChainName,
+    host_chain: TruncatedChainId,
     funds: Vec<Coin>,
 ) -> IbcClientResult {
     host_chain.verify()?;

--- a/framework/contracts/native/ibc-client/src/contract.rs
+++ b/framework/contracts/native/ibc-client/src/contract.rs
@@ -322,7 +322,7 @@ mod tests {
     mod register_infrastructure {
         use std::str::FromStr;
 
-        use abstract_std::objects::chain_name::ChainName;
+        use abstract_std::objects::truncated_chain_id::TruncatedChainId;
         use cosmwasm_std::wasm_execute;
         use polytone::callbacks::CallbackRequest;
 
@@ -345,7 +345,7 @@ mod tests {
 
             IBC_INFRA.save(
                 deps.as_mut().storage,
-                &ChainName::from_str(TEST_CHAIN)?,
+                &TruncatedChainId::from_str(TEST_CHAIN)?,
                 &IbcInfrastructure {
                     polytone_note: Addr::unchecked("note"),
                     remote_abstract_host: "test_remote_host".into(),
@@ -372,7 +372,7 @@ mod tests {
             let mut deps = mock_dependencies();
             mock_init(deps.as_mut())?;
 
-            let chain_name = ChainName::from_str(TEST_CHAIN)?;
+            let chain_name = TruncatedChainId::from_str(TEST_CHAIN)?;
             let note = String::from("note");
             let host = String::from("test_remote_host");
 
@@ -469,7 +469,7 @@ mod tests {
         use abstract_std::{
             ibc_host::{self, HostAction, InternalAction},
             manager,
-            objects::{chain_name::ChainName, version_control::VersionControlError},
+            objects::{truncated_chain_id::TruncatedChainId, version_control::VersionControlError},
         };
 
         use cosmwasm_std::wasm_execute;
@@ -482,7 +482,7 @@ mod tests {
             deps.querier = mocked_account_querier_builder().build();
             mock_init(deps.as_mut())?;
 
-            let chain_name = ChainName::from_str(TEST_CHAIN)?;
+            let chain_name = TruncatedChainId::from_str(TEST_CHAIN)?;
 
             let msg = ExecuteMsg::RemoteAction {
                 host_chain: chain_name,
@@ -512,7 +512,7 @@ mod tests {
             deps.querier = mocked_account_querier_builder().build();
             mock_init(deps.as_mut())?;
 
-            let chain_name = ChainName::from_str(TEST_CHAIN)?;
+            let chain_name = TruncatedChainId::from_str(TEST_CHAIN)?;
 
             let msg = ExecuteMsg::RemoteAction {
                 host_chain: chain_name,
@@ -540,7 +540,7 @@ mod tests {
             deps.querier = mocked_account_querier_builder().build();
             mock_init(deps.as_mut())?;
 
-            let chain_name = ChainName::from_str(TEST_CHAIN)?;
+            let chain_name = TruncatedChainId::from_str(TEST_CHAIN)?;
             let note_contract = Addr::unchecked("note");
             let remote_ibc_host = String::from("test_remote_host");
 
@@ -602,7 +602,10 @@ mod tests {
 
         use crate::commands::PACKET_LIFETIME;
         use abstract_std::{
-            objects::{chain_name::ChainName, version_control::VersionControlError, ChannelEntry},
+            objects::{
+                truncated_chain_id::TruncatedChainId, version_control::VersionControlError,
+                ChannelEntry,
+            },
             ICS20,
         };
         use cosmwasm_std::{coins, Coin, CosmosMsg, IbcMsg};
@@ -614,7 +617,7 @@ mod tests {
             deps.querier = mocked_account_querier_builder().build();
             mock_init(deps.as_mut())?;
 
-            let chain_name = ChainName::from_str(TEST_CHAIN)?;
+            let chain_name = TruncatedChainId::from_str(TEST_CHAIN)?;
 
             let msg = ExecuteMsg::SendFunds {
                 host_chain: chain_name,
@@ -635,7 +638,7 @@ mod tests {
         #[test]
         fn works() -> IbcClientTestResult {
             let mut deps = mock_dependencies();
-            let chain_name = ChainName::from_str(TEST_CHAIN)?;
+            let chain_name = TruncatedChainId::from_str(TEST_CHAIN)?;
             let channel_entry = ChannelEntry {
                 connected_chain: chain_name.clone(),
                 protocol: String::from(ICS20),
@@ -692,7 +695,7 @@ mod tests {
             ibc_host::{self, HostAction, InternalAction},
             manager,
             objects::{
-                chain_name::ChainName, gov_type::GovernanceDetails,
+                gov_type::GovernanceDetails, truncated_chain_id::TruncatedChainId,
                 version_control::VersionControlError,
             },
         };
@@ -706,7 +709,7 @@ mod tests {
             deps.querier = mocked_account_querier_builder().build();
             mock_init(deps.as_mut())?;
 
-            let chain_name = ChainName::from_str(TEST_CHAIN)?;
+            let chain_name = TruncatedChainId::from_str(TEST_CHAIN)?;
 
             let msg = ExecuteMsg::Register {
                 host_chain: chain_name,
@@ -751,7 +754,7 @@ mod tests {
                 .build();
             mock_init(deps.as_mut())?;
 
-            let chain_name = ChainName::from_str(TEST_CHAIN)?;
+            let chain_name = TruncatedChainId::from_str(TEST_CHAIN)?;
             let note_contract = Addr::unchecked("note");
             let remote_ibc_host = String::from("test_remote_host");
 
@@ -818,7 +821,7 @@ mod tests {
     mod update_config {
         use std::str::FromStr;
 
-        use abstract_std::objects::chain_name::ChainName;
+        use abstract_std::objects::truncated_chain_id::TruncatedChainId;
 
         use super::*;
 
@@ -888,7 +891,7 @@ mod tests {
                 (
                     TEST_ACCOUNT_ID.trace(),
                     TEST_ACCOUNT_ID.seq(),
-                    &ChainName::from_str("channel")?,
+                    &TruncatedChainId::from_str("channel")?,
                 ),
                 &"Some-remote-account".to_string(),
             )?;
@@ -912,7 +915,7 @@ mod tests {
     mod remove_host {
         use std::str::FromStr;
 
-        use abstract_std::objects::chain_name::ChainName;
+        use abstract_std::objects::truncated_chain_id::TruncatedChainId;
 
         use super::*;
 
@@ -930,7 +933,7 @@ mod tests {
 
             IBC_INFRA.save(
                 deps.as_mut().storage,
-                &ChainName::from_str(TEST_CHAIN)?,
+                &TruncatedChainId::from_str(TEST_CHAIN)?,
                 &IbcInfrastructure {
                     polytone_note: Addr::unchecked("note"),
                     remote_abstract_host: "test_remote_host".into(),
@@ -969,7 +972,9 @@ mod tests {
     mod callback {
         use std::str::FromStr;
 
-        use abstract_std::objects::{account::TEST_ACCOUNT_ID, chain_name::ChainName};
+        use abstract_std::objects::{
+            account::TEST_ACCOUNT_ID, truncated_chain_id::TruncatedChainId,
+        };
         use cosmwasm_std::{from_json, Binary, Event, SubMsgResponse};
         use polytone::callbacks::{Callback, CallbackMessage, ExecutionResponse};
 
@@ -981,7 +986,7 @@ mod tests {
             mock_init(deps.as_mut())?;
 
             let note = Addr::unchecked("note");
-            let chain_name = ChainName::from_str(TEST_CHAIN)?;
+            let chain_name = TruncatedChainId::from_str(TEST_CHAIN)?;
             REVERSE_POLYTONE_NOTE.save(deps.as_mut().storage, &note, &chain_name)?;
 
             let msg = ExecuteMsg::Callback(CallbackMessage {
@@ -1008,7 +1013,7 @@ mod tests {
             mock_init(deps.as_mut())?;
 
             let note = Addr::unchecked("note");
-            let chain_name = ChainName::from_str(TEST_CHAIN)?;
+            let chain_name = TruncatedChainId::from_str(TEST_CHAIN)?;
             REVERSE_POLYTONE_NOTE.save(deps.as_mut().storage, &note, &chain_name)?;
 
             let msg = ExecuteMsg::Callback(CallbackMessage {
@@ -1036,7 +1041,7 @@ mod tests {
             let env = mock_env();
 
             let note = Addr::unchecked("note");
-            let chain_name = ChainName::from_str(TEST_CHAIN)?;
+            let chain_name = TruncatedChainId::from_str(TEST_CHAIN)?;
             REVERSE_POLYTONE_NOTE.save(deps.as_mut().storage, &note, &chain_name)?;
 
             let msg = ExecuteMsg::Callback(CallbackMessage {
@@ -1063,7 +1068,7 @@ mod tests {
             mock_init(deps.as_mut())?;
             let env = mock_env();
 
-            let chain_name = ChainName::from_str(TEST_CHAIN)?;
+            let chain_name = TruncatedChainId::from_str(TEST_CHAIN)?;
             let note = Addr::unchecked("note");
             let remote_ibc_host = String::from("test_remote_host");
 
@@ -1100,7 +1105,7 @@ mod tests {
             mock_init(deps.as_mut())?;
             let env = mock_env();
 
-            let chain_name = ChainName::from_str(TEST_CHAIN)?;
+            let chain_name = TruncatedChainId::from_str(TEST_CHAIN)?;
             let note = Addr::unchecked("note");
             let remote_ibc_host = String::from("test_remote_host");
 
@@ -1154,7 +1159,7 @@ mod tests {
             mock_init(deps.as_mut())?;
             let env = mock_env();
 
-            let chain_name = ChainName::from_str(TEST_CHAIN)?;
+            let chain_name = TruncatedChainId::from_str(TEST_CHAIN)?;
             let note = Addr::unchecked("note");
 
             REVERSE_POLYTONE_NOTE.save(deps.as_mut().storage, &note, &chain_name)?;
@@ -1183,7 +1188,7 @@ mod tests {
             mock_init(deps.as_mut())?;
             let env = mock_env();
 
-            let chain_name = ChainName::from_str(TEST_CHAIN)?;
+            let chain_name = TruncatedChainId::from_str(TEST_CHAIN)?;
             let note = Addr::unchecked("note");
             let remote_proxy = String::from("remote_proxy");
 
@@ -1219,7 +1224,7 @@ mod tests {
             mock_init(deps.as_mut())?;
             let env = mock_env();
 
-            let chain_name = ChainName::from_str(TEST_CHAIN)?;
+            let chain_name = TruncatedChainId::from_str(TEST_CHAIN)?;
             let note = Addr::unchecked("note");
             let remote_proxy = String::from("remote_proxy");
 
@@ -1255,7 +1260,7 @@ mod tests {
             mock_init(deps.as_mut())?;
             let env = mock_env();
 
-            let chain_name = ChainName::from_str(TEST_CHAIN)?;
+            let chain_name = TruncatedChainId::from_str(TEST_CHAIN)?;
             let note = Addr::unchecked("note");
             let remote_proxy = String::from("remote_proxy");
 
@@ -1350,7 +1355,9 @@ mod tests {
 
         use std::str::FromStr;
 
-        use abstract_std::objects::{account::AccountTrace, chain_name::ChainName, AccountId};
+        use abstract_std::objects::{
+            account::AccountTrace, truncated_chain_id::TruncatedChainId, AccountId,
+        };
 
         #[test]
         fn works_with_multiple_local_accounts() -> IbcClientTestResult {
@@ -1359,10 +1366,10 @@ mod tests {
 
             let (trace, seq) = TEST_ACCOUNT_ID.decompose();
 
-            let chain1 = ChainName::from_str("chain-a")?;
+            let chain1 = TruncatedChainId::from_str("chain-a")?;
             let proxy1 = String::from("proxy1");
 
-            let chain2 = ChainName::from_str("chain-b")?;
+            let chain2 = TruncatedChainId::from_str("chain-b")?;
             let proxy2 = String::from("proxy2");
 
             ACCOUNTS.save(deps.as_mut().storage, (&trace, seq, &chain1), &proxy1)?;
@@ -1394,17 +1401,17 @@ mod tests {
             let account_id = AccountId::new(
                 1,
                 AccountTrace::Remote(vec![
-                    ChainName::from_str("juno")?,
-                    ChainName::from_str("osmosis")?,
+                    TruncatedChainId::from_str("juno")?,
+                    TruncatedChainId::from_str("osmosis")?,
                 ]),
             )?;
 
             let (trace, seq) = account_id.clone().decompose();
 
-            let terra_chain = ChainName::from_str("terra")?;
+            let terra_chain = TruncatedChainId::from_str("terra")?;
             let terra_proxy = String::from("terra-proxy");
 
-            let archway_chain = ChainName::from_str("archway")?;
+            let archway_chain = TruncatedChainId::from_str("archway")?;
             let archway_proxy = String::from("archway-proxy");
 
             ACCOUNTS.save(

--- a/framework/contracts/native/ibc-client/src/ibc.rs
+++ b/framework/contracts/native/ibc-client/src/ibc.rs
@@ -4,7 +4,7 @@ use abstract_std::{
         state::{ACCOUNTS, IBC_INFRA, REVERSE_POLYTONE_NOTE},
         IbcClientCallback,
     },
-    objects::chain_name::ChainName,
+    objects::truncated_chain_id::TruncatedChainId,
 };
 use cosmwasm_std::{from_json, Attribute, DepsMut, Env, MessageInfo};
 use polytone::callbacks::{Callback as PolytoneCallback, CallbackMessage};
@@ -24,7 +24,7 @@ pub fn receive_action_callback(
     // 1. First we verify the callback is well formed and sent by the right contract
 
     // only a note contract can call this endpoint
-    let host_chain: ChainName = REVERSE_POLYTONE_NOTE
+    let host_chain: TruncatedChainId = REVERSE_POLYTONE_NOTE
         .may_load(deps.storage, &info.sender)?
         .ok_or(IbcClientError::Unauthorized {})?;
 

--- a/framework/contracts/native/ibc-host/src/account_commands.rs
+++ b/framework/contracts/native/ibc-host/src/account_commands.rs
@@ -6,7 +6,7 @@ use abstract_std::{
     account_factory,
     ibc_host::state::CONFIG,
     manager::{self, ModuleInstallConfig},
-    objects::{chain_name::ChainName, AccountId, AssetEntry},
+    objects::{truncated_chain_id::TruncatedChainId, AccountId, AssetEntry},
     proxy,
     version_control::AccountBase,
     PROXY,
@@ -106,7 +106,7 @@ pub fn receive_send_all_back(
     env: Env,
     account: AccountBase,
     client_proxy_address: String,
-    client_chain: ChainName,
+    client_chain: TruncatedChainId,
 ) -> HostResult {
     let wasm_msg = send_all_back(
         deps.as_ref(),
@@ -125,7 +125,7 @@ pub fn send_all_back(
     env: Env,
     account: AccountBase,
     client_proxy_address: String,
-    client_chain: ChainName,
+    client_chain: TruncatedChainId,
 ) -> Result<CosmosMsg, HostError> {
     // get the ICS20 channel information
     let ans = CONFIG.load(deps.storage)?.ans_host;

--- a/framework/contracts/native/ibc-host/src/endpoints/execute.rs
+++ b/framework/contracts/native/ibc-host/src/endpoints/execute.rs
@@ -1,7 +1,7 @@
 use abstract_sdk::{feature_objects::VersionControlContract, std::ibc_host::ExecuteMsg};
 use abstract_std::{
     ibc_host::state::{CHAIN_PROXIES, CONFIG, REVERSE_CHAIN_PROXIES},
-    objects::chain_name::ChainName,
+    objects::truncated_chain_id::TruncatedChainId,
 };
 use cosmwasm_std::{DepsMut, Env, MessageInfo};
 
@@ -34,7 +34,8 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> H
             action,
         } => {
             // This endpoint retrieves the chain name from the executor of the message
-            let client_chain: ChainName = REVERSE_CHAIN_PROXIES.load(deps.storage, &info.sender)?;
+            let client_chain: TruncatedChainId =
+                REVERSE_CHAIN_PROXIES.load(deps.storage, &info.sender)?;
 
             handle_host_action(deps, env, client_chain, proxy_address, account_id, action)
         }
@@ -47,7 +48,8 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> H
             source_module,
             target_module,
         } => {
-            let src_chain: ChainName = REVERSE_CHAIN_PROXIES.load(deps.storage, &info.sender)?;
+            let src_chain: TruncatedChainId =
+                REVERSE_CHAIN_PROXIES.load(deps.storage, &info.sender)?;
             handle_module_execute(deps, env, src_chain, source_module, target_module, msg)
         }
     }
@@ -90,7 +92,7 @@ fn update_config(
 fn register_chain_proxy(
     deps: DepsMut,
     info: MessageInfo,
-    chain: ChainName,
+    chain: TruncatedChainId,
     proxy: String,
 ) -> HostResult {
     cw_ownable::assert_owner(deps.storage, &info.sender)?;
@@ -109,7 +111,7 @@ fn register_chain_proxy(
     Ok(HostResponse::action("register_chain_client"))
 }
 
-fn remove_chain_proxy(deps: DepsMut, info: MessageInfo, chain: ChainName) -> HostResult {
+fn remove_chain_proxy(deps: DepsMut, info: MessageInfo, chain: TruncatedChainId) -> HostResult {
     cw_ownable::assert_owner(deps.storage, &info.sender)?;
 
     chain.verify()?;

--- a/framework/contracts/native/ibc-host/src/endpoints/packet.rs
+++ b/framework/contracts/native/ibc-host/src/endpoints/packet.rs
@@ -7,8 +7,8 @@ use abstract_std::{
         HelperAction, HostAction, InternalAction,
     },
     objects::{
-        account::AccountTrace, chain_name::ChainName, module::ModuleInfo,
-        module_reference::ModuleReference, AccountId,
+        account::AccountTrace, module::ModuleInfo, module_reference::ModuleReference,
+        truncated_chain_id::TruncatedChainId, AccountId,
     },
 };
 use cosmwasm_std::{
@@ -28,7 +28,7 @@ use crate::{
 pub fn handle_host_action(
     deps: DepsMut,
     env: Env,
-    client_chain: ChainName,
+    client_chain: TruncatedChainId,
     proxy_address: String,
     received_account_id: AccountId,
     host_action: HostAction,
@@ -122,7 +122,7 @@ pub fn handle_host_action(
 pub fn handle_module_execute(
     deps: DepsMut,
     env: Env,
-    src_chain: ChainName,
+    src_chain: TruncatedChainId,
     source_module: InstalledModuleIdentification,
     target_module: ModuleInfo,
     msg: Binary,
@@ -197,14 +197,14 @@ pub fn handle_host_module_query(
 /// We need to figure what trace module is implying here
 pub fn client_to_host_module_account_id(
     env: &Env,
-    remote_chain: ChainName,
+    remote_chain: TruncatedChainId,
     mut account_id: AccountId,
 ) -> AccountId {
     let account_trace = account_id.trace_mut();
     match account_trace {
         AccountTrace::Local => account_trace.push_chain(remote_chain),
         AccountTrace::Remote(trace) => {
-            let current_chain_name = ChainName::from_chain_id(&env.block.chain_id);
+            let current_chain_name = TruncatedChainId::from_chain_id(&env.block.chain_id);
             // If current chain_name == last trace in account_id it means we got response back from remote chain
             if current_chain_name.eq(trace.last().unwrap()) {
                 trace.pop();

--- a/framework/contracts/native/ibc-host/src/endpoints/query.rs
+++ b/framework/contracts/native/ibc-host/src/endpoints/query.rs
@@ -6,7 +6,7 @@ use abstract_std::{
         state::{CHAIN_PROXIES, CONFIG},
         ClientProxiesResponse, ClientProxyResponse, ConfigResponse,
     },
-    objects::chain_name::ChainName,
+    objects::truncated_chain_id::TruncatedChainId,
 };
 use cosmwasm_std::{to_json_binary, Binary, Deps, Env};
 use cw_storage_plus::Bound;
@@ -44,7 +44,7 @@ fn registered_chains(
     start_after: Option<String>,
     limit: Option<u32>,
 ) -> HostResult<ClientProxiesResponse> {
-    let start = start_after.map(ChainName::from_string).transpose()?;
+    let start = start_after.map(TruncatedChainId::from_string).transpose()?;
 
     let chains = cw_paginate::paginate_map(
         &CHAIN_PROXIES,
@@ -58,7 +58,7 @@ fn registered_chains(
 }
 
 fn associated_client(deps: Deps, chain: String) -> HostResult<ClientProxyResponse> {
-    let proxy = CHAIN_PROXIES.load(deps.storage, &ChainName::from_str(&chain)?)?;
+    let proxy = CHAIN_PROXIES.load(deps.storage, &TruncatedChainId::from_str(&chain)?)?;
     Ok(ClientProxyResponse { proxy })
 }
 

--- a/framework/docs/src/releases/v0.md
+++ b/framework/docs/src/releases/v0.md
@@ -42,6 +42,7 @@
 - Ibc API: Where applicable - accept `ChainName` instead of `String` to add clarity for the user
 - Standalones and IBC Client no longer added to proxy whitelist
 - IBC client and host now migrated only if version is not breaking and deployed otherwise
+- Renamed `ChainName` to `TruncatedChainId`
 
 ### Removed
 

--- a/framework/packages/abstract-client/src/error.rs
+++ b/framework/packages/abstract-client/src/error.rs
@@ -42,7 +42,7 @@ pub enum AbstractClientError {
     #[error("Remote account of {account_id} not found on {chain} in {ibc_client_addr}")]
     RemoteAccountNotFound {
         account_id: abstract_std::objects::AccountId,
-        chain: abstract_std::objects::chain_name::ChainName,
+        chain: abstract_std::objects::truncated_chain_id::TruncatedChainId,
         ibc_client_addr: cosmwasm_std::Addr,
     },
 

--- a/framework/packages/abstract-client/src/interchain/remote_account.rs
+++ b/framework/packages/abstract-client/src/interchain/remote_account.rs
@@ -15,11 +15,11 @@ use abstract_std::{
         ModuleInfosResponse, ModuleInstallConfig,
     },
     objects::{
-        chain_name::ChainName,
         gov_type::GovernanceDetails,
         module::{ModuleInfo, ModuleVersion},
         namespace::Namespace,
         nested_admin::MAX_ADMIN_RECURSION,
+        truncated_chain_id::TruncatedChainId,
         AccountId, AssetEntry,
     },
     proxy, IBC_CLIENT, PROXY,
@@ -65,7 +65,7 @@ impl<'a, Chain: IbcQueryHandler> Account<Chain> {
     ) -> AbstractClientResult<RemoteAccount<Chain, IBC>> {
         // Make sure ibc client installed on account
         let ibc_client = self.application::<IbcClient<Chain>>()?;
-        let remote_chain_name = ChainName::from_chain_id(&remote_chain.chain_id());
+        let remote_chain_name = TruncatedChainId::from_chain_id(&remote_chain.chain_id());
         let account_id = self.id()?;
 
         // Check it exists first
@@ -85,7 +85,7 @@ impl<'a, Chain: IbcQueryHandler> Account<Chain> {
         let remote_account_id = {
             let mut id = owner_account.id()?;
             let chain_name =
-                ChainName::from_chain_id(&owner_account.manager.get_chain().chain_id());
+                TruncatedChainId::from_chain_id(&owner_account.manager.get_chain().chain_id());
             id.push_chain(chain_name);
             id
         };
@@ -183,7 +183,7 @@ impl<'a, Chain: IbcQueryHandler, IBC: InterchainEnv<Chain>> RemoteAccountBuilder
             install_modules,
             ..Default::default()
         };
-        let host_chain = ChainName::from_chain_id(&remote_env_info.chain_id);
+        let host_chain = TruncatedChainId::from_chain_id(&remote_env_info.chain_id);
 
         let response = owner_account
             .abstr_account
@@ -192,7 +192,7 @@ impl<'a, Chain: IbcQueryHandler, IBC: InterchainEnv<Chain>> RemoteAccountBuilder
 
         let remote_account_id = {
             let mut id = owner_account.id()?;
-            let chain_name = ChainName::from_chain_id(
+            let chain_name = TruncatedChainId::from_chain_id(
                 &owner_account.abstr_account.manager.get_chain().chain_id(),
             );
             id.push_chain(chain_name);
@@ -242,9 +242,9 @@ impl<'a, Chain: IbcQueryHandler, IBC: InterchainEnv<Chain>> RemoteAccount<'a, Ch
         self.remote_account_id.clone()
     }
 
-    /// ChainName of the host chain
-    pub fn host_chain(&self) -> ChainName {
-        ChainName::from_chain_id(&self.remote_chain().env_info().chain_id)
+    /// Truncated chain id of the host chain
+    pub fn host_chain(&self) -> TruncatedChainId {
+        TruncatedChainId::from_chain_id(&self.remote_chain().env_info().chain_id)
     }
 
     fn remote_chain(&self) -> Chain {

--- a/framework/packages/abstract-interface/src/account/manager.rs
+++ b/framework/packages/abstract-interface/src/account/manager.rs
@@ -5,8 +5,8 @@ use abstract_std::{
     manager::*,
     module_factory::SimulateInstallModulesResponse,
     objects::{
-        chain_name::ChainName,
         module::{ModuleInfo, ModuleVersion},
+        truncated_chain_id::TruncatedChainId,
         AccountId,
     },
     IBC_CLIENT, MANAGER, PROXY,
@@ -196,7 +196,7 @@ impl<Chain: CwEnv> Manager<Chain> {
     /// Helper to create remote accounts
     pub fn register_remote_account(
         &self,
-        host_chain: ChainName,
+        host_chain: TruncatedChainId,
     ) -> Result<<Chain as cw_orch::prelude::TxHandler>::Response, crate::AbstractInterfaceError>
     {
         let result = self.exec_on_module(
@@ -233,7 +233,7 @@ impl<Chain: CwEnv> Manager<Chain> {
 
     pub fn execute_on_remote(
         &self,
-        host_chain: ChainName,
+        host_chain: TruncatedChainId,
         msg: ExecuteMsg,
     ) -> Result<<Chain as cw_orch::prelude::TxHandler>::Response, crate::AbstractInterfaceError>
     {
@@ -251,7 +251,7 @@ impl<Chain: CwEnv> Manager<Chain> {
 
     pub fn execute_on_remote_module(
         &self,
-        host_chain: ChainName,
+        host_chain: TruncatedChainId,
         module_id: &str,
         msg: Binary,
     ) -> Result<<Chain as cw_orch::prelude::TxHandler>::Response, crate::AbstractInterfaceError>
@@ -273,7 +273,7 @@ impl<Chain: CwEnv> Manager<Chain> {
 
     pub fn send_all_funds_back(
         &self,
-        host_chain: ChainName,
+        host_chain: TruncatedChainId,
     ) -> Result<<Chain as cw_orch::prelude::TxHandler>::Response, crate::AbstractInterfaceError>
     {
         let msg = abstract_std::proxy::ExecuteMsg::IbcAction {

--- a/framework/packages/abstract-interface/src/account/mod.rs
+++ b/framework/packages/abstract-interface/src/account/mod.rs
@@ -14,8 +14,8 @@
 use abstract_std::{
     manager::ModuleInstallConfig,
     objects::{
-        chain_name::ChainName,
         module::{ModuleInfo, ModuleStatus, ModuleVersion},
+        truncated_chain_id::TruncatedChainId,
     },
     version_control::{ExecuteMsgFns, ModuleFilter, QueryMsgFns},
     ABSTRACT_EVENT_TYPE, MANAGER, PROXY,
@@ -213,7 +213,7 @@ impl<Chain: CwEnv> AbstractAccount<Chain> {
 
     pub fn register_remote_account(
         &self,
-        host_chain: ChainName,
+        host_chain: TruncatedChainId,
     ) -> Result<<Chain as cw_orch::prelude::TxHandler>::Response, crate::AbstractInterfaceError>
     {
         self.manager.register_remote_account(host_chain)
@@ -222,7 +222,7 @@ impl<Chain: CwEnv> AbstractAccount<Chain> {
     pub fn create_remote_account(
         &self,
         account_details: AccountDetails,
-        host_chain: ChainName,
+        host_chain: TruncatedChainId,
     ) -> Result<<Chain as cw_orch::prelude::TxHandler>::Response, crate::AbstractInterfaceError>
     {
         let AccountDetails {

--- a/framework/packages/abstract-interface/src/ibc.rs
+++ b/framework/packages/abstract-interface/src/ibc.rs
@@ -68,7 +68,7 @@ pub mod connection {
     use abstract_std::ibc_client::ExecuteMsgFns as _;
     use abstract_std::ibc_client::QueryMsgFns;
     use abstract_std::ibc_host::ExecuteMsgFns as _;
-    use abstract_std::objects::chain_name::ChainName;
+    use abstract_std::objects::truncated_chain_id::TruncatedChainId;
     use cw_orch_interchain::prelude::*;
     use cw_orch_polytone::interchain::PolytoneConnection;
 
@@ -96,10 +96,10 @@ pub mod connection {
     ) -> Result<(), AbstractInterfaceError> {
         // First we register client and host respectively
         let chain1_id = abstr.ibc.client.get_chain().chain_id();
-        let chain1_name = ChainName::from_chain_id(&chain1_id);
+        let chain1_name = TruncatedChainId::from_chain_id(&chain1_id);
 
         let chain2_id = dest.ibc.client.get_chain().chain_id();
-        let chain2_name = ChainName::from_chain_id(&chain2_id);
+        let chain2_name = TruncatedChainId::from_chain_id(&chain2_id);
 
         // We get the polytone connection
         let polytone_connection =

--- a/framework/packages/abstract-sdk/src/ans_resolve.rs
+++ b/framework/packages/abstract-sdk/src/ans_resolve.rs
@@ -494,7 +494,7 @@ mod tests {
     mod channel_entry {
         use std::str::FromStr;
 
-        use abstract_std::objects::chain_name::ChainName;
+        use abstract_std::objects::truncated_chain_id::TruncatedChainId;
 
         use super::*;
         use crate::std::ans_host::state::CHANNELS;
@@ -503,7 +503,7 @@ mod tests {
         fn exists() {
             let test_channel_entry = ChannelEntry {
                 protocol: "protocol".to_string(),
-                connected_chain: ChainName::from_str("abstract").unwrap(),
+                connected_chain: TruncatedChainId::from_str("abstract").unwrap(),
             };
 
             let expected_value = "channel-id".to_string();
@@ -524,7 +524,7 @@ mod tests {
         fn does_not_exist() {
             let not_exist_channel = ChannelEntry {
                 protocol: "protocol".to_string(),
-                connected_chain: ChainName::from_str("chain").unwrap(),
+                connected_chain: TruncatedChainId::from_str("chain").unwrap(),
             };
 
             test_dne(&not_exist_channel);

--- a/framework/packages/abstract-sdk/src/apis/ibc.rs
+++ b/framework/packages/abstract-sdk/src/apis/ibc.rs
@@ -8,7 +8,7 @@ use abstract_std::{
     ibc_client::{self, ExecuteMsg as IbcClientMsg, InstalledModuleIdentification},
     ibc_host::HostAction,
     manager::ModuleInstallConfig,
-    objects::{chain_name::ChainName, module::ModuleInfo},
+    objects::{module::ModuleInfo, truncated_chain_id::TruncatedChainId},
     proxy::ExecuteMsg,
     ABSTRACT_VERSION, IBC_CLIENT,
 };
@@ -100,7 +100,7 @@ impl<'a, T: IbcInterface> IbcClient<'a, T> {
     /// Send module action from this module to the target module
     pub fn module_ibc_action<M: Serialize>(
         &self,
-        host_chain: ChainName,
+        host_chain: TruncatedChainId,
         target_module: ModuleInfo,
         exec_msg: &M,
         callback: Option<Callback>,
@@ -123,7 +123,7 @@ impl<'a, T: IbcInterface> IbcClient<'a, T> {
     /// Use [`abstract_std::ibc::IbcResponseMsg::module_query_response`] to parse response
     pub fn module_ibc_query<B: Serialize, M: Serialize>(
         &self,
-        host_chain: ChainName,
+        host_chain: TruncatedChainId,
         target_module: InstalledModuleIdentification,
         query_msg: &base::QueryMsg<B, M>,
         callback: Callback,
@@ -147,7 +147,7 @@ impl<'a, T: IbcInterface> IbcClient<'a, T> {
     /// Send query from this module to the host chain
     pub fn ibc_query(
         &self,
-        host_chain: ChainName,
+        host_chain: TruncatedChainId,
         query: impl Into<QueryRequest<ModuleQuery>>,
         callback: Callback,
     ) -> AbstractSdkResult<CosmosMsg> {
@@ -167,7 +167,7 @@ impl<'a, T: IbcInterface> IbcClient<'a, T> {
     /// Send queries from this module to the host chain
     pub fn ibc_queries(
         &self,
-        host_chain: ChainName,
+        host_chain: TruncatedChainId,
         queries: Vec<QueryRequest<ModuleQuery>>,
         callback: Callback,
     ) -> AbstractSdkResult<CosmosMsg> {
@@ -186,7 +186,10 @@ impl<'a, T: IbcInterface> IbcClient<'a, T> {
 
     /// Address of the remote proxy
     /// Note: only Accounts that are remote to *this* chain are queryable
-    pub fn remote_proxy_addr(&self, host_chain: &ChainName) -> AbstractSdkResult<Option<String>> {
+    pub fn remote_proxy_addr(
+        &self,
+        host_chain: &TruncatedChainId,
+    ) -> AbstractSdkResult<Option<String>> {
         let ibc_client_addr = self.module_address()?;
         let account_id = self.base.account_id(self.deps)?;
 
@@ -206,7 +209,7 @@ impl<'a, T: IbcInterface + AccountExecutor> IbcClient<'a, T> {
     pub fn create_remote_account(
         &self,
         // The chain on which you want to create an account
-        host_chain: ChainName,
+        host_chain: TruncatedChainId,
     ) -> AbstractSdkResult<CosmosMsg> {
         Ok(wasm_execute(
             self.base.proxy_address(self.deps)?.to_string(),
@@ -226,7 +229,7 @@ impl<'a, T: IbcInterface + AccountExecutor> IbcClient<'a, T> {
     /// Call a [`HostAction`] on the host of the provided `host_chain`.
     pub fn host_action(
         &self,
-        host_chain: ChainName,
+        host_chain: TruncatedChainId,
         action: HostAction,
     ) -> AbstractSdkResult<CosmosMsg> {
         Ok(wasm_execute(
@@ -242,7 +245,7 @@ impl<'a, T: IbcInterface + AccountExecutor> IbcClient<'a, T> {
     /// IbcClient the provided coins from the Account to its proxy on the `receiving_chain`.
     pub fn ics20_transfer(
         &self,
-        host_chain: ChainName,
+        host_chain: TruncatedChainId,
         funds: Vec<Coin>,
     ) -> AbstractSdkResult<CosmosMsg> {
         Ok(wasm_execute(
@@ -259,7 +262,7 @@ impl<'a, T: IbcInterface + AccountExecutor> IbcClient<'a, T> {
     pub fn install_remote_app<M: Serialize>(
         &self,
         // The chain on which you want to install an app
-        host_chain: ChainName,
+        host_chain: TruncatedChainId,
         module: ModuleInfo,
         init_msg: &M,
     ) -> AbstractSdkResult<CosmosMsg> {
@@ -280,7 +283,7 @@ impl<'a, T: IbcInterface + AccountExecutor> IbcClient<'a, T> {
     pub fn install_remote_api<M: Serialize>(
         &self,
         // The chain on which you want to install an api
-        host_chain: ChainName,
+        host_chain: TruncatedChainId,
         module: ModuleInfo,
     ) -> AbstractSdkResult<CosmosMsg> {
         self.host_action(
@@ -298,7 +301,7 @@ impl<'a, T: IbcInterface + AccountExecutor> IbcClient<'a, T> {
     /// I.e. can be used to execute admin actions on remote modules.
     pub fn execute_on_module<M: Serialize>(
         &self,
-        host_chain: ChainName,
+        host_chain: TruncatedChainId,
         module_id: String,
         exec_msg: &M,
     ) -> AbstractSdkResult<CosmosMsg> {
@@ -315,7 +318,7 @@ impl<'a, T: IbcInterface + AccountExecutor> IbcClient<'a, T> {
 
     /// Address of the remote proxy
     /// Note: only works if account is local
-    pub fn remote_proxy(&self, host_chain: &ChainName) -> AbstractSdkResult<Option<String>> {
+    pub fn remote_proxy(&self, host_chain: &TruncatedChainId) -> AbstractSdkResult<Option<String>> {
         let account_id = self.base.account_id(self.deps)?;
         let ibc_client_addr = self.module_address()?;
 

--- a/framework/packages/abstract-std/src/native/ibc.rs
+++ b/framework/packages/abstract-std/src/native/ibc.rs
@@ -8,7 +8,7 @@ use schemars::JsonSchema;
 use crate::{
     base::ExecuteMsg,
     ibc_client,
-    objects::{chain_name::ChainName, module::ModuleInfo},
+    objects::{module::ModuleInfo, truncated_chain_id::TruncatedChainId},
 };
 
 /// Callback from modules, that is turned into an IbcResponseMsg by the ibc client
@@ -145,7 +145,7 @@ pub struct ModuleIbcMsg {
 #[cw_serde]
 pub struct ModuleIbcInfo {
     /// Remote chain identification
-    pub chain: ChainName,
+    pub chain: TruncatedChainId,
     /// Information about the module that called ibc action on this module
     pub module: ModuleInfo,
 }

--- a/framework/packages/abstract-std/src/native/ibc_client.rs
+++ b/framework/packages/abstract-std/src/native/ibc_client.rs
@@ -8,8 +8,8 @@ use crate::{
     ibc_host::HostAction,
     manager::{self, ModuleInstallConfig},
     objects::{
-        account::AccountId, chain_name::ChainName, module::ModuleInfo,
-        module_reference::ModuleReference, version_control::VersionControlContract, AssetEntry,
+        account::AccountId, module::ModuleInfo, module_reference::ModuleReference,
+        truncated_chain_id::TruncatedChainId, version_control::VersionControlContract, AssetEntry,
     },
     AbstractError,
 };
@@ -22,7 +22,7 @@ pub mod state {
     use crate::objects::{
         account::{AccountSequence, AccountTrace},
         ans_host::AnsHost,
-        chain_name::ChainName,
+        truncated_chain_id::TruncatedChainId,
         version_control::VersionControlContract,
     };
 
@@ -45,14 +45,14 @@ pub mod state {
 
     // Saves the local note deployed contract and the remote abstract host connected
     // This allows sending cross-chain messages
-    pub const IBC_INFRA: Map<&ChainName, IbcInfrastructure> = Map::new("ibci");
-    pub const REVERSE_POLYTONE_NOTE: Map<&Addr, ChainName> = Map::new("revpn");
+    pub const IBC_INFRA: Map<&TruncatedChainId, IbcInfrastructure> = Map::new("ibci");
+    pub const REVERSE_POLYTONE_NOTE: Map<&Addr, TruncatedChainId> = Map::new("revpn");
 
     pub const CONFIG: Item<Config> = Item::new("config");
     /// (account_trace, account_sequence, chain_name) -> remote proxy account address. We use a
     /// triple instead of including AccountId since nested tuples do not behave as expected due to
     /// a bug that will be fixed in a future release.
-    pub const ACCOUNTS: Map<(&AccountTrace, AccountSequence, &ChainName), String> =
+    pub const ACCOUNTS: Map<(&AccountTrace, AccountSequence, &TruncatedChainId), String> =
         Map::new("accs");
 
     // For callbacks tests
@@ -78,7 +78,7 @@ pub enum ExecuteMsg {
     /// This allows for monitoring which chain are connected to the contract remotely
     RegisterInfrastructure {
         /// Chain to register the infrastructure for ("juno", "osmosis", etc.)
-        chain: ChainName,
+        chain: TruncatedChainId,
         /// Polytone note (locally deployed)
         note: String,
         /// Address of the abstract host deployed on the remote chain
@@ -95,7 +95,7 @@ pub enum ExecuteMsg {
     SendFunds {
         /// host chain to be executed on
         /// Example: "osmosis"
-        host_chain: ChainName,
+        host_chain: TruncatedChainId,
         funds: Vec<Coin>,
     },
     /// Only callable by Account proxy
@@ -104,7 +104,7 @@ pub enum ExecuteMsg {
     Register {
         /// host chain to be executed on
         /// Example: "osmosis"
-        host_chain: ChainName,
+        host_chain: TruncatedChainId,
         base_asset: Option<AssetEntry>,
         namespace: Option<String>,
         install_modules: Vec<ModuleInstallConfig>,
@@ -114,7 +114,7 @@ pub enum ExecuteMsg {
     ModuleIbcAction {
         /// host chain to be executed on
         /// Example: "osmosis"
-        host_chain: ChainName,
+        host_chain: TruncatedChainId,
         /// Module of this account on host chain
         target_module: ModuleInfo,
         /// Json-encoded IbcMsg to the target module
@@ -127,7 +127,7 @@ pub enum ExecuteMsg {
     IbcQuery {
         /// host chain to be executed on
         /// Example: "osmosis"
-        host_chain: ChainName,
+        host_chain: TruncatedChainId,
         /// Cosmos Query requests
         queries: Vec<QueryRequest<ModuleQuery>>,
         /// Callback info to identify the callback that is sent (acts similar to the reply ID)
@@ -139,12 +139,12 @@ pub enum ExecuteMsg {
     RemoteAction {
         /// host chain to be executed on
         /// Example: "osmosis"
-        host_chain: ChainName,
+        host_chain: TruncatedChainId,
         /// execute the custom host function
         action: HostAction,
     },
     /// Owner method: Remove connection for remote chain
-    RemoveHost { host_chain: ChainName },
+    RemoveHost { host_chain: TruncatedChainId },
     /// Callback from the Polytone implementation
     /// This is triggered regardless of the execution result
     Callback(CallbackMessage),
@@ -263,7 +263,7 @@ pub enum QueryMsg {
     /// Returns the host information associated with a specific chain-name (e.g. osmosis, juno)
     /// Returns [`HostResponse`]
     #[returns(HostResponse)]
-    Host { chain_name: ChainName },
+    Host { chain_name: TruncatedChainId },
 
     /// Get list of remote accounts
     /// Returns [`ListAccountsResponse`]
@@ -278,7 +278,7 @@ pub enum QueryMsg {
     #[returns(AccountResponse)]
     #[cw_orch(fn_name("remote_account"))]
     Account {
-        chain_name: ChainName,
+        chain_name: TruncatedChainId,
         account_id: AccountId,
     },
 
@@ -311,22 +311,22 @@ pub struct ConfigResponse {
 
 #[cosmwasm_schema::cw_serde]
 pub struct ListAccountsResponse {
-    pub accounts: Vec<(AccountId, ChainName, String)>,
+    pub accounts: Vec<(AccountId, TruncatedChainId, String)>,
 }
 
 #[cosmwasm_schema::cw_serde]
 pub struct ListRemoteHostsResponse {
-    pub hosts: Vec<(ChainName, String)>,
+    pub hosts: Vec<(TruncatedChainId, String)>,
 }
 
 #[cosmwasm_schema::cw_serde]
 pub struct ListRemoteProxiesResponse {
-    pub proxies: Vec<(ChainName, Option<String>)>,
+    pub proxies: Vec<(TruncatedChainId, Option<String>)>,
 }
 
 #[cosmwasm_schema::cw_serde]
 pub struct ListIbcInfrastructureResponse {
-    pub counterparts: Vec<(ChainName, IbcInfrastructure)>,
+    pub counterparts: Vec<(TruncatedChainId, IbcInfrastructure)>,
 }
 
 #[cosmwasm_schema::cw_serde]

--- a/framework/packages/abstract-std/src/native/ibc_host.rs
+++ b/framework/packages/abstract-std/src/native/ibc_host.rs
@@ -13,7 +13,9 @@ use cosmwasm_std::{Addr, Binary};
 use crate::{
     ibc_client::InstalledModuleIdentification,
     manager::{self, ModuleInstallConfig},
-    objects::{account::AccountId, chain_name::ChainName, module::ModuleInfo, AssetEntry},
+    objects::{
+        account::AccountId, module::ModuleInfo, truncated_chain_id::TruncatedChainId, AssetEntry,
+    },
 };
 
 pub mod state {
@@ -23,8 +25,8 @@ pub mod state {
     use crate::objects::{ans_host::AnsHost, version_control::VersionControlContract};
 
     /// Maps a chain name to the proxy it uses to interact on this local chain
-    pub const CHAIN_PROXIES: Map<&ChainName, Addr> = Map::new("ccl");
-    pub const REVERSE_CHAIN_PROXIES: Map<&Addr, ChainName> = Map::new("rev-ccl");
+    pub const CHAIN_PROXIES: Map<&TruncatedChainId, Addr> = Map::new("ccl");
+    pub const REVERSE_CHAIN_PROXIES: Map<&Addr, TruncatedChainId> = Map::new("rev-ccl");
     /// Configuration of the IBC host
     pub const CONFIG: Item<Config> = Item::new("cfg");
 
@@ -47,7 +49,7 @@ pub mod state {
         pub client_proxy_address: String,
         pub account_id: AccountId,
         pub action: HostAction,
-        pub chain_name: ChainName,
+        pub chain_name: TruncatedChainId,
     }
 }
 /// Used by Abstract to instantiate the contract
@@ -113,12 +115,12 @@ pub enum ExecuteMsg {
     /// Register the Polytone proxy for a specific chain.
     /// proxy should be a local address (will be validated)
     RegisterChainProxy {
-        chain: ChainName,
+        chain: TruncatedChainId,
         proxy: String,
     },
     /// Remove the Polytone proxy for a specific chain.
     RemoveChainProxy {
-        chain: ChainName,
+        chain: TruncatedChainId,
     },
     // ANCHOR: ibc-host-execute
     /// Allows for remote execution from the Polytone implementation
@@ -178,7 +180,7 @@ pub struct ConfigResponse {
 
 #[cosmwasm_schema::cw_serde]
 pub struct ClientProxiesResponse {
-    pub chains: Vec<(ChainName, Addr)>,
+    pub chains: Vec<(TruncatedChainId, Addr)>,
 }
 
 #[cosmwasm_schema::cw_serde]

--- a/framework/packages/abstract-std/src/objects/account/account_id.rs
+++ b/framework/packages/abstract-std/src/objects/account/account_id.rs
@@ -4,7 +4,7 @@ use cosmwasm_std::{StdError, StdResult};
 use cw_storage_plus::{Key, KeyDeserialize, Prefixer, PrimaryKey};
 
 use super::{account_trace::AccountTrace, AccountSequence};
-use crate::{objects::chain_name::ChainName, AbstractError};
+use crate::{objects::truncated_chain_id::TruncatedChainId, AbstractError};
 
 /// Unique identifier for an account.
 /// On each chain this is unique.
@@ -39,7 +39,10 @@ impl AccountId {
         }
     }
 
-    pub fn remote(seq: AccountSequence, trace: Vec<ChainName>) -> Result<Self, AbstractError> {
+    pub fn remote(
+        seq: AccountSequence,
+        trace: Vec<TruncatedChainId>,
+    ) -> Result<Self, AbstractError> {
         let trace = AccountTrace::Remote(trace);
         trace.verify()?;
         Ok(Self { seq, trace })
@@ -71,7 +74,7 @@ impl AccountId {
     }
 
     /// Push the chain to the account trace
-    pub fn push_chain(&mut self, chain: ChainName) {
+    pub fn push_chain(&mut self, chain: TruncatedChainId) {
         self.trace_mut().push_chain(chain)
     }
 
@@ -189,7 +192,7 @@ mod test {
         fn mock_key() -> AccountId {
             AccountId {
                 seq: 1,
-                trace: AccountTrace::Remote(vec![ChainName::from_str("bitcoin").unwrap()]),
+                trace: AccountTrace::Remote(vec![TruncatedChainId::from_str("bitcoin").unwrap()]),
             }
         }
 
@@ -202,15 +205,15 @@ mod test {
                 AccountId {
                     seq: 1,
                     trace: AccountTrace::Remote(vec![
-                        ChainName::from_str("ethereum").unwrap(),
-                        ChainName::from_str("bitcoin").unwrap(),
+                        TruncatedChainId::from_str("ethereum").unwrap(),
+                        TruncatedChainId::from_str("bitcoin").unwrap(),
                     ]),
                 },
                 AccountId {
                     seq: 2,
                     trace: AccountTrace::Remote(vec![
-                        ChainName::from_str("ethereum").unwrap(),
-                        ChainName::from_str("bitcoin").unwrap(),
+                        TruncatedChainId::from_str("ethereum").unwrap(),
+                        TruncatedChainId::from_str("bitcoin").unwrap(),
                     ]),
                 },
             )
@@ -280,8 +283,8 @@ mod test {
 
             let items = map
                 .prefix(AccountTrace::Remote(vec![
-                    ChainName::from_str("ethereum").unwrap(),
-                    ChainName::from_str("bitcoin").unwrap(),
+                    TruncatedChainId::from_str("ethereum").unwrap(),
+                    TruncatedChainId::from_str("bitcoin").unwrap(),
                 ]))
                 .range(deps.as_ref().storage, None, None, Order::Ascending)
                 .map(|item| item.unwrap())
@@ -298,8 +301,8 @@ mod test {
             let key = AccountId {
                 seq: 1,
                 trace: AccountTrace::Remote(vec![
-                    ChainName::from_str("ethereum").unwrap(),
-                    ChainName::from_str("bitcoin").unwrap(),
+                    TruncatedChainId::from_str("ethereum").unwrap(),
+                    TruncatedChainId::from_str("bitcoin").unwrap(),
                 ]),
             };
             let map: Map<&AccountId, u64> = Map::new("map");
@@ -329,8 +332,8 @@ mod test {
             assert_eq!(
                 account_id.trace,
                 AccountTrace::Remote(vec![
-                    ChainName::_from_str("ethereum"),
-                    ChainName::_from_str("bitcoin"),
+                    TruncatedChainId::_from_str("ethereum"),
+                    TruncatedChainId::_from_str("bitcoin"),
                 ])
             );
         }
@@ -342,9 +345,9 @@ mod test {
             assert_eq!(
                 account_id.trace,
                 AccountTrace::Remote(vec![
-                    ChainName::_from_str("ethereum"),
-                    ChainName::_from_str("bitcoin"),
-                    ChainName::_from_str("cosmos"),
+                    TruncatedChainId::_from_str("ethereum"),
+                    TruncatedChainId::_from_str("bitcoin"),
+                    TruncatedChainId::_from_str("cosmos"),
                 ])
             );
         }

--- a/framework/packages/abstract-std/src/objects/account/account_trace.rs
+++ b/framework/packages/abstract-std/src/objects/account/account_trace.rs
@@ -3,7 +3,9 @@ use std::fmt::Display;
 use cosmwasm_std::{ensure, Env, StdError, StdResult};
 use cw_storage_plus::{Key, KeyDeserialize, Prefixer, PrimaryKey};
 
-use crate::{constants::CHAIN_DELIMITER, objects::chain_name::ChainName, AbstractError};
+use crate::{
+    constants::CHAIN_DELIMITER, objects::truncated_chain_id::TruncatedChainId, AbstractError,
+};
 
 pub const MAX_TRACE_LENGTH: usize = 6;
 pub(crate) const LOCAL: &str = "local";
@@ -13,7 +15,7 @@ pub(crate) const LOCAL: &str = "local";
 pub enum AccountTrace {
     Local,
     // path of the chains that triggered the account creation
-    Remote(Vec<ChainName>),
+    Remote(Vec<TruncatedChainId>),
 }
 
 impl KeyDeserialize for &AccountTrace {
@@ -121,18 +123,18 @@ impl AccountTrace {
     pub fn push_local_chain(&mut self, env: &Env) {
         match &self {
             AccountTrace::Local => {
-                *self = AccountTrace::Remote(vec![ChainName::new(env)]);
+                *self = AccountTrace::Remote(vec![TruncatedChainId::new(env)]);
             }
             AccountTrace::Remote(path) => {
                 let mut path = path.clone();
-                path.push(ChainName::new(env));
+                path.push(TruncatedChainId::new(env));
                 *self = AccountTrace::Remote(path);
             }
         }
     }
 
     /// push a chain name to the account's path
-    pub fn push_chain(&mut self, chain_name: ChainName) {
+    pub fn push_chain(&mut self, chain_name: TruncatedChainId) {
         match &self {
             AccountTrace::Local => {
                 *self = AccountTrace::Remote(vec![chain_name]);
@@ -155,7 +157,7 @@ impl AccountTrace {
             Self::Remote(
                 trace
                     .split(CHAIN_DELIMITER)
-                    .map(ChainName::_from_str)
+                    .map(TruncatedChainId::_from_str)
                     .collect(),
             )
         };
@@ -173,7 +175,7 @@ impl AccountTrace {
             Self::Remote(
                 trace
                     .split(CHAIN_DELIMITER)
-                    .map(ChainName::_from_str)
+                    .map(TruncatedChainId::_from_str)
                     .collect(),
             )
         };
@@ -189,9 +191,9 @@ impl TryFrom<&str> for AccountTrace {
         if trace == LOCAL {
             Ok(Self::Local)
         } else {
-            let chain_trace: Vec<ChainName> = trace
+            let chain_trace: Vec<TruncatedChainId> = trace
                 .split(CHAIN_DELIMITER)
-                .map(|t| ChainName::from_string(t.to_string()))
+                .map(|t| TruncatedChainId::from_string(t.to_string()))
                 .collect::<Result<Vec<_>, _>>()?;
             Ok(Self::Remote(chain_trace))
         }
@@ -231,7 +233,7 @@ mod test {
 
     mod format {
         use super::*;
-        use crate::objects::chain_name::MAX_CHAIN_NAME_LENGTH;
+        use crate::objects::truncated_chain_id::MAX_CHAIN_NAME_LENGTH;
 
         #[test]
         fn local_works() {
@@ -244,7 +246,7 @@ mod test {
             let trace = AccountTrace::from_str("bitcoin").unwrap();
             assert_eq!(
                 trace,
-                AccountTrace::Remote(vec![ChainName::from_str("bitcoin").unwrap()])
+                AccountTrace::Remote(vec![TruncatedChainId::from_str("bitcoin").unwrap()])
             );
         }
 
@@ -254,8 +256,8 @@ mod test {
             assert_eq!(
                 trace,
                 AccountTrace::Remote(vec![
-                    ChainName::from_str("bitcoin").unwrap(),
-                    ChainName::from_str("ethereum").unwrap()
+                    TruncatedChainId::from_str("bitcoin").unwrap(),
+                    TruncatedChainId::from_str("ethereum").unwrap()
                 ])
             );
         }
@@ -266,9 +268,9 @@ mod test {
             assert_eq!(
                 trace,
                 AccountTrace::Remote(vec![
-                    ChainName::from_str("bitcoin").unwrap(),
-                    ChainName::from_str("ethereum").unwrap(),
-                    ChainName::from_str("cosmos").unwrap(),
+                    TruncatedChainId::from_str("bitcoin").unwrap(),
+                    TruncatedChainId::from_str("ethereum").unwrap(),
+                    TruncatedChainId::from_str("cosmos").unwrap(),
                 ])
             );
         }
@@ -304,7 +306,7 @@ mod test {
         use super::*;
 
         fn mock_key() -> AccountTrace {
-            AccountTrace::Remote(vec![ChainName::from_str("bitcoin").unwrap()])
+            AccountTrace::Remote(vec![TruncatedChainId::from_str("bitcoin").unwrap()])
         }
 
         #[test]

--- a/framework/packages/abstract-std/src/objects/entry/channel_entry.rs
+++ b/framework/packages/abstract-std/src/objects/entry/channel_entry.rs
@@ -5,7 +5,7 @@ use cw_storage_plus::{Key, KeyDeserialize, Prefixer, PrimaryKey};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::{objects::chain_name::ChainName, AbstractResult};
+use crate::{objects::truncated_chain_id::TruncatedChainId, AbstractResult};
 
 /// Key to get the Address of a connected_chain
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, JsonSchema, PartialOrd, Ord)]
@@ -22,7 +22,7 @@ impl UncheckedChannelEntry {
         }
     }
     pub fn check(self) -> AbstractResult<ChannelEntry> {
-        let chain_name: ChainName = ChainName::from_string(self.connected_chain)?;
+        let chain_name: TruncatedChainId = TruncatedChainId::from_string(self.connected_chain)?;
         Ok(ChannelEntry {
             connected_chain: chain_name,
             protocol: self.protocol.to_ascii_lowercase(),
@@ -47,7 +47,7 @@ impl TryFrom<String> for UncheckedChannelEntry {
 /// Use [`UncheckedChannelEntry`] to construct this type.  
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, JsonSchema, Eq, PartialOrd, Ord)]
 pub struct ChannelEntry {
-    pub connected_chain: ChainName,
+    pub connected_chain: TruncatedChainId,
     pub protocol: String,
 }
 
@@ -91,7 +91,7 @@ impl KeyDeserialize for &ChannelEntry {
         let u = tu.split_off(t_len);
 
         Ok(ChannelEntry {
-            connected_chain: ChainName::_from_string(String::from_vec(tu)?),
+            connected_chain: TruncatedChainId::_from_string(String::from_vec(tu)?),
             protocol: String::from_vec(u)?,
         })
     }
@@ -122,7 +122,7 @@ mod test {
 
     fn mock_key() -> ChannelEntry {
         ChannelEntry {
-            connected_chain: ChainName::from_str("osmosis").unwrap(),
+            connected_chain: TruncatedChainId::from_str("osmosis").unwrap(),
             protocol: "ics20".to_string(),
         }
     }
@@ -130,15 +130,15 @@ mod test {
     fn mock_keys() -> (ChannelEntry, ChannelEntry, ChannelEntry) {
         (
             ChannelEntry {
-                connected_chain: ChainName::from_str("osmosis").unwrap(),
+                connected_chain: TruncatedChainId::from_str("osmosis").unwrap(),
                 protocol: "ics20".to_string(),
             },
             ChannelEntry {
-                connected_chain: ChainName::from_str("osmosis").unwrap(),
+                connected_chain: TruncatedChainId::from_str("osmosis").unwrap(),
                 protocol: "ics".to_string(),
             },
             ChannelEntry {
-                connected_chain: ChainName::from_str("cosmos").unwrap(),
+                connected_chain: TruncatedChainId::from_str("cosmos").unwrap(),
                 protocol: "abstract".to_string(),
             },
         )

--- a/framework/packages/abstract-std/src/objects/mod.rs
+++ b/framework/packages/abstract-std/src/objects/mod.rs
@@ -15,7 +15,6 @@ pub mod salt;
 pub use pool::*;
 
 pub mod account;
-pub mod chain_name;
 pub mod dependency;
 pub mod deposit_info;
 pub mod deposit_manager;
@@ -28,6 +27,7 @@ pub mod namespace;
 pub mod paged_map;
 pub mod price_source;
 pub mod time_weighted_average;
+pub mod truncated_chain_id;
 pub mod validation;
 pub mod voting;
 

--- a/framework/packages/abstract-std/src/objects/salt.rs
+++ b/framework/packages/abstract-std/src/objects/salt.rs
@@ -14,7 +14,7 @@ pub fn generate_instantiate_salt(account_id: &AccountId) -> Binary {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::objects::{account::AccountTrace, chain_name::ChainName};
+    use crate::objects::{account::AccountTrace, truncated_chain_id::TruncatedChainId};
 
     #[test]
     fn generate_module_salt_local() {
@@ -29,12 +29,12 @@ mod test {
             &AccountId::new(
                 5,
                 AccountTrace::Remote(vec![
-                    ChainName::from_chain_id("foo-1"),
-                    ChainName::from_chain_id("bar-42"),
-                    ChainName::from_chain_id("baz-4"),
-                    ChainName::from_chain_id("qux-24"),
-                    ChainName::from_chain_id("quux-99"),
-                    ChainName::from_chain_id("corge-5"),
+                    TruncatedChainId::from_chain_id("foo-1"),
+                    TruncatedChainId::from_chain_id("bar-42"),
+                    TruncatedChainId::from_chain_id("baz-4"),
+                    TruncatedChainId::from_chain_id("qux-24"),
+                    TruncatedChainId::from_chain_id("quux-99"),
+                    TruncatedChainId::from_chain_id("corge-5"),
                 ]),
             )
             .unwrap(),

--- a/framework/packages/abstract-std/src/objects/truncated_chain_id.rs
+++ b/framework/packages/abstract-std/src/objects/truncated_chain_id.rs
@@ -13,9 +13,9 @@ pub const MIN_CHAIN_NAME_LENGTH: usize = 3;
 #[derive(Eq, PartialOrd, Ord)]
 /// The name of a chain, aka the chain-id without the post-fix number.
 /// ex. `cosmoshub-4` -> `cosmoshub`, `juno-1` -> `juno`
-pub struct ChainName(String);
+pub struct TruncatedChainId(String);
 
-impl ChainName {
+impl TruncatedChainId {
     // Construct the chain name from the environment (chain-id)
     pub fn new(env: &Env) -> Self {
         let chain_id = &env.block.chain_id;
@@ -85,13 +85,13 @@ impl ChainName {
     }
 }
 
-impl std::fmt::Display for ChainName {
+impl std::fmt::Display for TruncatedChainId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
     }
 }
 
-impl FromStr for ChainName {
+impl FromStr for TruncatedChainId {
     type Err = AbstractError;
     fn from_str(value: &str) -> AbstractResult<Self> {
         let chain_name = Self(value.to_string());
@@ -100,7 +100,7 @@ impl FromStr for ChainName {
     }
 }
 
-impl<'a> PrimaryKey<'a> for &ChainName {
+impl<'a> PrimaryKey<'a> for &TruncatedChainId {
     type Prefix = ();
 
     type SubPrefix = ();
@@ -114,18 +114,18 @@ impl<'a> PrimaryKey<'a> for &ChainName {
     }
 }
 
-impl<'a> Prefixer<'a> for &ChainName {
+impl<'a> Prefixer<'a> for &TruncatedChainId {
     fn prefix(&self) -> Vec<Key> {
         self.0.prefix()
     }
 }
 
-impl KeyDeserialize for &ChainName {
-    type Output = ChainName;
+impl KeyDeserialize for &TruncatedChainId {
+    type Output = TruncatedChainId;
 
     #[inline(always)]
     fn from_vec(value: Vec<u8>) -> StdResult<Self::Output> {
-        Ok(ChainName(String::from_vec(value)?))
+        Ok(TruncatedChainId(String::from_vec(value)?))
     }
 }
 
@@ -138,37 +138,37 @@ mod test {
 
     #[test]
     fn test_namespace() {
-        let namespace = ChainName::new(&mock_env());
+        let namespace = TruncatedChainId::new(&mock_env());
         assert_that!(namespace.as_str()).is_equal_to("cosmos-testnet");
     }
 
     #[test]
     fn test_from_string() {
-        let namespace = ChainName::from_string("test-me".to_string()).unwrap();
+        let namespace = TruncatedChainId::from_string("test-me".to_string()).unwrap();
         assert_that!(namespace.as_str()).is_equal_to("test-me");
     }
 
     #[test]
     fn test_from_str() {
-        let namespace = ChainName::from_str("test-too").unwrap();
+        let namespace = TruncatedChainId::from_str("test-too").unwrap();
         assert_that!(namespace.as_str()).is_equal_to("test-too");
     }
 
     #[test]
     fn test_to_string() {
-        let namespace = ChainName::from_str("test").unwrap();
+        let namespace = TruncatedChainId::from_str("test").unwrap();
         assert_that!(namespace.to_string()).is_equal_to("test".to_string());
     }
 
     #[test]
     fn test_from_str_long() {
-        let namespace = ChainName::from_str("test-a-b-c-d-e-f").unwrap();
+        let namespace = TruncatedChainId::from_str("test-a-b-c-d-e-f").unwrap();
         assert_that!(namespace.as_str()).is_equal_to("test-a-b-c-d-e-f");
     }
 
     #[test]
     fn string_key_works() {
-        let k = &ChainName::from_str("test-abc").unwrap();
+        let k = &TruncatedChainId::from_str("test-abc").unwrap();
         let path = k.key();
         assert_eq!(1, path.len());
         assert_eq!(b"test-abc", path[0].as_ref());
@@ -181,35 +181,35 @@ mod test {
 
     #[test]
     fn local_empty_fails() {
-        ChainName::from_str("").unwrap_err();
+        TruncatedChainId::from_str("").unwrap_err();
     }
 
     #[test]
     fn local_too_short_fails() {
-        ChainName::from_str("a").unwrap_err();
+        TruncatedChainId::from_str("a").unwrap_err();
     }
 
     #[test]
     fn local_too_long_fails() {
-        ChainName::from_str(&"a".repeat(MAX_CHAIN_NAME_LENGTH + 1)).unwrap_err();
+        TruncatedChainId::from_str(&"a".repeat(MAX_CHAIN_NAME_LENGTH + 1)).unwrap_err();
     }
 
     #[test]
     fn local_uppercase_fails() {
-        ChainName::from_str("AAAAA").unwrap_err();
+        TruncatedChainId::from_str("AAAAA").unwrap_err();
     }
 
     #[test]
     fn local_non_alphanumeric_fails() {
-        ChainName::from_str("a_aoeuoau").unwrap_err();
+        TruncatedChainId::from_str("a_aoeuoau").unwrap_err();
     }
 
     #[test]
     fn from_chain_id() {
-        let normal_chain_name = ChainName::from_chain_id("juno-1");
-        assert_eq!(normal_chain_name, ChainName::_from_str("juno"));
+        let normal_chain_name = TruncatedChainId::from_chain_id("juno-1");
+        assert_eq!(normal_chain_name, TruncatedChainId::_from_str("juno"));
 
-        let postfixless_chain_name = ChainName::from_chain_id("juno");
-        assert_eq!(postfixless_chain_name, ChainName::_from_str("juno"));
+        let postfixless_chain_name = TruncatedChainId::from_chain_id("juno");
+        assert_eq!(postfixless_chain_name, TruncatedChainId::_from_str("juno"));
     }
 }

--- a/interchain/interchain-tests/src/bin/setup_funds.rs
+++ b/interchain/interchain-tests/src/bin/setup_funds.rs
@@ -75,7 +75,7 @@ pub fn test_send_funds() -> AnyResult<()> {
     // let account_config = osmo_abstr.account.manager.config()?;
     // let account_id = AccountId::new(
     //     account_config.account_id.seq(),
-    //     AccountTrace::Remote(vec![ChainName::from("osmosis")]),
+    //     AccountTrace::Remote(vec![TruncatedChainId::from("osmosis")]),
     // )?;
 
     // Get the ibc client address

--- a/interchain/interchain-tests/src/interchain_accounts.rs
+++ b/interchain/interchain-tests/src/interchain_accounts.rs
@@ -1,4 +1,6 @@
-use abstract_std::objects::{account::AccountTrace, chain_name::ChainName, AccountId};
+use abstract_std::objects::{
+    account::AccountTrace, truncated_chain_id::TruncatedChainId, AccountId,
+};
 // We need to rewrite this because cosmrs::Msg is not implemented for IBC types
 use abstract_interface::{Abstract, AbstractAccount, AccountDetails, ManagerQueryFns};
 use anyhow::Result as AnyResult;
@@ -21,8 +23,8 @@ pub fn create_test_remote_account<Chain: IbcQueryHandler, IBC: InterchainEnv<Cha
     interchain: &IBC,
     funds: Option<Vec<Coin>>,
 ) -> AnyResult<(AbstractAccount<Chain>, AccountId)> {
-    let origin_name = ChainName::from_chain_id(origin_id);
-    let remote_name = ChainName::from_chain_id(remote_id);
+    let origin_name = TruncatedChainId::from_chain_id(origin_id);
+    let remote_name = TruncatedChainId::from_chain_id(remote_id);
 
     // Create a local account for testing
     let account_name = TEST_ACCOUNT_NAME.to_string();
@@ -103,7 +105,7 @@ mod test {
         // We just verified all steps pass
         let (abstr_origin, abstr_remote) = ibc_abstract_setup(&mock_interchain, JUNO, STARGAZE)?;
 
-        let remote_name = ChainName::from_chain_id(STARGAZE);
+        let remote_name = TruncatedChainId::from_chain_id(STARGAZE);
 
         let (origin_account, remote_account_id) =
             create_test_remote_account(&abstr_origin, JUNO, STARGAZE, &mock_interchain, None)?;
@@ -143,7 +145,7 @@ mod test {
                 .ibc
                 .client
                 .query(&abstract_std::ibc_client::QueryMsg::Account {
-                    chain_name: ChainName::from_chain_id(STARGAZE),
+                    chain_name: TruncatedChainId::from_chain_id(STARGAZE),
                     account_id: AccountId::new(1, AccountTrace::Local)?,
                 })?;
 
@@ -214,17 +216,17 @@ mod test {
         // Now we send a message to the client saying that we want to create an account on the
         // destination chain
         let register_tx =
-            origin_account.register_remote_account(ChainName::from_chain_id(STARGAZE))?;
+            origin_account.register_remote_account(TruncatedChainId::from_chain_id(STARGAZE))?;
 
         mock_interchain.check_ibc(JUNO, register_tx)?;
 
         // Create account from JUNO on OSMOSIS by going through STARGAZE
         let create_account_remote_tx = origin_account.manager.execute_on_remote_module(
-            ChainName::from_chain_id(STARGAZE),
+            TruncatedChainId::from_chain_id(STARGAZE),
             PROXY,
             to_json_binary(&abstract_std::proxy::ExecuteMsg::IbcAction {
                 msg: abstract_std::ibc_client::ExecuteMsg::Register {
-                    host_chain: ChainName::from_chain_id(OSMOSIS),
+                    host_chain: TruncatedChainId::from_chain_id(OSMOSIS),
                     base_asset: None,
                     namespace: None,
                     install_modules: vec![],
@@ -237,8 +239,8 @@ mod test {
         let destination_remote_account_id = AccountId::new(
             origin_account.manager.config()?.account_id.seq(),
             AccountTrace::Remote(vec![
-                ChainName::from_chain_id(JUNO),
-                ChainName::from_chain_id(STARGAZE),
+                TruncatedChainId::from_chain_id(JUNO),
+                TruncatedChainId::from_chain_id(STARGAZE),
             ]),
         )?;
 
@@ -321,7 +323,7 @@ mod test {
         // ii. Now we test that we can indeed create an account remotely from the interchain account
         let account_name = String::from("Abstract Test Remote Remote account");
         let create_account_remote_tx = origin_account.manager.execute_on_remote_module(
-            ChainName::from_chain_id(STARGAZE),
+            TruncatedChainId::from_chain_id(STARGAZE),
             PROXY,
             to_json_binary(&abstract_std::proxy::ExecuteMsg::ModuleAction {
                 msgs: vec![wasm_execute(
@@ -401,7 +403,7 @@ mod test {
             String::from("name"),
             Some(AccountId::new(
                 2,
-                AccountTrace::Remote(vec![ChainName::from_chain_id(JUNO)]),
+                AccountTrace::Remote(vec![TruncatedChainId::from_chain_id(JUNO)]),
             )?),
             None,
             None,
@@ -465,7 +467,7 @@ mod test {
             .ibc
             .host
             .call_as(&Addr::unchecked("rando"))
-            .remove_chain_proxy(ChainName::from_chain_id(STARGAZE));
+            .remove_chain_proxy(TruncatedChainId::from_chain_id(STARGAZE));
 
         assert!(result.is_err());
 
@@ -485,7 +487,7 @@ mod test {
             .ibc
             .host
             .call_as(&Addr::unchecked("rando"))
-            .register_chain_proxy(ChainName::from_chain_id(OSMOSIS), PROXY.to_owned());
+            .register_chain_proxy(TruncatedChainId::from_chain_id(OSMOSIS), PROXY.to_owned());
         assert!(result.is_err());
 
         Ok(())
@@ -660,7 +662,7 @@ mod test {
             abstract_std::proxy::ExecuteMsg::IbcAction {
                 msg: abstract_std::ibc_client::ExecuteMsg::SendFunds {
                     funds: coins(10, origin_denom),
-                    host_chain: ChainName::from_chain_id(STARGAZE),
+                    host_chain: TruncatedChainId::from_chain_id(STARGAZE),
                 },
             },
         )?;
@@ -684,7 +686,7 @@ mod test {
         // Send all back.
         let send_funds_back_tx = origin_account
             .manager
-            .send_all_funds_back(ChainName::from_chain_id(STARGAZE))?;
+            .send_all_funds_back(TruncatedChainId::from_chain_id(STARGAZE))?;
 
         mock_interchain.check_ibc(JUNO, send_funds_back_tx)?;
 

--- a/interchain/interchain-tests/src/module_to_module_interactions.rs
+++ b/interchain/interchain-tests/src/module_to_module_interactions.rs
@@ -2,7 +2,9 @@ pub use abstract_std::app;
 use abstract_std::{
     ibc::{Callback, IbcResult},
     ibc_client::{self, InstalledModuleIdentification},
-    objects::{chain_name::ChainName, dependency::StaticDependency, module::ModuleInfo},
+    objects::{
+        dependency::StaticDependency, module::ModuleInfo, truncated_chain_id::TruncatedChainId,
+    },
     IBC_CLIENT,
 };
 use cosmwasm_schema::{cw_serde, QueryResponses};
@@ -26,15 +28,15 @@ pub enum MockExecMsg {
     DoSomething {},
     DoSomethingAdmin {},
     DoSomethingIbc {
-        remote_chain: ChainName,
+        remote_chain: TruncatedChainId,
         target_module: ModuleInfo,
     },
     QuerySomethingIbc {
-        remote_chain: ChainName,
+        remote_chain: TruncatedChainId,
         address: String,
     },
     QueryModuleIbc {
-        remote_chain: ChainName,
+        remote_chain: TruncatedChainId,
         target_module: ModuleInfo,
     },
 }
@@ -205,7 +207,7 @@ pub const fn mock_app(id: &'static str, version: &'static str) -> MockAppContrac
                 use abstract_sdk::features::AccountIdentification;
                 let ibc_client = app.ibc_client(deps.as_ref());
                 let mut account = app.account_id(deps.as_ref())?;
-                account.push_chain(ChainName::new(&env));
+                account.push_chain(TruncatedChainId::new(&env));
                 let msg = ibc_client.module_ibc_query(
                     remote_chain,
                     InstalledModuleIdentification {
@@ -346,7 +348,7 @@ pub mod test {
         setup::{ibc_abstract_setup, mock_test::logger_test_init},
         JUNO, STARGAZE,
     };
-    use abstract_app::objects::{chain_name::ChainName, module::ModuleInfo};
+    use abstract_app::objects::{module::ModuleInfo, truncated_chain_id::TruncatedChainId};
     use abstract_interface::{
         AppDeployer, DeployStrategy, Manager, ManagerQueryFns, VCExecFns, VCQueryFns,
     };
@@ -365,7 +367,7 @@ pub mod test {
 
         let (abstr_origin, _abstr_remote) = ibc_abstract_setup(&mock_interchain, JUNO, STARGAZE)?;
 
-        let remote_name = ChainName::from_chain_id(STARGAZE);
+        let remote_name = TruncatedChainId::from_chain_id(STARGAZE);
 
         let (origin_account, _remote_account_id) =
             create_test_remote_account(&abstr_origin, JUNO, STARGAZE, &mock_interchain, None)?;
@@ -415,7 +417,7 @@ pub mod test {
 
         let (abstr_origin, abstr_remote) = ibc_abstract_setup(&mock_interchain, JUNO, STARGAZE)?;
 
-        let remote_name = ChainName::from_chain_id(STARGAZE);
+        let remote_name = TruncatedChainId::from_chain_id(STARGAZE);
 
         let (origin_account, _remote_account_id) =
             create_test_remote_account(&abstr_origin, JUNO, STARGAZE, &mock_interchain, None)?;
@@ -478,7 +480,7 @@ pub mod test {
 
         let (abstr_origin, abstr_remote) = ibc_abstract_setup(&mock_interchain, JUNO, STARGAZE)?;
 
-        let remote_name = ChainName::from_chain_id(STARGAZE);
+        let remote_name = TruncatedChainId::from_chain_id(STARGAZE);
 
         let (origin_account, remote_account_id) =
             create_test_remote_account(&abstr_origin, JUNO, STARGAZE, &mock_interchain, None)?;
@@ -589,7 +591,7 @@ pub mod test {
 
         let (abstr_origin, _abstr_remote) = ibc_abstract_setup(&mock_interchain, JUNO, STARGAZE)?;
 
-        let remote_name = ChainName::from_chain_id(STARGAZE);
+        let remote_name = TruncatedChainId::from_chain_id(STARGAZE);
         let remote = mock_interchain.chain(STARGAZE)?;
         let remote_address =
             remote.addr_make_with_balance("remote-test", coins(REMOTE_AMOUNT, REMOTE_DENOM))?;
@@ -652,7 +654,7 @@ pub mod test {
             let (abstr_origin, abstr_remote) =
                 ibc_abstract_setup(&mock_interchain, JUNO, STARGAZE)?;
 
-            let remote_name = ChainName::from_chain_id(STARGAZE);
+            let remote_name = TruncatedChainId::from_chain_id(STARGAZE);
 
             let (origin_account, remote_account_id) =
                 create_test_remote_account(&abstr_origin, JUNO, STARGAZE, &mock_interchain, None)?;

--- a/interchain/interchain-tests/src/setup.rs
+++ b/interchain/interchain-tests/src/setup.rs
@@ -25,7 +25,8 @@ pub fn ibc_abstract_setup<Chain: IbcQueryHandler, IBC: InterchainEnv<Chain>>(
 #[cfg(test)]
 pub mod mock_test {
     use abstract_std::{
-        ibc_client::QueryMsgFns, ibc_host::QueryMsgFns as _, objects::chain_name::ChainName,
+        ibc_client::QueryMsgFns, ibc_host::QueryMsgFns as _,
+        objects::truncated_chain_id::TruncatedChainId,
     };
 
     use super::*;
@@ -49,12 +50,18 @@ pub mod mock_test {
         // We verify the host is active on the client on chain JUNO
         let remote_hosts = origin_abstr.ibc.client.list_remote_hosts()?;
         assert_eq!(remote_hosts.hosts.len(), 1);
-        assert_eq!(remote_hosts.hosts[0].0, ChainName::from_chain_id(STARGAZE));
+        assert_eq!(
+            remote_hosts.hosts[0].0,
+            TruncatedChainId::from_chain_id(STARGAZE)
+        );
 
         // We verify the client is active on the host chain JUNO
         let remote_hosts = remote_abstr.ibc.host.client_proxies(None, None)?;
         assert_eq!(remote_hosts.chains.len(), 1);
-        assert_eq!(remote_hosts.chains[0].0, ChainName::from_chain_id(JUNO));
+        assert_eq!(
+            remote_hosts.chains[0].0,
+            TruncatedChainId::from_chain_id(JUNO)
+        );
 
         Ok(())
     }

--- a/interchain/scripts/src/abstract_ibc.rs
+++ b/interchain/scripts/src/abstract_ibc.rs
@@ -1,7 +1,7 @@
 use abstract_interface::Abstract;
 use abstract_std::ibc_client::QueryMsgFns as _;
 use abstract_std::ibc_host::QueryMsgFns;
-use abstract_std::objects::chain_name::ChainName;
+use abstract_std::objects::truncated_chain_id::TruncatedChainId;
 use anyhow::anyhow;
 use cw_orch::prelude::*;
 use cw_orch_polytone::Polytone;
@@ -54,7 +54,7 @@ pub fn verify_abstract_ibc(
     let host = src_abstract
         .ibc
         .client
-        .host(ChainName::from_chain_id(dst_chain.chain_id))?;
+        .host(TruncatedChainId::from_chain_id(dst_chain.chain_id))?;
 
     // We verify the host matches dst chain host for this original chain
     if host.remote_polytone_proxy.is_none() {
@@ -69,7 +69,7 @@ pub fn verify_abstract_ibc(
     let proxy = dst_abstract
         .ibc
         .host
-        .client_proxy(ChainName::from_chain_id(src_chain.chain_id).into_string())?;
+        .client_proxy(TruncatedChainId::from_chain_id(src_chain.chain_id).into_string())?;
 
     if host.remote_polytone_proxy.unwrap() != proxy.proxy {
         anyhow::bail!("Wrong proxy address registered on the dst chain")

--- a/interchain/scripts/src/bin/create_remote_account.rs
+++ b/interchain/scripts/src/bin/create_remote_account.rs
@@ -4,7 +4,7 @@ use abstract_scripts::abstract_ibc::{
     has_abstract_ibc, has_polytone_connection, verify_abstract_ibc,
 };
 use abstract_scripts::NEUTRON_1;
-use abstract_std::objects::chain_name::ChainName;
+use abstract_std::objects::truncated_chain_id::TruncatedChainId;
 use abstract_std::objects::module::ModuleVersion;
 use abstract_std::objects::namespace::Namespace;
 use cw_orch::daemon::networks::neutron::NEUTRON_NETWORK;

--- a/modules/contracts/adapters/cw-staking/src/handlers/execute.rs
+++ b/modules/contracts/adapters/cw-staking/src/handlers/execute.rs
@@ -4,7 +4,7 @@ use abstract_adapter::sdk::{
     IbcInterface, Resolve,
 };
 use abstract_adapter::std::ibc::Callback;
-use abstract_adapter::std::objects::chain_name::ChainName;
+use abstract_adapter::std::objects::truncated_chain_id::TruncatedChainId;
 use abstract_staking_standard::msg::{ExecuteMsg, ProviderName, StakingAction, StakingExecuteMsg};
 use cosmwasm_std::{to_json_binary, Coin, Deps, DepsMut, Env, MessageInfo};
 
@@ -68,7 +68,7 @@ fn handle_ibc_request(
     provider_name: ProviderName,
     action: &StakingAction,
 ) -> StakingResult {
-    let host_chain = ChainName::from_string(provider_name.clone())?; // TODO : Especially this line is faulty
+    let host_chain = TruncatedChainId::from_string(provider_name.clone())?; // TODO : Especially this line is faulty
     let ans = adapter.name_service(deps.as_ref());
     let ibc_client = adapter.ibc_client(deps.as_ref());
     // get the to-be-sent assets from the action

--- a/modules/contracts/adapters/dex/src/handlers/execute.rs
+++ b/modules/contracts/adapters/dex/src/handlers/execute.rs
@@ -7,8 +7,8 @@ use abstract_adapter::std::{
     objects::{
         account::AccountTrace,
         ans_host::AnsHost,
-        chain_name::ChainName,
         namespace::{Namespace, ABSTRACT_NAMESPACE},
+        truncated_chain_id::TruncatedChainId,
         AccountId,
     },
 };
@@ -140,7 +140,7 @@ fn handle_ibc_request(
     dex_name: DexName,
     action: &DexRawAction,
 ) -> DexResult {
-    let host_chain = ChainName::from_string(dex_name.clone())?; // TODO, this is faulty
+    let host_chain = TruncatedChainId::from_string(dex_name.clone())?; // TODO, this is faulty
 
     let ans = adapter.name_service(deps.as_ref());
     let ibc_client = adapter.ibc_client(deps.as_ref());


### PR DESCRIPTION
The type we called `ChainName` did not represent the type underneath it. This PR aims to add some clarity for the type using it's type name

### Checklist

- [ ] CI is green.
- [x] Changelog updated.
