### PR TITLE
Fix account_sequence saving provided account_seq

### DIFF
--- a/framework/contracts/account/manager/tests/proxy.rs
+++ b/framework/contracts/account/manager/tests/proxy.rs
@@ -456,7 +456,7 @@ fn increment_not_effected_by_claiming() -> AResult {
     let deployment = Abstract::deploy_on(chain.clone(), sender.to_string())?;
 
     let next_account_id = deployment.account_factory.config()?.local_account_sequence;
-    assert_eq!(next_account_id, 2);
+    assert_eq!(next_account_id, 1);
 
     deployment.account_factory.create_new_account(
         AccountDetails {
@@ -475,13 +475,13 @@ fn increment_not_effected_by_claiming() -> AResult {
     )?;
 
     let next_account_id = deployment.account_factory.config()?.local_account_sequence;
-    assert_eq!(next_account_id, 2);
+    assert_eq!(next_account_id, 1);
 
     // create new account
     deployment.account_factory.create_default_account(GovernanceDetails::Monarchy { monarch: sender.to_string() })?;
 
     let next_account_id = deployment.account_factory.config()?.local_account_sequence;
-    assert_eq!(next_account_id, 3);
-    
+    assert_eq!(next_account_id, 2);
+
     Ok(())
 }

--- a/framework/contracts/account/manager/tests/proxy.rs
+++ b/framework/contracts/account/manager/tests/proxy.rs
@@ -448,7 +448,6 @@ fn can_take_any_last_two_billion_accounts() -> AResult {
     Ok(())
 }
 
-
 #[test]
 fn increment_not_effected_by_claiming() -> AResult {
     let chain = MockBech32::new("mock");
@@ -478,7 +477,11 @@ fn increment_not_effected_by_claiming() -> AResult {
     assert_eq!(next_account_id, 1);
 
     // create new account
-    deployment.account_factory.create_default_account(GovernanceDetails::Monarchy { monarch: sender.to_string() })?;
+    deployment
+        .account_factory
+        .create_default_account(GovernanceDetails::Monarchy {
+            monarch: sender.to_string(),
+        })?;
 
     let next_account_id = deployment.account_factory.config()?.local_account_sequence;
     assert_eq!(next_account_id, 2);


### PR DESCRIPTION
The account_seq of the account_factory was being saved after account instantiation without taking into account if the account_seq was provided or not. This resulted in the sequence jumping around (instead of being sequential). We fix this by updating the sequence logic to save the sequence right after retrieving it