### PR TITLE
Bump abstract to 0.23.0

### DIFF
--- a/framework/Cargo.toml
+++ b/framework/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.23.0-beta.0"
+version = "0.23.0"
 authors = [
   "CyberHoward <cyberhoward@protonmail.com>",
   "Riada <riada@abstract.money>",
@@ -83,14 +83,14 @@ ibc-host = { package = "abstract-ibc-host", path = "contracts/native/ibc-host" }
 proxy = { package = "abstract-proxy", path = "contracts/account/proxy" }
 manager = { package = "abstract-manager", path = "contracts/account/manager" }
 
-abstract-sdk = { version = "0.23.0-beta.0", path = "packages/abstract-sdk" }
-abstract-testing = { version = "0.23.0-beta.0", path = "packages/abstract-testing" }
-abstract-std = { version = "0.23.0-beta.0", path = "packages/abstract-std" }
+abstract-sdk = { version = "0.23.0", path = "packages/abstract-sdk" }
+abstract-testing = { version = "0.23.0", path = "packages/abstract-testing" }
+abstract-std = { version = "0.23.0", path = "packages/abstract-std" }
 
 # These should remain fixed and don't need to be re-published (unless changes are made)
-abstract-macros = { version = "0.23.0-beta.0", path = "packages/abstract-macros" }
+abstract-macros = { version = "0.23.0", path = "packages/abstract-macros" }
 
-abstract-adapter-utils = { version = "0.23.0-beta.0", path = "packages/standards/utils" }
+abstract-adapter-utils = { version = "0.23.0", path = "packages/standards/utils" }
 abstract-dex-standard = { path = "packages/standards/dex" }
 abstract-staking-standard = { path = "packages/standards/staking" }
 

--- a/framework/contracts/account/manager/tests/snapshots/adapters__account_install_adapter.snap
+++ b/framework/contracts/account/manager/tests/snapshots/adapters__account_install_adapter.snap
@@ -8,14 +8,14 @@ expression: all_storage
   - - cfg
     - "{\"version_control_contract\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_contract\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\",\"module_factory_address\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ans-host":
   - - config
     - "{\"next_unique_pool_id\":1}"
   - - contract_info
-    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
   - - registered_dexes
@@ -24,16 +24,16 @@ expression: all_storage
   - - config
     - "{\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"},\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0\"}"
   - - module_data
-    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\",\"dependencies\":[],\"metadata\":null}"
+    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0\",\"dependencies\":[],\"metadata\":null}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ibc-host":
   - - cfg
     - "{\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"},\"account_factory\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:manager-local-0":
@@ -48,7 +48,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - info
     - "{\"name\":\"Default Abstract Account\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":null,\"link\":null}"
   - - ownership
@@ -67,7 +67,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - icontext
     - "[[{\"info\":{\"namespace\":\"tester\",\"name\":\"mock-adapter1\",\"version\":{\"version\":\"1.0.0\"}},\"reference\":{\"adapter\":\"mock1g6kht9c5s4jwn4akfjt3zmsfh4nvguewaegjeavpz3f0q9uylrqswspf09\"}},null]]"
   - - info
@@ -78,7 +78,7 @@ expression: all_storage
   - - "\u0000{5}config"
     - "{\"version_control_address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:proxy-local-0":
@@ -91,7 +91,7 @@ expression: all_storage
   - - admin
     - "\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:proxy-local-1":
   - - "\u0000{5}state"
     - "{\"modules\":[\"mock1ps47cz26ugmzp2emuqap8jmvjrkwyzgh4uupechr9et6w0a3ar6sv5ag3c\",\"mock1g6kht9c5s4jwn4akfjt3zmsfh4nvguewaegjeavpz3f0q9uylrqswspf09\"]}"
@@ -102,25 +102,25 @@ expression: all_storage
   - - admin
     - "\"mock1ps47cz26ugmzp2emuqap8jmvjrkwyzgh4uupechr9et6w0a3ar6sv5ag3c\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:version-control":
   - - "\u0000\u0003lib\u0000\u0006tester\u0000\rmock-adapter11.0.0"
     - "{\"adapter\":\"mock1g6kht9c5s4jwn4akfjt3zmsfh4nvguewaegjeavpz3f0q9uylrqswspf09\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0"
     - "{\"account_base\":6}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0"
     - "{\"account_base\":5}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0"
     - "{\"native\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0"
     - "{\"native\":\"mock14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les6xzvf5\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0"
     - "{\"native\":\"mock1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcns7ctvz5\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0"
     - "{\"native\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0"
     - "{\"native\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0"
     - "{\"native\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}"
   - - "\u0000\u0004accs\u0000\u0005local\u0000\u0000\u0000\u0000"
     - "{\"manager\":\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\",\"proxy\":\"mock1xsemjm2xzx8nfaj50rt2dn04g24yarrr3mf6uwhqtc4ampff9nsqrc867x\"}"
@@ -137,7 +137,7 @@ expression: all_storage
   - - cfg
     - "{\"account_factory_address\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"security_disabled\":true,\"namespace_registration_fee\":null}"
   - - contract_info
-    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "tester:mock-adapter1":

--- a/framework/contracts/account/manager/tests/snapshots/adapters__install_one_adapter.snap
+++ b/framework/contracts/account/manager/tests/snapshots/adapters__install_one_adapter.snap
@@ -8,14 +8,14 @@ expression: all_storage
   - - cfg
     - "{\"version_control_contract\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_contract\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\",\"module_factory_address\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ans-host":
   - - config
     - "{\"next_unique_pool_id\":1}"
   - - contract_info
-    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
   - - registered_dexes
@@ -24,16 +24,16 @@ expression: all_storage
   - - config
     - "{\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"},\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0\"}"
   - - module_data
-    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\",\"dependencies\":[],\"metadata\":null}"
+    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0\",\"dependencies\":[],\"metadata\":null}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ibc-host":
   - - cfg
     - "{\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"},\"account_factory\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:manager-local-0":
@@ -48,7 +48,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - info
     - "{\"name\":\"Default Abstract Account\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":null,\"link\":null}"
   - - ownership
@@ -67,9 +67,9 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - icontext
-    - "[[{\"info\":{\"namespace\":\"tester\",\"name\":\"test-module-id\",\"version\":{\"version\":\"0.23.0-beta.0\"}},\"reference\":{\"adapter\":\"mock1g6kht9c5s4jwn4akfjt3zmsfh4nvguewaegjeavpz3f0q9uylrqswspf09\"}},null]]"
+    - "[[{\"info\":{\"namespace\":\"tester\",\"name\":\"test-module-id\",\"version\":{\"version\":\"0.23.0\"}},\"reference\":{\"adapter\":\"mock1g6kht9c5s4jwn4akfjt3zmsfh4nvguewaegjeavpz3f0q9uylrqswspf09\"}},null]]"
   - - info
     - "{\"name\":\"Default Abstract Account\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":null,\"link\":null}"
   - - ownership
@@ -78,7 +78,7 @@ expression: all_storage
   - - "\u0000{5}config"
     - "{\"version_control_address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:proxy-local-0":
@@ -91,7 +91,7 @@ expression: all_storage
   - - admin
     - "\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:proxy-local-1":
   - - "\u0000{5}state"
     - "{\"modules\":[\"mock1ps47cz26ugmzp2emuqap8jmvjrkwyzgh4uupechr9et6w0a3ar6sv5ag3c\",\"mock1g6kht9c5s4jwn4akfjt3zmsfh4nvguewaegjeavpz3f0q9uylrqswspf09\"]}"
@@ -102,25 +102,25 @@ expression: all_storage
   - - admin
     - "\"mock1ps47cz26ugmzp2emuqap8jmvjrkwyzgh4uupechr9et6w0a3ar6sv5ag3c\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:version-control":
-  - - "\u0000\u0003lib\u0000\u0006tester\u0000\u000etest-module-id0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\u0006tester\u0000\u000etest-module-id0.23.0"
     - "{\"adapter\":\"mock1g6kht9c5s4jwn4akfjt3zmsfh4nvguewaegjeavpz3f0q9uylrqswspf09\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0"
     - "{\"account_base\":6}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0"
     - "{\"account_base\":5}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0"
     - "{\"native\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0"
     - "{\"native\":\"mock14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les6xzvf5\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0"
     - "{\"native\":\"mock1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcns7ctvz5\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0"
     - "{\"native\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0"
     - "{\"native\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0"
     - "{\"native\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}"
   - - "\u0000\u0004accs\u0000\u0005local\u0000\u0000\u0000\u0000"
     - "{\"manager\":\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\",\"proxy\":\"mock1xsemjm2xzx8nfaj50rt2dn04g24yarrr3mf6uwhqtc4ampff9nsqrc867x\"}"
@@ -137,15 +137,15 @@ expression: all_storage
   - - cfg
     - "{\"account_factory_address\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"security_disabled\":true,\"namespace_registration_fee\":null}"
   - - contract_info
-    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "tester:test-module-id":
   - - base_state
     - "{\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"},\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}}"
   - - contract_info
-    - "{\"contract\":\"tester:test-module-id\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"tester:test-module-id\",\"version\":\"0.23.0\"}"
   - - ibc_callback_received
     - "false"
   - - module_data
-    - "{\"module\":\"tester:test-module-id\",\"version\":\"0.23.0-beta.0\",\"dependencies\":[],\"metadata\":\"test_metadata\"}"
+    - "{\"module\":\"tester:test-module-id\",\"version\":\"0.23.0\",\"dependencies\":[],\"metadata\":\"test_metadata\"}"

--- a/framework/contracts/account/manager/tests/snapshots/adapters__install_one_adapter_with_fee.snap
+++ b/framework/contracts/account/manager/tests/snapshots/adapters__install_one_adapter_with_fee.snap
@@ -8,14 +8,14 @@ expression: all_storage
   - - cfg
     - "{\"version_control_contract\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_contract\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\",\"module_factory_address\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ans-host":
   - - config
     - "{\"next_unique_pool_id\":1}"
   - - contract_info
-    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
   - - registered_dexes
@@ -24,16 +24,16 @@ expression: all_storage
   - - config
     - "{\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"},\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0\"}"
   - - module_data
-    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\",\"dependencies\":[],\"metadata\":null}"
+    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0\",\"dependencies\":[],\"metadata\":null}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ibc-host":
   - - cfg
     - "{\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"},\"account_factory\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:manager-local-0":
@@ -48,7 +48,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - info
     - "{\"name\":\"Default Abstract Account\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":null,\"link\":null}"
   - - ownership
@@ -67,9 +67,9 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - icontext
-    - "[[{\"info\":{\"namespace\":\"tester\",\"name\":\"test-module-id\",\"version\":{\"version\":\"0.23.0-beta.0\"}},\"reference\":{\"adapter\":\"mock1g6kht9c5s4jwn4akfjt3zmsfh4nvguewaegjeavpz3f0q9uylrqswspf09\"}},null]]"
+    - "[[{\"info\":{\"namespace\":\"tester\",\"name\":\"test-module-id\",\"version\":{\"version\":\"0.23.0\"}},\"reference\":{\"adapter\":\"mock1g6kht9c5s4jwn4akfjt3zmsfh4nvguewaegjeavpz3f0q9uylrqswspf09\"}},null]]"
   - - info
     - "{\"name\":\"Default Abstract Account\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":null,\"link\":null}"
   - - ownership
@@ -78,7 +78,7 @@ expression: all_storage
   - - "\u0000{5}config"
     - "{\"version_control_address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:proxy-local-0":
@@ -91,7 +91,7 @@ expression: all_storage
   - - admin
     - "\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:proxy-local-1":
   - - "\u0000{5}state"
     - "{\"modules\":[\"mock1ps47cz26ugmzp2emuqap8jmvjrkwyzgh4uupechr9et6w0a3ar6sv5ag3c\",\"mock1g6kht9c5s4jwn4akfjt3zmsfh4nvguewaegjeavpz3f0q9uylrqswspf09\"]}"
@@ -102,27 +102,27 @@ expression: all_storage
   - - admin
     - "\"mock1ps47cz26ugmzp2emuqap8jmvjrkwyzgh4uupechr9et6w0a3ar6sv5ag3c\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:version-control":
-  - - "\u0000\u0003cfg\u0000\u0006tester\u0000\u000etest-module-id0.23.0-beta.0"
+  - - "\u0000\u0003cfg\u0000\u0006tester\u0000\u000etest-module-id0.23.0"
     - "{\"monetization\":{\"install_fee\":{\"fee\":{\"denom\":\"ujunox\",\"amount\":\"45\"}}},\"metadata\":null,\"instantiation_funds\":[]}"
-  - - "\u0000\u0003lib\u0000\u0006tester\u0000\u000etest-module-id0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\u0006tester\u0000\u000etest-module-id0.23.0"
     - "{\"adapter\":\"mock1g6kht9c5s4jwn4akfjt3zmsfh4nvguewaegjeavpz3f0q9uylrqswspf09\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0"
     - "{\"account_base\":6}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0"
     - "{\"account_base\":5}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0"
     - "{\"native\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0"
     - "{\"native\":\"mock14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les6xzvf5\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0"
     - "{\"native\":\"mock1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcns7ctvz5\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0"
     - "{\"native\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0"
     - "{\"native\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0"
     - "{\"native\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}"
   - - "\u0000\u0004accs\u0000\u0005local\u0000\u0000\u0000\u0000"
     - "{\"manager\":\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\",\"proxy\":\"mock1xsemjm2xzx8nfaj50rt2dn04g24yarrr3mf6uwhqtc4ampff9nsqrc867x\"}"
@@ -139,15 +139,15 @@ expression: all_storage
   - - cfg
     - "{\"account_factory_address\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"security_disabled\":true,\"namespace_registration_fee\":null}"
   - - contract_info
-    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "tester:test-module-id":
   - - base_state
     - "{\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"},\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}}"
   - - contract_info
-    - "{\"contract\":\"tester:test-module-id\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"tester:test-module-id\",\"version\":\"0.23.0\"}"
   - - ibc_callback_received
     - "false"
   - - module_data
-    - "{\"module\":\"tester:test-module-id\",\"version\":\"0.23.0-beta.0\",\"dependencies\":[],\"metadata\":\"test_metadata\"}"
+    - "{\"module\":\"tester:test-module-id\",\"version\":\"0.23.0\",\"dependencies\":[],\"metadata\":\"test_metadata\"}"

--- a/framework/contracts/account/manager/tests/snapshots/adapters__installing_specific_version_should_install_expected.snap
+++ b/framework/contracts/account/manager/tests/snapshots/adapters__installing_specific_version_should_install_expected.snap
@@ -8,14 +8,14 @@ expression: all_storage
   - - cfg
     - "{\"version_control_contract\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_contract\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\",\"module_factory_address\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ans-host":
   - - config
     - "{\"next_unique_pool_id\":1}"
   - - contract_info
-    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
   - - registered_dexes
@@ -24,16 +24,16 @@ expression: all_storage
   - - config
     - "{\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"},\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0\"}"
   - - module_data
-    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\",\"dependencies\":[],\"metadata\":null}"
+    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0\",\"dependencies\":[],\"metadata\":null}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ibc-host":
   - - cfg
     - "{\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"},\"account_factory\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:manager-local-0":
@@ -48,7 +48,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - info
     - "{\"name\":\"Default Abstract Account\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":null,\"link\":null}"
   - - ownership
@@ -67,7 +67,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - icontext
     - "[[{\"info\":{\"namespace\":\"tester\",\"name\":\"mock-adapter1\",\"version\":{\"version\":\"1.0.0\"}},\"reference\":{\"adapter\":\"mock1g6kht9c5s4jwn4akfjt3zmsfh4nvguewaegjeavpz3f0q9uylrqswspf09\"}},null]]"
   - - info
@@ -78,7 +78,7 @@ expression: all_storage
   - - "\u0000{5}config"
     - "{\"version_control_address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:proxy-local-0":
@@ -91,7 +91,7 @@ expression: all_storage
   - - admin
     - "\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:proxy-local-1":
   - - "\u0000{5}state"
     - "{\"modules\":[\"mock1ps47cz26ugmzp2emuqap8jmvjrkwyzgh4uupechr9et6w0a3ar6sv5ag3c\",\"mock1g6kht9c5s4jwn4akfjt3zmsfh4nvguewaegjeavpz3f0q9uylrqswspf09\"]}"
@@ -102,27 +102,27 @@ expression: all_storage
   - - admin
     - "\"mock1ps47cz26ugmzp2emuqap8jmvjrkwyzgh4uupechr9et6w0a3ar6sv5ag3c\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:version-control":
   - - "\u0000\u0003lib\u0000\u0006tester\u0000\rmock-adapter11.0.0"
     - "{\"adapter\":\"mock1g6kht9c5s4jwn4akfjt3zmsfh4nvguewaegjeavpz3f0q9uylrqswspf09\"}"
   - - "\u0000\u0003lib\u0000\u0006tester\u0000\rmock-adapter12.0.0"
     - "{\"adapter\":\"mock1x22q8lfhz7qcvtzs0dakhgx2th64l79kepjujhhxk5x804taeqlqu2pr45\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0"
     - "{\"account_base\":6}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0"
     - "{\"account_base\":5}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0"
     - "{\"native\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0"
     - "{\"native\":\"mock14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les6xzvf5\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0"
     - "{\"native\":\"mock1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcns7ctvz5\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0"
     - "{\"native\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0"
     - "{\"native\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0"
     - "{\"native\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}"
   - - "\u0000\u0004accs\u0000\u0005local\u0000\u0000\u0000\u0000"
     - "{\"manager\":\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\",\"proxy\":\"mock1xsemjm2xzx8nfaj50rt2dn04g24yarrr3mf6uwhqtc4ampff9nsqrc867x\"}"
@@ -139,7 +139,7 @@ expression: all_storage
   - - cfg
     - "{\"account_factory_address\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"security_disabled\":true,\"namespace_registration_fee\":null}"
   - - contract_info
-    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "tester:mock-adapter1":

--- a/framework/contracts/account/manager/tests/snapshots/adapters__reinstalling_adapter_should_be_allowed.snap
+++ b/framework/contracts/account/manager/tests/snapshots/adapters__reinstalling_adapter_should_be_allowed.snap
@@ -8,14 +8,14 @@ expression: all_storage
   - - cfg
     - "{\"version_control_contract\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_contract\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\",\"module_factory_address\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ans-host":
   - - config
     - "{\"next_unique_pool_id\":1}"
   - - contract_info
-    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
   - - registered_dexes
@@ -24,16 +24,16 @@ expression: all_storage
   - - config
     - "{\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"},\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0\"}"
   - - module_data
-    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\",\"dependencies\":[],\"metadata\":null}"
+    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0\",\"dependencies\":[],\"metadata\":null}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ibc-host":
   - - cfg
     - "{\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"},\"account_factory\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:manager-local-0":
@@ -48,7 +48,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - info
     - "{\"name\":\"Default Abstract Account\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":null,\"link\":null}"
   - - ownership
@@ -67,9 +67,9 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - icontext
-    - "[[{\"info\":{\"namespace\":\"tester\",\"name\":\"test-module-id\",\"version\":{\"version\":\"0.23.0-beta.0\"}},\"reference\":{\"adapter\":\"mock1g6kht9c5s4jwn4akfjt3zmsfh4nvguewaegjeavpz3f0q9uylrqswspf09\"}},null]]"
+    - "[[{\"info\":{\"namespace\":\"tester\",\"name\":\"test-module-id\",\"version\":{\"version\":\"0.23.0\"}},\"reference\":{\"adapter\":\"mock1g6kht9c5s4jwn4akfjt3zmsfh4nvguewaegjeavpz3f0q9uylrqswspf09\"}},null]]"
   - - info
     - "{\"name\":\"Default Abstract Account\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":null,\"link\":null}"
   - - ownership
@@ -78,7 +78,7 @@ expression: all_storage
   - - "\u0000{5}config"
     - "{\"version_control_address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:proxy-local-0":
@@ -91,7 +91,7 @@ expression: all_storage
   - - admin
     - "\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:proxy-local-1":
   - - "\u0000{5}state"
     - "{\"modules\":[\"mock1ps47cz26ugmzp2emuqap8jmvjrkwyzgh4uupechr9et6w0a3ar6sv5ag3c\",\"mock1g6kht9c5s4jwn4akfjt3zmsfh4nvguewaegjeavpz3f0q9uylrqswspf09\"]}"
@@ -102,25 +102,25 @@ expression: all_storage
   - - admin
     - "\"mock1ps47cz26ugmzp2emuqap8jmvjrkwyzgh4uupechr9et6w0a3ar6sv5ag3c\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:version-control":
-  - - "\u0000\u0003lib\u0000\u0006tester\u0000\u000etest-module-id0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\u0006tester\u0000\u000etest-module-id0.23.0"
     - "{\"adapter\":\"mock1g6kht9c5s4jwn4akfjt3zmsfh4nvguewaegjeavpz3f0q9uylrqswspf09\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0"
     - "{\"account_base\":6}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0"
     - "{\"account_base\":5}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0"
     - "{\"native\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0"
     - "{\"native\":\"mock14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les6xzvf5\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0"
     - "{\"native\":\"mock1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcns7ctvz5\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0"
     - "{\"native\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0"
     - "{\"native\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0"
     - "{\"native\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}"
   - - "\u0000\u0004accs\u0000\u0005local\u0000\u0000\u0000\u0000"
     - "{\"manager\":\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\",\"proxy\":\"mock1xsemjm2xzx8nfaj50rt2dn04g24yarrr3mf6uwhqtc4ampff9nsqrc867x\"}"
@@ -137,15 +137,15 @@ expression: all_storage
   - - cfg
     - "{\"account_factory_address\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"security_disabled\":true,\"namespace_registration_fee\":null}"
   - - contract_info
-    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "tester:test-module-id":
   - - base_state
     - "{\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"},\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}}"
   - - contract_info
-    - "{\"contract\":\"tester:test-module-id\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"tester:test-module-id\",\"version\":\"0.23.0\"}"
   - - ibc_callback_received
     - "false"
   - - module_data
-    - "{\"module\":\"tester:test-module-id\",\"version\":\"0.23.0-beta.0\",\"dependencies\":[],\"metadata\":\"test_metadata\"}"
+    - "{\"module\":\"tester:test-module-id\",\"version\":\"0.23.0\",\"dependencies\":[],\"metadata\":\"test_metadata\"}"

--- a/framework/contracts/account/manager/tests/snapshots/adapters__reinstalling_new_version_should_install_latest.snap
+++ b/framework/contracts/account/manager/tests/snapshots/adapters__reinstalling_new_version_should_install_latest.snap
@@ -8,14 +8,14 @@ expression: all_storage
   - - cfg
     - "{\"version_control_contract\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_contract\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\",\"module_factory_address\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ans-host":
   - - config
     - "{\"next_unique_pool_id\":1}"
   - - contract_info
-    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
   - - registered_dexes
@@ -24,16 +24,16 @@ expression: all_storage
   - - config
     - "{\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"},\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0\"}"
   - - module_data
-    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\",\"dependencies\":[],\"metadata\":null}"
+    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0\",\"dependencies\":[],\"metadata\":null}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ibc-host":
   - - cfg
     - "{\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"},\"account_factory\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:manager-local-0":
@@ -48,7 +48,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - info
     - "{\"name\":\"Default Abstract Account\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":null,\"link\":null}"
   - - ownership
@@ -67,7 +67,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - icontext
     - "[[{\"info\":{\"namespace\":\"tester\",\"name\":\"mock-adapter1\",\"version\":{\"version\":\"2.0.0\"}},\"reference\":{\"adapter\":\"mock1x22q8lfhz7qcvtzs0dakhgx2th64l79kepjujhhxk5x804taeqlqu2pr45\"}},null]]"
   - - info
@@ -78,7 +78,7 @@ expression: all_storage
   - - "\u0000{5}config"
     - "{\"version_control_address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:proxy-local-0":
@@ -91,7 +91,7 @@ expression: all_storage
   - - admin
     - "\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:proxy-local-1":
   - - "\u0000{5}state"
     - "{\"modules\":[\"mock1ps47cz26ugmzp2emuqap8jmvjrkwyzgh4uupechr9et6w0a3ar6sv5ag3c\",\"mock1x22q8lfhz7qcvtzs0dakhgx2th64l79kepjujhhxk5x804taeqlqu2pr45\"]}"
@@ -102,27 +102,27 @@ expression: all_storage
   - - admin
     - "\"mock1ps47cz26ugmzp2emuqap8jmvjrkwyzgh4uupechr9et6w0a3ar6sv5ag3c\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:version-control":
   - - "\u0000\u0003lib\u0000\u0006tester\u0000\rmock-adapter11.0.0"
     - "{\"adapter\":\"mock1g6kht9c5s4jwn4akfjt3zmsfh4nvguewaegjeavpz3f0q9uylrqswspf09\"}"
   - - "\u0000\u0003lib\u0000\u0006tester\u0000\rmock-adapter12.0.0"
     - "{\"adapter\":\"mock1x22q8lfhz7qcvtzs0dakhgx2th64l79kepjujhhxk5x804taeqlqu2pr45\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0"
     - "{\"account_base\":6}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0"
     - "{\"account_base\":5}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0"
     - "{\"native\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0"
     - "{\"native\":\"mock14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les6xzvf5\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0"
     - "{\"native\":\"mock1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcns7ctvz5\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0"
     - "{\"native\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0"
     - "{\"native\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0"
     - "{\"native\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}"
   - - "\u0000\u0004accs\u0000\u0005local\u0000\u0000\u0000\u0000"
     - "{\"manager\":\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\",\"proxy\":\"mock1xsemjm2xzx8nfaj50rt2dn04g24yarrr3mf6uwhqtc4ampff9nsqrc867x\"}"
@@ -139,7 +139,7 @@ expression: all_storage
   - - cfg
     - "{\"account_factory_address\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"security_disabled\":true,\"namespace_registration_fee\":null}"
   - - contract_info
-    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "tester:mock-adapter1":

--- a/framework/contracts/account/manager/tests/snapshots/apps__account_install_app.snap
+++ b/framework/contracts/account/manager/tests/snapshots/apps__account_install_app.snap
@@ -8,14 +8,14 @@ expression: all_storage
   - - cfg
     - "{\"version_control_contract\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_contract\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\",\"module_factory_address\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ans-host":
   - - config
     - "{\"next_unique_pool_id\":1}"
   - - contract_info
-    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
   - - registered_dexes
@@ -24,16 +24,16 @@ expression: all_storage
   - - config
     - "{\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"},\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0\"}"
   - - module_data
-    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\",\"dependencies\":[],\"metadata\":null}"
+    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0\",\"dependencies\":[],\"metadata\":null}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ibc-host":
   - - cfg
     - "{\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"},\"account_factory\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:manager-local-0":
@@ -48,7 +48,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - info
     - "{\"name\":\"Default Abstract Account\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":null,\"link\":null}"
   - - ownership
@@ -67,7 +67,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - icontext
     - "[[{\"info\":{\"namespace\":\"tester\",\"name\":\"app\",\"version\":{\"version\":\"1.0.0\"}},\"reference\":{\"app\":9}},\"mock1pvj0q8g3ku6udgqaq7z8x768fjv3qezmjc8l8rk9y84e0pw6u9msg3zwyl\"]]"
   - - info
@@ -78,7 +78,7 @@ expression: all_storage
   - - "\u0000{5}config"
     - "{\"version_control_address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:proxy-local-0":
@@ -91,7 +91,7 @@ expression: all_storage
   - - admin
     - "\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:proxy-local-1":
   - - "\u0000{5}state"
     - "{\"modules\":[\"mock1ps47cz26ugmzp2emuqap8jmvjrkwyzgh4uupechr9et6w0a3ar6sv5ag3c\",\"mock1pvj0q8g3ku6udgqaq7z8x768fjv3qezmjc8l8rk9y84e0pw6u9msg3zwyl\"]}"
@@ -102,25 +102,25 @@ expression: all_storage
   - - admin
     - "\"mock1ps47cz26ugmzp2emuqap8jmvjrkwyzgh4uupechr9et6w0a3ar6sv5ag3c\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:version-control":
   - - "\u0000\u0003lib\u0000\u0006tester\u0000\u0003app1.0.0"
     - "{\"app\":9}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0"
     - "{\"account_base\":6}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0"
     - "{\"account_base\":5}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0"
     - "{\"native\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0"
     - "{\"native\":\"mock14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les6xzvf5\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0"
     - "{\"native\":\"mock1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcns7ctvz5\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0"
     - "{\"native\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0"
     - "{\"native\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0"
     - "{\"native\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}"
   - - "\u0000\u0004accs\u0000\u0005local\u0000\u0000\u0000\u0000"
     - "{\"manager\":\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\",\"proxy\":\"mock1xsemjm2xzx8nfaj50rt2dn04g24yarrr3mf6uwhqtc4ampff9nsqrc867x\"}"
@@ -137,7 +137,7 @@ expression: all_storage
   - - cfg
     - "{\"account_factory_address\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"security_disabled\":true,\"namespace_registration_fee\":null}"
   - - contract_info
-    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "tester:app":

--- a/framework/contracts/account/manager/tests/snapshots/apps__execute_on_proxy_through_manager.snap
+++ b/framework/contracts/account/manager/tests/snapshots/apps__execute_on_proxy_through_manager.snap
@@ -8,14 +8,14 @@ expression: all_storage
   - - cfg
     - "{\"version_control_contract\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_contract\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\",\"module_factory_address\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ans-host":
   - - config
     - "{\"next_unique_pool_id\":1}"
   - - contract_info
-    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
   - - registered_dexes
@@ -24,16 +24,16 @@ expression: all_storage
   - - config
     - "{\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"},\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0\"}"
   - - module_data
-    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\",\"dependencies\":[],\"metadata\":null}"
+    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0\",\"dependencies\":[],\"metadata\":null}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ibc-host":
   - - cfg
     - "{\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"},\"account_factory\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:manager-local-0":
@@ -48,7 +48,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - info
     - "{\"name\":\"Default Abstract Account\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":null,\"link\":null}"
   - - ownership
@@ -65,7 +65,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - info
     - "{\"name\":\"Default Abstract Account\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":null,\"link\":null}"
   - - ownership
@@ -74,7 +74,7 @@ expression: all_storage
   - - "\u0000{5}config"
     - "{\"version_control_address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:proxy-local-0":
@@ -87,7 +87,7 @@ expression: all_storage
   - - admin
     - "\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:proxy-local-1":
   - - "\u0000{5}state"
     - "{\"modules\":[\"mock1ps47cz26ugmzp2emuqap8jmvjrkwyzgh4uupechr9et6w0a3ar6sv5ag3c\"]}"
@@ -98,23 +98,23 @@ expression: all_storage
   - - admin
     - "\"mock1ps47cz26ugmzp2emuqap8jmvjrkwyzgh4uupechr9et6w0a3ar6sv5ag3c\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:version-control":
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0"
     - "{\"account_base\":6}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0"
     - "{\"account_base\":5}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0"
     - "{\"native\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0"
     - "{\"native\":\"mock14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les6xzvf5\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0"
     - "{\"native\":\"mock1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcns7ctvz5\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0"
     - "{\"native\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0"
     - "{\"native\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0"
     - "{\"native\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}"
   - - "\u0000\u0004accs\u0000\u0005local\u0000\u0000\u0000\u0000"
     - "{\"manager\":\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\",\"proxy\":\"mock1xsemjm2xzx8nfaj50rt2dn04g24yarrr3mf6uwhqtc4ampff9nsqrc867x\"}"
@@ -127,6 +127,6 @@ expression: all_storage
   - - cfg
     - "{\"account_factory_address\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"security_disabled\":true,\"namespace_registration_fee\":null}"
   - - contract_info
-    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"

--- a/framework/contracts/account/manager/tests/snapshots/install_modules__adds_module_to_account_modules.snap
+++ b/framework/contracts/account/manager/tests/snapshots/install_modules__adds_module_to_account_modules.snap
@@ -8,14 +8,14 @@ expression: all_storage
   - - cfg
     - "{\"version_control_contract\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_contract\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\",\"module_factory_address\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ans-host":
   - - config
     - "{\"next_unique_pool_id\":1}"
   - - contract_info
-    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
   - - registered_dexes
@@ -24,16 +24,16 @@ expression: all_storage
   - - config
     - "{\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"},\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0\"}"
   - - module_data
-    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\",\"dependencies\":[],\"metadata\":null}"
+    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0\",\"dependencies\":[],\"metadata\":null}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ibc-host":
   - - cfg
     - "{\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"},\"account_factory\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:manager-local-0":
@@ -48,7 +48,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - info
     - "{\"name\":\"Default Abstract Account\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":null,\"link\":null}"
   - - ownership
@@ -67,7 +67,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - icontext
     - "[[{\"info\":{\"namespace\":\"tester\",\"name\":\"mock-adapter1\",\"version\":{\"version\":\"1.0.0\"}},\"reference\":{\"adapter\":\"mock1g6kht9c5s4jwn4akfjt3zmsfh4nvguewaegjeavpz3f0q9uylrqswspf09\"}},null]]"
   - - info
@@ -78,7 +78,7 @@ expression: all_storage
   - - "\u0000{5}config"
     - "{\"version_control_address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:proxy-local-0":
@@ -91,7 +91,7 @@ expression: all_storage
   - - admin
     - "\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:proxy-local-1":
   - - "\u0000{5}state"
     - "{\"modules\":[\"mock1ps47cz26ugmzp2emuqap8jmvjrkwyzgh4uupechr9et6w0a3ar6sv5ag3c\",\"mock1g6kht9c5s4jwn4akfjt3zmsfh4nvguewaegjeavpz3f0q9uylrqswspf09\"]}"
@@ -102,7 +102,7 @@ expression: all_storage
   - - admin
     - "\"mock1ps47cz26ugmzp2emuqap8jmvjrkwyzgh4uupechr9et6w0a3ar6sv5ag3c\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:version-control":
   - - "\u0000\u0003lib\u0000\u0006tester\u0000\tmock-app11.0.0"
     - "{\"app\":13}"
@@ -116,21 +116,21 @@ expression: all_storage
     - "{\"adapter\":\"mock1fuyxwxlsgjkfjmxfthq8427dm2am3ya3cwcdr8gls29l7jadtazs7kt0c7\"}"
   - - "\u0000\u0003lib\u0000\u0006tester\u0000\rmock-adapter22.0.0"
     - "{\"adapter\":\"mock1qyygux5t4s3a3l25k8psxjydhtudu5lnt0tk0szm8q4s27xa980sgvgwkw\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0"
     - "{\"account_base\":6}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0"
     - "{\"account_base\":5}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0"
     - "{\"native\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0"
     - "{\"native\":\"mock14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les6xzvf5\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0"
     - "{\"native\":\"mock1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcns7ctvz5\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0"
     - "{\"native\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0"
     - "{\"native\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0"
     - "{\"native\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}"
   - - "\u0000\u0004accs\u0000\u0005local\u0000\u0000\u0000\u0000"
     - "{\"manager\":\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\",\"proxy\":\"mock1xsemjm2xzx8nfaj50rt2dn04g24yarrr3mf6uwhqtc4ampff9nsqrc867x\"}"
@@ -147,7 +147,7 @@ expression: all_storage
   - - cfg
     - "{\"account_factory_address\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"security_disabled\":true,\"namespace_registration_fee\":null}"
   - - contract_info
-    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "tester:mock-adapter1":

--- a/framework/contracts/account/manager/tests/snapshots/proxy__default_without_response_data.snap
+++ b/framework/contracts/account/manager/tests/snapshots/proxy__default_without_response_data.snap
@@ -8,14 +8,14 @@ expression: all_storage
   - - cfg
     - "{\"version_control_contract\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_contract\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\",\"module_factory_address\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ans-host":
   - - config
     - "{\"next_unique_pool_id\":1}"
   - - contract_info
-    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
   - - registered_dexes
@@ -24,16 +24,16 @@ expression: all_storage
   - - config
     - "{\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"},\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0\"}"
   - - module_data
-    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\",\"dependencies\":[],\"metadata\":null}"
+    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0\",\"dependencies\":[],\"metadata\":null}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ibc-host":
   - - cfg
     - "{\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"},\"account_factory\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:manager-local-0":
@@ -48,7 +48,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - info
     - "{\"name\":\"Default Abstract Account\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":null,\"link\":null}"
   - - ownership
@@ -67,9 +67,9 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - icontext
-    - "[[{\"info\":{\"namespace\":\"tester\",\"name\":\"test-module-id\",\"version\":{\"version\":\"0.23.0-beta.0\"}},\"reference\":{\"adapter\":\"mock1g6kht9c5s4jwn4akfjt3zmsfh4nvguewaegjeavpz3f0q9uylrqswspf09\"}},null]]"
+    - "[[{\"info\":{\"namespace\":\"tester\",\"name\":\"test-module-id\",\"version\":{\"version\":\"0.23.0\"}},\"reference\":{\"adapter\":\"mock1g6kht9c5s4jwn4akfjt3zmsfh4nvguewaegjeavpz3f0q9uylrqswspf09\"}},null]]"
   - - info
     - "{\"name\":\"Default Abstract Account\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":null,\"link\":null}"
   - - ownership
@@ -78,7 +78,7 @@ expression: all_storage
   - - "\u0000{5}config"
     - "{\"version_control_address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:proxy-local-0":
@@ -91,7 +91,7 @@ expression: all_storage
   - - admin
     - "\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:proxy-local-1":
   - - "\u0000{5}state"
     - "{\"modules\":[\"mock1ps47cz26ugmzp2emuqap8jmvjrkwyzgh4uupechr9et6w0a3ar6sv5ag3c\",\"mock1g6kht9c5s4jwn4akfjt3zmsfh4nvguewaegjeavpz3f0q9uylrqswspf09\"]}"
@@ -102,25 +102,25 @@ expression: all_storage
   - - admin
     - "\"mock1ps47cz26ugmzp2emuqap8jmvjrkwyzgh4uupechr9et6w0a3ar6sv5ag3c\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:version-control":
-  - - "\u0000\u0003lib\u0000\u0006tester\u0000\u000etest-module-id0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\u0006tester\u0000\u000etest-module-id0.23.0"
     - "{\"adapter\":\"mock1g6kht9c5s4jwn4akfjt3zmsfh4nvguewaegjeavpz3f0q9uylrqswspf09\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0"
     - "{\"account_base\":6}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0"
     - "{\"account_base\":5}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0"
     - "{\"native\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0"
     - "{\"native\":\"mock14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les6xzvf5\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0"
     - "{\"native\":\"mock1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcns7ctvz5\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0"
     - "{\"native\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0"
     - "{\"native\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0"
     - "{\"native\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}"
   - - "\u0000\u0004accs\u0000\u0005local\u0000\u0000\u0000\u0000"
     - "{\"manager\":\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\",\"proxy\":\"mock1xsemjm2xzx8nfaj50rt2dn04g24yarrr3mf6uwhqtc4ampff9nsqrc867x\"}"
@@ -137,15 +137,15 @@ expression: all_storage
   - - cfg
     - "{\"account_factory_address\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"security_disabled\":true,\"namespace_registration_fee\":null}"
   - - contract_info
-    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "tester:test-module-id":
   - - base_state
     - "{\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"},\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}}"
   - - contract_info
-    - "{\"contract\":\"tester:test-module-id\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"tester:test-module-id\",\"version\":\"0.23.0\"}"
   - - ibc_callback_received
     - "false"
   - - module_data
-    - "{\"module\":\"tester:test-module-id\",\"version\":\"0.23.0-beta.0\",\"dependencies\":[],\"metadata\":\"test_metadata\"}"
+    - "{\"module\":\"tester:test-module-id\",\"version\":\"0.23.0\",\"dependencies\":[],\"metadata\":\"test_metadata\"}"

--- a/framework/contracts/account/manager/tests/snapshots/proxy__exec_through_manager.snap
+++ b/framework/contracts/account/manager/tests/snapshots/proxy__exec_through_manager.snap
@@ -8,14 +8,14 @@ expression: all_storage
   - - cfg
     - "{\"version_control_contract\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_contract\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\",\"module_factory_address\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ans-host":
   - - config
     - "{\"next_unique_pool_id\":1}"
   - - contract_info
-    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
   - - registered_dexes
@@ -24,16 +24,16 @@ expression: all_storage
   - - config
     - "{\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"},\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0\"}"
   - - module_data
-    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\",\"dependencies\":[],\"metadata\":null}"
+    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0\",\"dependencies\":[],\"metadata\":null}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ibc-host":
   - - cfg
     - "{\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"},\"account_factory\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:manager-local-0":
@@ -48,7 +48,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - info
     - "{\"name\":\"Default Abstract Account\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":null,\"link\":null}"
   - - ownership
@@ -65,7 +65,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - info
     - "{\"name\":\"Default Abstract Account\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":null,\"link\":null}"
   - - ownership
@@ -74,7 +74,7 @@ expression: all_storage
   - - "\u0000{5}config"
     - "{\"version_control_address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:proxy-local-0":
@@ -87,7 +87,7 @@ expression: all_storage
   - - admin
     - "\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:proxy-local-1":
   - - "\u0000{5}state"
     - "{\"modules\":[\"mock1ps47cz26ugmzp2emuqap8jmvjrkwyzgh4uupechr9et6w0a3ar6sv5ag3c\"]}"
@@ -98,23 +98,23 @@ expression: all_storage
   - - admin
     - "\"mock1ps47cz26ugmzp2emuqap8jmvjrkwyzgh4uupechr9et6w0a3ar6sv5ag3c\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:version-control":
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0"
     - "{\"account_base\":6}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0"
     - "{\"account_base\":5}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0"
     - "{\"native\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0"
     - "{\"native\":\"mock14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les6xzvf5\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0"
     - "{\"native\":\"mock1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcns7ctvz5\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0"
     - "{\"native\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0"
     - "{\"native\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0"
     - "{\"native\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}"
   - - "\u0000\u0004accs\u0000\u0005local\u0000\u0000\u0000\u0000"
     - "{\"manager\":\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\",\"proxy\":\"mock1xsemjm2xzx8nfaj50rt2dn04g24yarrr3mf6uwhqtc4ampff9nsqrc867x\"}"
@@ -127,6 +127,6 @@ expression: all_storage
   - - cfg
     - "{\"account_factory_address\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"security_disabled\":true,\"namespace_registration_fee\":null}"
   - - contract_info
-    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"

--- a/framework/contracts/account/manager/tests/snapshots/proxy__instantiate_proxy.snap
+++ b/framework/contracts/account/manager/tests/snapshots/proxy__instantiate_proxy.snap
@@ -8,14 +8,14 @@ expression: all_storage
   - - cfg
     - "{\"version_control_contract\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_contract\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\",\"module_factory_address\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ans-host":
   - - config
     - "{\"next_unique_pool_id\":1}"
   - - contract_info
-    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
   - - registered_dexes
@@ -24,16 +24,16 @@ expression: all_storage
   - - config
     - "{\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"},\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0\"}"
   - - module_data
-    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\",\"dependencies\":[],\"metadata\":null}"
+    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0\",\"dependencies\":[],\"metadata\":null}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ibc-host":
   - - cfg
     - "{\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"},\"account_factory\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:manager-local-0":
@@ -48,7 +48,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - info
     - "{\"name\":\"Default Abstract Account\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":null,\"link\":null}"
   - - ownership
@@ -65,7 +65,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - info
     - "{\"name\":\"Default Abstract Account\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":null,\"link\":null}"
   - - ownership
@@ -74,7 +74,7 @@ expression: all_storage
   - - "\u0000{5}config"
     - "{\"version_control_address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:proxy-local-0":
@@ -87,7 +87,7 @@ expression: all_storage
   - - admin
     - "\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:proxy-local-1":
   - - "\u0000{5}state"
     - "{\"modules\":[\"mock1ps47cz26ugmzp2emuqap8jmvjrkwyzgh4uupechr9et6w0a3ar6sv5ag3c\"]}"
@@ -98,23 +98,23 @@ expression: all_storage
   - - admin
     - "\"mock1ps47cz26ugmzp2emuqap8jmvjrkwyzgh4uupechr9et6w0a3ar6sv5ag3c\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:version-control":
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0"
     - "{\"account_base\":6}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0"
     - "{\"account_base\":5}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0"
     - "{\"native\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0"
     - "{\"native\":\"mock14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les6xzvf5\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0"
     - "{\"native\":\"mock1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcns7ctvz5\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0"
     - "{\"native\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0"
     - "{\"native\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0"
     - "{\"native\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}"
   - - "\u0000\u0004accs\u0000\u0005local\u0000\u0000\u0000\u0000"
     - "{\"manager\":\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\",\"proxy\":\"mock1xsemjm2xzx8nfaj50rt2dn04g24yarrr3mf6uwhqtc4ampff9nsqrc867x\"}"
@@ -127,6 +127,6 @@ expression: all_storage
   - - cfg
     - "{\"account_factory_address\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"security_disabled\":true,\"namespace_registration_fee\":null}"
   - - contract_info
-    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"

--- a/framework/contracts/account/manager/tests/snapshots/proxy__proxy_install_multiple_modules.snap
+++ b/framework/contracts/account/manager/tests/snapshots/proxy__proxy_install_multiple_modules.snap
@@ -8,14 +8,14 @@ expression: all_storage
   - - cfg
     - "{\"version_control_contract\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_contract\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\",\"module_factory_address\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ans-host":
   - - config
     - "{\"next_unique_pool_id\":1}"
   - - contract_info
-    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
   - - registered_dexes
@@ -24,16 +24,16 @@ expression: all_storage
   - - config
     - "{\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"},\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0\"}"
   - - module_data
-    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\",\"dependencies\":[],\"metadata\":null}"
+    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0\",\"dependencies\":[],\"metadata\":null}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ibc-host":
   - - cfg
     - "{\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"},\"account_factory\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:manager-local-0":
@@ -52,7 +52,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - icontext
     - "[[{\"info\":{\"namespace\":\"abstract\",\"name\":\"standalone1\",\"version\":{\"version\":\"1.0.0\"}},\"reference\":{\"standalone\":9}},\"mock140yszardgjx5keqq59krnuwt2h7sxzpwdzevm0v904gws2rp562sejmztn\"],[{\"info\":{\"namespace\":\"abstract\",\"name\":\"standalone2\",\"version\":{\"version\":\"1.0.0\"}},\"reference\":{\"standalone\":10}},\"mock169wfeuug4rpczvhzkayh53apewph6n5fkuf5j597n9a43krex9sq8mkset\"]]"
   - - info
@@ -63,7 +63,7 @@ expression: all_storage
   - - "\u0000{5}config"
     - "{\"version_control_address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0\"}"
   - - cur_manager
     - "{\"manager\":\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\",\"proxy\":\"mock1xsemjm2xzx8nfaj50rt2dn04g24yarrr3mf6uwhqtc4ampff9nsqrc867x\"}"
   - - ownership
@@ -78,31 +78,31 @@ expression: all_storage
   - - admin
     - "\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:version-control":
   - - "\u0000\u0003cfg\u0000\babstract\u0000\u000bstandalone11.0.0"
     - "{\"monetization\":{\"install_fee\":{\"fee\":{\"denom\":\"token1\",\"amount\":\"42\"}}},\"metadata\":null,\"instantiation_funds\":[]}"
   - - "\u0000\u0003cfg\u0000\babstract\u0000\u000bstandalone21.0.0"
     - "{\"monetization\":\"none\",\"metadata\":null,\"instantiation_funds\":[{\"denom\":\"token1\",\"amount\":\"42\"},{\"denom\":\"token2\",\"amount\":\"500\"}]}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0"
     - "{\"account_base\":6}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0"
     - "{\"account_base\":5}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0"
     - "{\"native\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0"
     - "{\"native\":\"mock14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les6xzvf5\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0"
     - "{\"native\":\"mock1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcns7ctvz5\"}"
   - - "\u0000\u0003lib\u0000\babstract\u0000\u000bstandalone11.0.0"
     - "{\"standalone\":9}"
   - - "\u0000\u0003lib\u0000\babstract\u0000\u000bstandalone21.0.0"
     - "{\"standalone\":10}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0"
     - "{\"native\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0"
     - "{\"native\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0"
     - "{\"native\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}"
   - - "\u0000\u0004accs\u0000\u0005local\u0000\u0000\u0000\u0000"
     - "{\"manager\":\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\",\"proxy\":\"mock1xsemjm2xzx8nfaj50rt2dn04g24yarrr3mf6uwhqtc4ampff9nsqrc867x\"}"
@@ -117,6 +117,6 @@ expression: all_storage
   - - cfg
     - "{\"account_factory_address\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"security_disabled\":true,\"namespace_registration_fee\":null}"
   - - contract_info
-    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"

--- a/framework/contracts/account/manager/tests/snapshots/proxy__proxy_install_standalone_modules.snap
+++ b/framework/contracts/account/manager/tests/snapshots/proxy__proxy_install_standalone_modules.snap
@@ -8,14 +8,14 @@ expression: all_storage
   - - cfg
     - "{\"version_control_contract\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_contract\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\",\"module_factory_address\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ans-host":
   - - config
     - "{\"next_unique_pool_id\":1}"
   - - contract_info
-    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
   - - registered_dexes
@@ -24,16 +24,16 @@ expression: all_storage
   - - config
     - "{\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"},\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0\"}"
   - - module_data
-    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\",\"dependencies\":[],\"metadata\":null}"
+    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0\",\"dependencies\":[],\"metadata\":null}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ibc-host":
   - - cfg
     - "{\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"},\"account_factory\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:manager-local-0":
@@ -52,7 +52,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - icontext
     - "[[{\"info\":{\"namespace\":\"abstract\",\"name\":\"standalone2\",\"version\":{\"version\":\"1.0.0\"}},\"reference\":{\"standalone\":10}},\"mock169wfeuug4rpczvhzkayh53apewph6n5fkuf5j597n9a43krex9sq8mkset\"]]"
   - - info
@@ -63,7 +63,7 @@ expression: all_storage
   - - "\u0000{5}config"
     - "{\"version_control_address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0\"}"
   - - cur_manager
     - "{\"manager\":\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\",\"proxy\":\"mock1xsemjm2xzx8nfaj50rt2dn04g24yarrr3mf6uwhqtc4ampff9nsqrc867x\"}"
   - - ownership
@@ -78,27 +78,27 @@ expression: all_storage
   - - admin
     - "\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:version-control":
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0"
     - "{\"account_base\":6}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0"
     - "{\"account_base\":5}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0"
     - "{\"native\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0"
     - "{\"native\":\"mock14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les6xzvf5\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0"
     - "{\"native\":\"mock1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcns7ctvz5\"}"
   - - "\u0000\u0003lib\u0000\babstract\u0000\u000bstandalone11.0.0"
     - "{\"standalone\":9}"
   - - "\u0000\u0003lib\u0000\babstract\u0000\u000bstandalone21.0.0"
     - "{\"standalone\":10}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0"
     - "{\"native\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0"
     - "{\"native\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0"
     - "{\"native\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}"
   - - "\u0000\u0004accs\u0000\u0005local\u0000\u0000\u0000\u0000"
     - "{\"manager\":\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\",\"proxy\":\"mock1xsemjm2xzx8nfaj50rt2dn04g24yarrr3mf6uwhqtc4ampff9nsqrc867x\"}"
@@ -113,6 +113,6 @@ expression: all_storage
   - - cfg
     - "{\"account_factory_address\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"security_disabled\":true,\"namespace_registration_fee\":null}"
   - - contract_info
-    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"

--- a/framework/contracts/account/manager/tests/snapshots/proxy__proxy_with_response_data.snap
+++ b/framework/contracts/account/manager/tests/snapshots/proxy__proxy_with_response_data.snap
@@ -8,14 +8,14 @@ expression: all_storage
   - - cfg
     - "{\"version_control_contract\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_contract\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\",\"module_factory_address\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ans-host":
   - - config
     - "{\"next_unique_pool_id\":1}"
   - - contract_info
-    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
   - - registered_dexes
@@ -24,16 +24,16 @@ expression: all_storage
   - - config
     - "{\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"},\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0\"}"
   - - module_data
-    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\",\"dependencies\":[],\"metadata\":null}"
+    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0\",\"dependencies\":[],\"metadata\":null}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ibc-host":
   - - cfg
     - "{\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"},\"account_factory\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:manager-local-0":
@@ -48,7 +48,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - info
     - "{\"name\":\"Default Abstract Account\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":null,\"link\":null}"
   - - ownership
@@ -67,9 +67,9 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - icontext
-    - "[[{\"info\":{\"namespace\":\"tester\",\"name\":\"test-module-id\",\"version\":{\"version\":\"0.23.0-beta.0\"}},\"reference\":{\"adapter\":\"mock1g6kht9c5s4jwn4akfjt3zmsfh4nvguewaegjeavpz3f0q9uylrqswspf09\"}},null]]"
+    - "[[{\"info\":{\"namespace\":\"tester\",\"name\":\"test-module-id\",\"version\":{\"version\":\"0.23.0\"}},\"reference\":{\"adapter\":\"mock1g6kht9c5s4jwn4akfjt3zmsfh4nvguewaegjeavpz3f0q9uylrqswspf09\"}},null]]"
   - - info
     - "{\"name\":\"Default Abstract Account\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":null,\"link\":null}"
   - - ownership
@@ -78,7 +78,7 @@ expression: all_storage
   - - "\u0000{5}config"
     - "{\"version_control_address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:proxy-local-0":
@@ -91,7 +91,7 @@ expression: all_storage
   - - admin
     - "\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:proxy-local-1":
   - - "\u0000{5}state"
     - "{\"modules\":[\"mock1ps47cz26ugmzp2emuqap8jmvjrkwyzgh4uupechr9et6w0a3ar6sv5ag3c\",\"mock1g6kht9c5s4jwn4akfjt3zmsfh4nvguewaegjeavpz3f0q9uylrqswspf09\"]}"
@@ -102,25 +102,25 @@ expression: all_storage
   - - admin
     - "\"mock1ps47cz26ugmzp2emuqap8jmvjrkwyzgh4uupechr9et6w0a3ar6sv5ag3c\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:version-control":
-  - - "\u0000\u0003lib\u0000\u0006tester\u0000\u000etest-module-id0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\u0006tester\u0000\u000etest-module-id0.23.0"
     - "{\"adapter\":\"mock1g6kht9c5s4jwn4akfjt3zmsfh4nvguewaegjeavpz3f0q9uylrqswspf09\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0"
     - "{\"account_base\":6}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0"
     - "{\"account_base\":5}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0"
     - "{\"native\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0"
     - "{\"native\":\"mock14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les6xzvf5\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0"
     - "{\"native\":\"mock1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcns7ctvz5\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0"
     - "{\"native\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0"
     - "{\"native\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0"
     - "{\"native\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}"
   - - "\u0000\u0004accs\u0000\u0005local\u0000\u0000\u0000\u0000"
     - "{\"manager\":\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\",\"proxy\":\"mock1xsemjm2xzx8nfaj50rt2dn04g24yarrr3mf6uwhqtc4ampff9nsqrc867x\"}"
@@ -137,7 +137,7 @@ expression: all_storage
   - - cfg
     - "{\"account_factory_address\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"security_disabled\":true,\"namespace_registration_fee\":null}"
   - - contract_info
-    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "tester:test-module-id":
@@ -146,8 +146,8 @@ expression: all_storage
   - - base_state
     - "{\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"},\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}}"
   - - contract_info
-    - "{\"contract\":\"tester:test-module-id\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"tester:test-module-id\",\"version\":\"0.23.0\"}"
   - - ibc_callback_received
     - "false"
   - - module_data
-    - "{\"module\":\"tester:test-module-id\",\"version\":\"0.23.0-beta.0\",\"dependencies\":[],\"metadata\":\"test_metadata\"}"
+    - "{\"module\":\"tester:test-module-id\",\"version\":\"0.23.0\",\"dependencies\":[],\"metadata\":\"test_metadata\"}"

--- a/framework/contracts/account/manager/tests/snapshots/subaccount__account_move_ownership_to_falsy_sub_account.snap
+++ b/framework/contracts/account/manager/tests/snapshots/subaccount__account_move_ownership_to_falsy_sub_account.snap
@@ -8,14 +8,14 @@ expression: all_storage
   - - cfg
     - "{\"version_control_contract\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_contract\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\",\"module_factory_address\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ans-host":
   - - config
     - "{\"next_unique_pool_id\":1}"
   - - contract_info
-    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
   - - registered_dexes
@@ -24,16 +24,16 @@ expression: all_storage
   - - config
     - "{\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"},\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0\"}"
   - - module_data
-    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\",\"dependencies\":[],\"metadata\":null}"
+    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0\",\"dependencies\":[],\"metadata\":null}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ibc-host":
   - - cfg
     - "{\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"},\"account_factory\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:manager-local-0":
@@ -48,7 +48,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - info
     - "{\"name\":\"Default Abstract Account\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":null,\"link\":null}"
   - - ownership
@@ -67,7 +67,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - info
     - "{\"name\":\"Default Abstract Account\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":null,\"link\":null}"
   - - ownership
@@ -84,7 +84,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - info
     - "{\"name\":\"My subaccount\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":null,\"link\":null}"
   - - ownership
@@ -101,7 +101,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - info
     - "{\"name\":\"Default Abstract Account\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":null,\"link\":null}"
   - - ownership
@@ -110,7 +110,7 @@ expression: all_storage
   - - "\u0000{5}config"
     - "{\"version_control_address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:proxy-local-0":
@@ -123,7 +123,7 @@ expression: all_storage
   - - admin
     - "\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:proxy-local-1":
   - - "\u0000{5}state"
     - "{\"modules\":[\"mock1ps47cz26ugmzp2emuqap8jmvjrkwyzgh4uupechr9et6w0a3ar6sv5ag3c\"]}"
@@ -134,7 +134,7 @@ expression: all_storage
   - - admin
     - "\"mock1ps47cz26ugmzp2emuqap8jmvjrkwyzgh4uupechr9et6w0a3ar6sv5ag3c\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:proxy-local-2":
   - - "\u0000{5}state"
     - "{\"modules\":[\"mock13cahl7h567qy5pal82h4qztgg6yp0dum7h0rx26lkvyednndhh8qcfqqvj\"]}"
@@ -145,7 +145,7 @@ expression: all_storage
   - - admin
     - "\"mock13cahl7h567qy5pal82h4qztgg6yp0dum7h0rx26lkvyednndhh8qcfqqvj\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:proxy-local-3":
   - - "\u0000{5}state"
     - "{\"modules\":[\"mock19yh6uk2hsnsglg6fyuwv29p7g0s30a70vl9aj5sc90fda9xu4dgsmq42x3\"]}"
@@ -156,23 +156,23 @@ expression: all_storage
   - - admin
     - "\"mock19yh6uk2hsnsglg6fyuwv29p7g0s30a70vl9aj5sc90fda9xu4dgsmq42x3\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:version-control":
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0"
     - "{\"account_base\":6}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0"
     - "{\"account_base\":5}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0"
     - "{\"native\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0"
     - "{\"native\":\"mock14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les6xzvf5\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0"
     - "{\"native\":\"mock1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcns7ctvz5\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0"
     - "{\"native\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0"
     - "{\"native\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0"
     - "{\"native\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}"
   - - "\u0000\u0004accs\u0000\u0005local\u0000\u0000\u0000\u0000"
     - "{\"manager\":\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\",\"proxy\":\"mock1xsemjm2xzx8nfaj50rt2dn04g24yarrr3mf6uwhqtc4ampff9nsqrc867x\"}"
@@ -189,6 +189,6 @@ expression: all_storage
   - - cfg
     - "{\"account_factory_address\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"security_disabled\":true,\"namespace_registration_fee\":null}"
   - - contract_info
-    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"

--- a/framework/contracts/account/manager/tests/snapshots/subaccount__creating_on_subaccount_should_succeed.snap
+++ b/framework/contracts/account/manager/tests/snapshots/subaccount__creating_on_subaccount_should_succeed.snap
@@ -8,14 +8,14 @@ expression: all_storage
   - - cfg
     - "{\"version_control_contract\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_contract\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\",\"module_factory_address\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ans-host":
   - - config
     - "{\"next_unique_pool_id\":1}"
   - - contract_info
-    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
   - - registered_dexes
@@ -24,16 +24,16 @@ expression: all_storage
   - - config
     - "{\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"},\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0\"}"
   - - module_data
-    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\",\"dependencies\":[],\"metadata\":null}"
+    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0\",\"dependencies\":[],\"metadata\":null}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ibc-host":
   - - cfg
     - "{\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"},\"account_factory\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:manager-local-0":
@@ -48,7 +48,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - info
     - "{\"name\":\"Default Abstract Account\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":null,\"link\":null}"
   - - ownership
@@ -67,7 +67,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - info
     - "{\"name\":\"Default Abstract Account\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":null,\"link\":null}"
   - - ownership
@@ -76,7 +76,7 @@ expression: all_storage
   - - "\u0000{5}config"
     - "{\"version_control_address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:proxy-local-0":
@@ -89,7 +89,7 @@ expression: all_storage
   - - admin
     - "\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:proxy-local-1":
   - - "\u0000{5}state"
     - "{\"modules\":[\"mock1ps47cz26ugmzp2emuqap8jmvjrkwyzgh4uupechr9et6w0a3ar6sv5ag3c\"]}"
@@ -100,23 +100,23 @@ expression: all_storage
   - - admin
     - "\"mock1ps47cz26ugmzp2emuqap8jmvjrkwyzgh4uupechr9et6w0a3ar6sv5ag3c\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:version-control":
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0"
     - "{\"account_base\":6}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0"
     - "{\"account_base\":5}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0"
     - "{\"native\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0"
     - "{\"native\":\"mock14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les6xzvf5\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0"
     - "{\"native\":\"mock1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcns7ctvz5\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0"
     - "{\"native\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0"
     - "{\"native\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0"
     - "{\"native\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}"
   - - "\u0000\u0004accs\u0000\u0005local\u0000\u0000\u0000\u0000"
     - "{\"manager\":\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\",\"proxy\":\"mock1xsemjm2xzx8nfaj50rt2dn04g24yarrr3mf6uwhqtc4ampff9nsqrc867x\"}"
@@ -131,6 +131,6 @@ expression: all_storage
   - - cfg
     - "{\"account_factory_address\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"security_disabled\":true,\"namespace_registration_fee\":null}"
   - - contract_info
-    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"

--- a/framework/contracts/account/manager/tests/snapshots/subaccount__installed_app_updating_on_subaccount_should_succeed.snap
+++ b/framework/contracts/account/manager/tests/snapshots/subaccount__installed_app_updating_on_subaccount_should_succeed.snap
@@ -8,14 +8,14 @@ expression: all_storage
   - - cfg
     - "{\"version_control_contract\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_contract\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\",\"module_factory_address\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ans-host":
   - - config
     - "{\"next_unique_pool_id\":1}"
   - - contract_info
-    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
   - - registered_dexes
@@ -24,16 +24,16 @@ expression: all_storage
   - - config
     - "{\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"},\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0\"}"
   - - module_data
-    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\",\"dependencies\":[],\"metadata\":null}"
+    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0\",\"dependencies\":[],\"metadata\":null}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ibc-host":
   - - cfg
     - "{\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"},\"account_factory\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:manager-local-0":
@@ -48,7 +48,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - info
     - "{\"name\":\"Default Abstract Account\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":null,\"link\":null}"
   - - ownership
@@ -67,7 +67,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - info
     - "{\"name\":\"Default Abstract Account\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":null,\"link\":null}"
   - - ownership
@@ -84,7 +84,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - info
     - "{\"name\":\"My subaccount\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":\"new desc\",\"link\":null}"
   - - ownership
@@ -93,7 +93,7 @@ expression: all_storage
   - - "\u0000{5}config"
     - "{\"version_control_address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:proxy-local-0":
@@ -106,7 +106,7 @@ expression: all_storage
   - - admin
     - "\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:proxy-local-1":
   - - "\u0000{5}state"
     - "{\"modules\":[\"mock1ps47cz26ugmzp2emuqap8jmvjrkwyzgh4uupechr9et6w0a3ar6sv5ag3c\",\"mock15cnh8a268g6dhlzc4cay9mq7w8vt24hmknafxpngvmev4t7dj0jq607wev\"]}"
@@ -117,7 +117,7 @@ expression: all_storage
   - - admin
     - "\"mock1ps47cz26ugmzp2emuqap8jmvjrkwyzgh4uupechr9et6w0a3ar6sv5ag3c\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:proxy-local-2":
   - - "\u0000{5}state"
     - "{\"modules\":[\"mock13cahl7h567qy5pal82h4qztgg6yp0dum7h0rx26lkvyednndhh8qcfqqvj\"]}"
@@ -128,23 +128,23 @@ expression: all_storage
   - - admin
     - "\"mock13cahl7h567qy5pal82h4qztgg6yp0dum7h0rx26lkvyednndhh8qcfqqvj\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:version-control":
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0"
     - "{\"account_base\":6}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0"
     - "{\"account_base\":5}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0"
     - "{\"native\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0"
     - "{\"native\":\"mock14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les6xzvf5\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0"
     - "{\"native\":\"mock1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcns7ctvz5\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0"
     - "{\"native\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0"
     - "{\"native\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0"
     - "{\"native\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}"
   - - "\u0000\u0004accs\u0000\u0005local\u0000\u0000\u0000\u0000"
     - "{\"manager\":\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\",\"proxy\":\"mock1xsemjm2xzx8nfaj50rt2dn04g24yarrr3mf6uwhqtc4ampff9nsqrc867x\"}"
@@ -159,6 +159,6 @@ expression: all_storage
   - - cfg
     - "{\"account_factory_address\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"security_disabled\":true,\"namespace_registration_fee\":null}"
   - - contract_info
-    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"

--- a/framework/contracts/account/manager/tests/snapshots/subaccount__proxy_updating_on_subaccount_should_succeed.snap
+++ b/framework/contracts/account/manager/tests/snapshots/subaccount__proxy_updating_on_subaccount_should_succeed.snap
@@ -8,14 +8,14 @@ expression: all_storage
   - - cfg
     - "{\"version_control_contract\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_contract\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\",\"module_factory_address\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ans-host":
   - - config
     - "{\"next_unique_pool_id\":1}"
   - - contract_info
-    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
   - - registered_dexes
@@ -24,16 +24,16 @@ expression: all_storage
   - - config
     - "{\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"},\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0\"}"
   - - module_data
-    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\",\"dependencies\":[],\"metadata\":null}"
+    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0\",\"dependencies\":[],\"metadata\":null}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ibc-host":
   - - cfg
     - "{\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"},\"account_factory\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:manager-local-0":
@@ -48,7 +48,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - info
     - "{\"name\":\"Default Abstract Account\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":null,\"link\":null}"
   - - ownership
@@ -67,7 +67,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - info
     - "{\"name\":\"Default Abstract Account\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":null,\"link\":null}"
   - - ownership
@@ -84,7 +84,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - info
     - "{\"name\":\"My subaccount\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":\"new desc\",\"link\":null}"
   - - ownership
@@ -93,7 +93,7 @@ expression: all_storage
   - - "\u0000{5}config"
     - "{\"version_control_address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:proxy-local-0":
@@ -106,7 +106,7 @@ expression: all_storage
   - - admin
     - "\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:proxy-local-1":
   - - "\u0000{5}state"
     - "{\"modules\":[\"mock1ps47cz26ugmzp2emuqap8jmvjrkwyzgh4uupechr9et6w0a3ar6sv5ag3c\"]}"
@@ -117,7 +117,7 @@ expression: all_storage
   - - admin
     - "\"mock1ps47cz26ugmzp2emuqap8jmvjrkwyzgh4uupechr9et6w0a3ar6sv5ag3c\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:proxy-local-2":
   - - "\u0000{5}state"
     - "{\"modules\":[\"mock13cahl7h567qy5pal82h4qztgg6yp0dum7h0rx26lkvyednndhh8qcfqqvj\"]}"
@@ -128,23 +128,23 @@ expression: all_storage
   - - admin
     - "\"mock13cahl7h567qy5pal82h4qztgg6yp0dum7h0rx26lkvyednndhh8qcfqqvj\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:version-control":
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0"
     - "{\"account_base\":6}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0"
     - "{\"account_base\":5}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0"
     - "{\"native\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0"
     - "{\"native\":\"mock14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les6xzvf5\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0"
     - "{\"native\":\"mock1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcns7ctvz5\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0"
     - "{\"native\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0"
     - "{\"native\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0"
     - "{\"native\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}"
   - - "\u0000\u0004accs\u0000\u0005local\u0000\u0000\u0000\u0000"
     - "{\"manager\":\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\",\"proxy\":\"mock1xsemjm2xzx8nfaj50rt2dn04g24yarrr3mf6uwhqtc4ampff9nsqrc867x\"}"
@@ -159,6 +159,6 @@ expression: all_storage
   - - cfg
     - "{\"account_factory_address\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"security_disabled\":true,\"namespace_registration_fee\":null}"
   - - contract_info
-    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"

--- a/framework/contracts/account/manager/tests/snapshots/subaccount__recursive_updating_on_subaccount_should_succeed.snap
+++ b/framework/contracts/account/manager/tests/snapshots/subaccount__recursive_updating_on_subaccount_should_succeed.snap
@@ -8,14 +8,14 @@ expression: all_storage
   - - cfg
     - "{\"version_control_contract\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_contract\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\",\"module_factory_address\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ans-host":
   - - config
     - "{\"next_unique_pool_id\":1}"
   - - contract_info
-    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
   - - registered_dexes
@@ -24,16 +24,16 @@ expression: all_storage
   - - config
     - "{\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"},\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0\"}"
   - - module_data
-    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\",\"dependencies\":[],\"metadata\":null}"
+    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0\",\"dependencies\":[],\"metadata\":null}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ibc-host":
   - - cfg
     - "{\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"},\"account_factory\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:manager-local-0":
@@ -48,7 +48,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - info
     - "{\"name\":\"Default Abstract Account\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":null,\"link\":null}"
   - - ownership
@@ -67,7 +67,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - info
     - "{\"name\":\"Default Abstract Account\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":null,\"link\":null}"
   - - ownership
@@ -86,7 +86,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - info
     - "{\"name\":\"My subaccount\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":null,\"link\":null}"
   - - ownership
@@ -103,7 +103,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - info
     - "{\"name\":\"My subsubaccount\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":\"new desc\",\"link\":null}"
   - - ownership
@@ -112,7 +112,7 @@ expression: all_storage
   - - "\u0000{5}config"
     - "{\"version_control_address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:proxy-local-0":
@@ -125,7 +125,7 @@ expression: all_storage
   - - admin
     - "\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:proxy-local-1":
   - - "\u0000{5}state"
     - "{\"modules\":[\"mock1ps47cz26ugmzp2emuqap8jmvjrkwyzgh4uupechr9et6w0a3ar6sv5ag3c\"]}"
@@ -136,7 +136,7 @@ expression: all_storage
   - - admin
     - "\"mock1ps47cz26ugmzp2emuqap8jmvjrkwyzgh4uupechr9et6w0a3ar6sv5ag3c\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:proxy-local-2":
   - - "\u0000{5}state"
     - "{\"modules\":[\"mock13cahl7h567qy5pal82h4qztgg6yp0dum7h0rx26lkvyednndhh8qcfqqvj\"]}"
@@ -147,7 +147,7 @@ expression: all_storage
   - - admin
     - "\"mock13cahl7h567qy5pal82h4qztgg6yp0dum7h0rx26lkvyednndhh8qcfqqvj\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:proxy-local-3":
   - - "\u0000{5}state"
     - "{\"modules\":[\"mock19yh6uk2hsnsglg6fyuwv29p7g0s30a70vl9aj5sc90fda9xu4dgsmq42x3\"]}"
@@ -158,23 +158,23 @@ expression: all_storage
   - - admin
     - "\"mock19yh6uk2hsnsglg6fyuwv29p7g0s30a70vl9aj5sc90fda9xu4dgsmq42x3\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:version-control":
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0"
     - "{\"account_base\":6}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0"
     - "{\"account_base\":5}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0"
     - "{\"native\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0"
     - "{\"native\":\"mock14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les6xzvf5\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0"
     - "{\"native\":\"mock1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcns7ctvz5\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0"
     - "{\"native\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0"
     - "{\"native\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0"
     - "{\"native\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}"
   - - "\u0000\u0004accs\u0000\u0005local\u0000\u0000\u0000\u0000"
     - "{\"manager\":\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\",\"proxy\":\"mock1xsemjm2xzx8nfaj50rt2dn04g24yarrr3mf6uwhqtc4ampff9nsqrc867x\"}"
@@ -191,6 +191,6 @@ expression: all_storage
   - - cfg
     - "{\"account_factory_address\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"security_disabled\":true,\"namespace_registration_fee\":null}"
   - - contract_info
-    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"

--- a/framework/contracts/account/manager/tests/snapshots/subaccount__sub_account_move_ownership.snap
+++ b/framework/contracts/account/manager/tests/snapshots/subaccount__sub_account_move_ownership.snap
@@ -8,14 +8,14 @@ expression: all_storage
   - - cfg
     - "{\"version_control_contract\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_contract\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\",\"module_factory_address\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ans-host":
   - - config
     - "{\"next_unique_pool_id\":1}"
   - - contract_info
-    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
   - - registered_dexes
@@ -24,16 +24,16 @@ expression: all_storage
   - - config
     - "{\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"},\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0\"}"
   - - module_data
-    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\",\"dependencies\":[],\"metadata\":null}"
+    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0\",\"dependencies\":[],\"metadata\":null}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ibc-host":
   - - cfg
     - "{\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"},\"account_factory\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:manager-local-0":
@@ -48,7 +48,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - info
     - "{\"name\":\"Default Abstract Account\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":null,\"link\":null}"
   - - ownership
@@ -65,7 +65,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - info
     - "{\"name\":\"Default Abstract Account\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":null,\"link\":null}"
   - - ownership
@@ -82,7 +82,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - info
     - "{\"name\":\"My subaccount\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":null,\"link\":null}"
   - - ownership
@@ -91,7 +91,7 @@ expression: all_storage
   - - "\u0000{5}config"
     - "{\"version_control_address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:proxy-local-0":
@@ -104,7 +104,7 @@ expression: all_storage
   - - admin
     - "\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:proxy-local-1":
   - - "\u0000{5}state"
     - "{\"modules\":[\"mock1ps47cz26ugmzp2emuqap8jmvjrkwyzgh4uupechr9et6w0a3ar6sv5ag3c\"]}"
@@ -115,7 +115,7 @@ expression: all_storage
   - - admin
     - "\"mock1ps47cz26ugmzp2emuqap8jmvjrkwyzgh4uupechr9et6w0a3ar6sv5ag3c\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:proxy-local-2":
   - - "\u0000{5}state"
     - "{\"modules\":[\"mock13cahl7h567qy5pal82h4qztgg6yp0dum7h0rx26lkvyednndhh8qcfqqvj\"]}"
@@ -126,23 +126,23 @@ expression: all_storage
   - - admin
     - "\"mock13cahl7h567qy5pal82h4qztgg6yp0dum7h0rx26lkvyednndhh8qcfqqvj\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:version-control":
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0"
     - "{\"account_base\":6}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0"
     - "{\"account_base\":5}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0"
     - "{\"native\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0"
     - "{\"native\":\"mock14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les6xzvf5\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0"
     - "{\"native\":\"mock1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcns7ctvz5\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0"
     - "{\"native\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0"
     - "{\"native\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0"
     - "{\"native\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}"
   - - "\u0000\u0004accs\u0000\u0005local\u0000\u0000\u0000\u0000"
     - "{\"manager\":\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\",\"proxy\":\"mock1xsemjm2xzx8nfaj50rt2dn04g24yarrr3mf6uwhqtc4ampff9nsqrc867x\"}"
@@ -157,6 +157,6 @@ expression: all_storage
   - - cfg
     - "{\"account_factory_address\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"security_disabled\":true,\"namespace_registration_fee\":null}"
   - - contract_info
-    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"

--- a/framework/contracts/account/manager/tests/snapshots/subaccount__sub_account_move_ownership_to_sub_account.snap
+++ b/framework/contracts/account/manager/tests/snapshots/subaccount__sub_account_move_ownership_to_sub_account.snap
@@ -8,14 +8,14 @@ expression: all_storage
   - - cfg
     - "{\"version_control_contract\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_contract\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\",\"module_factory_address\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ans-host":
   - - config
     - "{\"next_unique_pool_id\":1}"
   - - contract_info
-    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
   - - registered_dexes
@@ -24,16 +24,16 @@ expression: all_storage
   - - config
     - "{\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"},\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0\"}"
   - - module_data
-    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\",\"dependencies\":[],\"metadata\":null}"
+    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0\",\"dependencies\":[],\"metadata\":null}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ibc-host":
   - - cfg
     - "{\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"},\"account_factory\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:manager-local-0":
@@ -48,7 +48,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - info
     - "{\"name\":\"Default Abstract Account\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":null,\"link\":null}"
   - - ownership
@@ -67,7 +67,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - info
     - "{\"name\":\"Default Abstract Account\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":null,\"link\":null}"
   - - ownership
@@ -86,7 +86,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - info
     - "{\"name\":\"My subaccount\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":null,\"link\":null}"
   - - ownership
@@ -103,7 +103,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - info
     - "{\"name\":\"Default Abstract Account\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":null,\"link\":null}"
   - - ownership
@@ -120,7 +120,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - info
     - "{\"name\":\"My second subaccount\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":null,\"link\":null}"
   - - ownership
@@ -129,7 +129,7 @@ expression: all_storage
   - - "\u0000{5}config"
     - "{\"version_control_address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:proxy-local-0":
@@ -142,7 +142,7 @@ expression: all_storage
   - - admin
     - "\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:proxy-local-1":
   - - "\u0000{5}state"
     - "{\"modules\":[\"mock1ps47cz26ugmzp2emuqap8jmvjrkwyzgh4uupechr9et6w0a3ar6sv5ag3c\"]}"
@@ -153,7 +153,7 @@ expression: all_storage
   - - admin
     - "\"mock1ps47cz26ugmzp2emuqap8jmvjrkwyzgh4uupechr9et6w0a3ar6sv5ag3c\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:proxy-local-2":
   - - "\u0000{5}state"
     - "{\"modules\":[\"mock13cahl7h567qy5pal82h4qztgg6yp0dum7h0rx26lkvyednndhh8qcfqqvj\",\"mock1ss2rtya5wf7xft2ktc3gqt5e9c9k9menzr57a37d47e0aq0nckkq3e6zkm\"]}"
@@ -164,7 +164,7 @@ expression: all_storage
   - - admin
     - "\"mock13cahl7h567qy5pal82h4qztgg6yp0dum7h0rx26lkvyednndhh8qcfqqvj\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:proxy-local-3":
   - - "\u0000{5}state"
     - "{\"modules\":[\"mock19yh6uk2hsnsglg6fyuwv29p7g0s30a70vl9aj5sc90fda9xu4dgsmq42x3\"]}"
@@ -175,7 +175,7 @@ expression: all_storage
   - - admin
     - "\"mock19yh6uk2hsnsglg6fyuwv29p7g0s30a70vl9aj5sc90fda9xu4dgsmq42x3\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:proxy-local-4":
   - - "\u0000{5}state"
     - "{\"modules\":[\"mock1pk8hn9cmnerpyf3e83spka86ywjq8582f8ut7xcpjks67zayh5vs9rntga\"]}"
@@ -186,23 +186,23 @@ expression: all_storage
   - - admin
     - "\"mock1pk8hn9cmnerpyf3e83spka86ywjq8582f8ut7xcpjks67zayh5vs9rntga\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:version-control":
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0"
     - "{\"account_base\":6}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0"
     - "{\"account_base\":5}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0"
     - "{\"native\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0"
     - "{\"native\":\"mock14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les6xzvf5\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0"
     - "{\"native\":\"mock1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcns7ctvz5\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0"
     - "{\"native\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0"
     - "{\"native\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0"
     - "{\"native\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}"
   - - "\u0000\u0004accs\u0000\u0005local\u0000\u0000\u0000\u0000"
     - "{\"manager\":\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\",\"proxy\":\"mock1xsemjm2xzx8nfaj50rt2dn04g24yarrr3mf6uwhqtc4ampff9nsqrc867x\"}"
@@ -221,6 +221,6 @@ expression: all_storage
   - - cfg
     - "{\"account_factory_address\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"security_disabled\":true,\"namespace_registration_fee\":null}"
   - - contract_info
-    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"

--- a/framework/contracts/account/manager/tests/snapshots/subaccount__updating_on_subaccount_should_succeed.snap
+++ b/framework/contracts/account/manager/tests/snapshots/subaccount__updating_on_subaccount_should_succeed.snap
@@ -8,14 +8,14 @@ expression: all_storage
   - - cfg
     - "{\"version_control_contract\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_contract\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\",\"module_factory_address\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:account-factory\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ans-host":
   - - config
     - "{\"next_unique_pool_id\":1}"
   - - contract_info
-    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
   - - registered_dexes
@@ -24,16 +24,16 @@ expression: all_storage
   - - config
     - "{\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"},\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-client\",\"version\":\"0.23.0\"}"
   - - module_data
-    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0-beta.0\",\"dependencies\":[],\"metadata\":null}"
+    - "{\"module\":\"abstract:ibc-client\",\"version\":\"0.23.0\",\"dependencies\":[],\"metadata\":null}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ibc-host":
   - - cfg
     - "{\"ans_host\":{\"address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"},\"account_factory\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"version_control\":{\"address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}}"
   - - contract_info
-    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:ibc-host\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:manager-local-0":
@@ -48,7 +48,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - info
     - "{\"name\":\"Default Abstract Account\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":null,\"link\":null}"
   - - ownership
@@ -67,7 +67,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - info
     - "{\"name\":\"Default Abstract Account\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":null,\"link\":null}"
   - - ownership
@@ -84,7 +84,7 @@ expression: all_storage
   - - context
     - "[]"
   - - contract_info
-    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:manager\",\"version\":\"0.23.0\"}"
   - - info
     - "{\"name\":\"My subaccount\",\"chain_id\":\"cosmos-testnet-14002\",\"description\":\"new desc\",\"link\":null}"
   - - ownership
@@ -93,7 +93,7 @@ expression: all_storage
   - - "\u0000{5}config"
     - "{\"version_control_address\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\",\"ans_host_address\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
   - - contract_info
-    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:module-factory\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:proxy-local-0":
@@ -106,7 +106,7 @@ expression: all_storage
   - - admin
     - "\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:proxy-local-1":
   - - "\u0000{5}state"
     - "{\"modules\":[\"mock1ps47cz26ugmzp2emuqap8jmvjrkwyzgh4uupechr9et6w0a3ar6sv5ag3c\"]}"
@@ -117,7 +117,7 @@ expression: all_storage
   - - admin
     - "\"mock1ps47cz26ugmzp2emuqap8jmvjrkwyzgh4uupechr9et6w0a3ar6sv5ag3c\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:proxy-local-2":
   - - "\u0000{5}state"
     - "{\"modules\":[\"mock13cahl7h567qy5pal82h4qztgg6yp0dum7h0rx26lkvyednndhh8qcfqqvj\"]}"
@@ -128,23 +128,23 @@ expression: all_storage
   - - admin
     - "\"mock13cahl7h567qy5pal82h4qztgg6yp0dum7h0rx26lkvyednndhh8qcfqqvj\""
   - - contract_info
-    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:proxy\",\"version\":\"0.23.0\"}"
 "abstract:version-control":
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0005proxy0.23.0"
     - "{\"account_base\":6}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u0007manager0.23.0"
     - "{\"account_base\":5}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bans-host0.23.0"
     - "{\"native\":\"mock1mzdhwvvh22wrt07w59wxyd58822qavwkx5lcej7aqfkpqqlhaqfsetqc4t\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\bibc-host0.23.0"
     - "{\"native\":\"mock14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les6xzvf5\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\nibc-client0.23.0"
     - "{\"native\":\"mock1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcns7ctvz5\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000emodule-factory0.23.0"
     - "{\"native\":\"mock1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5wsldye53\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000faccount-factory0.23.0"
     - "{\"native\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\"}"
-  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0-beta.0"
+  - - "\u0000\u0003lib\u0000\babstract\u0000\u000fversion-control0.23.0"
     - "{\"native\":\"mock1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqwm38hv\"}"
   - - "\u0000\u0004accs\u0000\u0005local\u0000\u0000\u0000\u0000"
     - "{\"manager\":\"mock1lqyzwgew5stjyj9mqf04f98d87yy0chklx25dvq58w4855v4lflqy7ppar\",\"proxy\":\"mock1xsemjm2xzx8nfaj50rt2dn04g24yarrr3mf6uwhqtc4ampff9nsqrc867x\"}"
@@ -159,6 +159,6 @@ expression: all_storage
   - - cfg
     - "{\"account_factory_address\":\"mock17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgszycl2y\",\"security_disabled\":true,\"namespace_registration_fee\":null}"
   - - contract_info
-    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0-beta.0\"}"
+    - "{\"contract\":\"abstract:version-control\",\"version\":\"0.23.0\"}"
   - - ownership
     - "{\"owner\":\"mock1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwrtv4f\",\"pending_owner\":null,\"pending_expiry\":null}"

--- a/framework/packages/abstract-adapter/Cargo.toml
+++ b/framework/packages/abstract-adapter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "abstract-adapter"
-version = "0.23.0-beta.0"
+version = "0.23.0"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
@@ -28,9 +28,9 @@ abstract-std = { workspace = true }
 abstract-testing = { workspace = true, optional = true }
 cw-orch = { workspace = true }
 # Keep this as a version and update when publishing new versions
-abstract-interface = { path = "../../packages/abstract-interface", version = "0.23.0-beta.0" }
-abstract-ibc-client = { version = "0.23.0-beta.0", path = "../../contracts/native/ibc-client", default-features = false }
-abstract-ibc-host = { version = "0.23.0-beta.0", path = "../../contracts/native/ibc-host", default-features = false }
+abstract-interface = { path = "../../packages/abstract-interface", version = "0.23.0" }
+abstract-ibc-client = { version = "0.23.0", path = "../../contracts/native/ibc-client", default-features = false }
+abstract-ibc-host = { version = "0.23.0", path = "../../contracts/native/ibc-host", default-features = false }
 
 [dev-dependencies]
 speculoos = { workspace = true }

--- a/framework/packages/abstract-app/Cargo.toml
+++ b/framework/packages/abstract-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "abstract-app"
-version = "0.23.0-beta.0"
+version = "0.23.0"
 edition = { workspace = true }
 license = { workspace = true }
 description = "base app contract implementation"
@@ -30,8 +30,8 @@ abstract-std = { workspace = true }
 abstract-testing = { workspace = true, optional = true }
 cw-orch = { workspace = true }
 
-abstract-interface = { version = "0.23.0-beta.0", path = "../../packages/abstract-interface" }
-abstract-ibc-host = { version = "0.23.0-beta.0", path = "../../contracts/native/ibc-host", default-features = false }
+abstract-interface = { version = "0.23.0", path = "../../packages/abstract-interface" }
+abstract-ibc-host = { version = "0.23.0", path = "../../contracts/native/ibc-host", default-features = false }
 
 [dev-dependencies]
 cosmwasm-schema = { workspace = true }

--- a/framework/packages/abstract-client/Cargo.toml
+++ b/framework/packages/abstract-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "abstract-client"
-version = "0.23.0-beta.0"
+version = "0.23.0"
 description = "A client oriented package for the Abstract Framework."
 authors.workspace = true
 edition.workspace = true
@@ -23,7 +23,7 @@ interchain = [
 ]
 
 [dependencies]
-abstract-interface = { version = "0.23.0-beta.0", path = "../abstract-interface" }
+abstract-interface = { version = "0.23.0", path = "../abstract-interface" }
 cosmwasm-std.workspace = true
 abstract-std.workspace = true
 cw-orch.workspace = true

--- a/framework/packages/abstract-interface/Cargo.toml
+++ b/framework/packages/abstract-interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "abstract-interface"
-version = "0.23.0-beta.0"
+version = "0.23.0"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Abstract deployment helpers with cw-orchestrator"
@@ -39,14 +39,14 @@ cw-orch-polytone = { workspace = true, optional = true }
 rust-embed = { version = "8.3.0", features = ["include-exclude"] }
 
 # Keep these here
-module-factory = { version = "0.23.0-beta.0", package = "abstract-module-factory", path = "../../contracts/native/module-factory", default-features = false }
-ibc-client = { version = "0.23.0-beta.0", package = "abstract-ibc-client", path = "../../contracts/native/ibc-client", default-features = false }
-ibc-host = { version = "0.23.0-beta.0", package = "abstract-ibc-host", path = "../../contracts/native/ibc-host", default-features = false }
-account-factory = { version = "0.23.0-beta.0", package = "abstract-account-factory", path = "../../contracts/native/account-factory", default-features = false }
-ans-host = { version = "0.23.0-beta.0", package = "abstract-ans-host", path = "../../contracts/native/ans-host", default-features = false }
-version-control = { version = "0.23.0-beta.0", package = "abstract-version-control", path = "../../contracts/native/version-control", default-features = false }
-proxy = { version = "0.23.0-beta.0", package = "abstract-proxy", path = "../../contracts/account/proxy", default-features = false }
-manager = { version = "0.23.0-beta.0", package = "abstract-manager", path = "../../contracts/account/manager", default-features = false }
+module-factory = { version = "0.23.0", package = "abstract-module-factory", path = "../../contracts/native/module-factory", default-features = false }
+ibc-client = { version = "0.23.0", package = "abstract-ibc-client", path = "../../contracts/native/ibc-client", default-features = false }
+ibc-host = { version = "0.23.0", package = "abstract-ibc-host", path = "../../contracts/native/ibc-host", default-features = false }
+account-factory = { version = "0.23.0", package = "abstract-account-factory", path = "../../contracts/native/account-factory", default-features = false }
+ans-host = { version = "0.23.0", package = "abstract-ans-host", path = "../../contracts/native/ans-host", default-features = false }
+version-control = { version = "0.23.0", package = "abstract-version-control", path = "../../contracts/native/version-control", default-features = false }
+proxy = { version = "0.23.0", package = "abstract-proxy", path = "../../contracts/account/proxy", default-features = false }
+manager = { version = "0.23.0", package = "abstract-manager", path = "../../contracts/account/manager", default-features = false }
 
 [build-dependencies]
 serde_json = "1.0.79"

--- a/framework/packages/standards/dex/Cargo.toml
+++ b/framework/packages/standards/dex/Cargo.toml
@@ -34,7 +34,7 @@ abstract-std = { workspace = true }
 abstract-sdk = { workspace = true }
 abstract-adapter-utils = { workspace = true }
 cw-orch = { workspace = true }
-abstract-adapter = { version = "0.23.0-beta.0", path = "../../abstract-adapter" }
+abstract-adapter = { version = "0.23.0", path = "../../abstract-adapter" }
 
 ibc-chain-registry = { version = "0.25.0", optional = true }
 

--- a/framework/packages/standards/money-market/Cargo.toml
+++ b/framework/packages/standards/money-market/Cargo.toml
@@ -33,4 +33,4 @@ abstract-std = { workspace = true }
 abstract-sdk = { workspace = true }
 abstract-adapter-utils = { workspace = true }
 cw-orch = { workspace = true }
-abstract-adapter = { version = "0.23.0-beta.0", path = "../../abstract-adapter" }
+abstract-adapter = { version = "0.23.0", path = "../../abstract-adapter" }

--- a/framework/packages/standards/staking/Cargo.toml
+++ b/framework/packages/standards/staking/Cargo.toml
@@ -32,7 +32,7 @@ abstract-std = { workspace = true }
 abstract-sdk = { workspace = true }
 abstract-adapter-utils = { workspace = true }
 cw-orch = { workspace = true }
-abstract-adapter = { version = "0.23.0-beta.0", path = "../../abstract-adapter" }
+abstract-adapter = { version = "0.23.0", path = "../../abstract-adapter" }
 
 [dev-dependencies]
 abstract-interface = { workspace = true, features = ["daemon"] }

--- a/integrations/Cargo.toml
+++ b/integrations/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.22.1"
+version = "0.23.0"
 authors = [
   "CyberHoward <cyberhoward@protonmail.com>",
   "Riada <riada@abstract.money>",
@@ -53,15 +53,15 @@ semver = "1.0"
 
 ## crates in order of publishing ## see docs/Publishing.md
 
-abstract-interface = { version = "0.23.0-beta.0" }
-abstract-adapter = { version = "0.23.0-beta.0" }
-abstract-sdk = { version = "0.23.0-beta.0" }
-abstract-std = { version = "0.23.0-beta.0" }
+abstract-interface = { version = "0.23.0" }
+abstract-adapter = { version = "0.23.0" }
+abstract-sdk = { version = "0.23.0" }
+abstract-std = { version = "0.23.0" }
 
-abstract-adapter-utils = { version = "0.23.0-beta.0" }
-abstract-dex-standard = { version = "0.23.0-beta.0" }
-abstract-money-market-standard = { version = "0.23.0-beta.0" }
-abstract-staking-standard = { version = "0.23.0-beta.0" }
+abstract-adapter-utils = { version = "0.23.0" }
+abstract-dex-standard = { version = "0.23.0" }
+abstract-money-market-standard = { version = "0.23.0" }
+abstract-staking-standard = { version = "0.23.0" }
 
 # TODO: REMOVE As soon as new dex-standard published
 [patch.crates-io]

--- a/interchain/Cargo.toml
+++ b/interchain/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.23.0-beta.0"
+version = "0.23.0"
 authors = [
   "CyberHoward <cyberhoward@protonmail.com>",
   "Riada <riada@abstract.money>",
@@ -67,13 +67,13 @@ cw-orch-proto = { version = "0.4.0" }
 
 # Keep these as path, creates cirular dependency otherwise
 # Only need to re-publish all contracts if a re-publish of abstract-interface is required
-abstract-interface = { version = "0.23.0-beta.0", path = "../framework/packages/abstract-interface" }
-abstract-sdk = { version = "0.23.0-beta.0", path = "../framework/packages/abstract-sdk" }
-abstract-std = { version = "0.23.0-beta.0", path = "../framework/packages/abstract-std" }
-abstract-app = { version = "0.23.0-beta.0", path = "../framework/packages/abstract-app" }
-abstract-adapter = { version = "0.23.0-beta.0", path = "../framework/packages/abstract-adapter" }
-abstract-testing = { version = "0.23.0-beta.0", path = "../framework/packages/abstract-testing" }
-abstract-client = { version = "0.23.0-beta.0", path = "../framework/packages/abstract-client" }
+abstract-interface = { version = "0.23.0", path = "../framework/packages/abstract-interface" }
+abstract-sdk = { version = "0.23.0", path = "../framework/packages/abstract-sdk" }
+abstract-std = { version = "0.23.0", path = "../framework/packages/abstract-std" }
+abstract-app = { version = "0.23.0", path = "../framework/packages/abstract-app" }
+abstract-adapter = { version = "0.23.0", path = "../framework/packages/abstract-adapter" }
+abstract-testing = { version = "0.23.0", path = "../framework/packages/abstract-testing" }
+abstract-client = { version = "0.23.0", path = "../framework/packages/abstract-client" }
 # Modules
 croncat-app = { path = "../modules/contracts/apps/croncat" }
 challenge-app = { path = "../modules/contracts/apps/challenge" }

--- a/interchain/interchain-tests/Cargo.toml
+++ b/interchain/interchain-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "abstract-interchain-tests"
-version = "0.23.0-beta.0"
+version = "0.23.0"
 edition = { workspace = true }
 license = { workspace = true }
 description = "Interchain testing library for the Abstract SDK. This is used primarily for tests but some elements are re-usable for testing apps and adapters"

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -4,7 +4,7 @@ members = ["contracts/apps/*", "contracts/adapters/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.22.1"
+version = "0.23.0"
 authors = [
   "CyberHoward <cyberhoward@protonmail.com>",
   "Riada <riada@abstract.money>",
@@ -51,17 +51,17 @@ tokio = { version = "1.4", features = ["full"] }
 
 ## crates in order of publishing ## see docs/Publishing.md
 
-abstract-interface = { version = "0.23.0-beta.0" }
-abstract-adapter = { version = "0.23.0-beta.0" }
-abstract-app = { version = "0.23.0-beta.0" }
-abstract-testing = { version = "0.23.0-beta.0" }
-abstract-macros = { version = "0.23.0-beta.0" }
-abstract-client = { version = "0.23.0-beta.0" }
+abstract-interface = { version = "0.23.0" }
+abstract-adapter = { version = "0.23.0" }
+abstract-app = { version = "0.23.0" }
+abstract-testing = { version = "0.23.0" }
+abstract-macros = { version = "0.23.0" }
+abstract-client = { version = "0.23.0" }
 
-abstract-adapter-utils = { version = "0.23.0-beta.0" }
-abstract-dex-standard = { version = "0.23.0-beta.0" }
-abstract-staking-standard = { version = "0.23.0-beta.0" }
-abstract-money-market-standard = { version = "0.23.0-beta.0" }
+abstract-adapter-utils = { version = "0.23.0" }
+abstract-dex-standard = { version = "0.23.0" }
+abstract-staking-standard = { version = "0.23.0" }
+abstract-money-market-standard = { version = "0.23.0" }
 
 # Integrations
 abstract-wyndex-adapter = { path = "../integrations/wyndex-adapter", default-features = false }

--- a/modules/contracts/apps/ping-pong/Cargo.toml
+++ b/modules/contracts/apps/ping-pong/Cargo.toml
@@ -22,7 +22,7 @@ schemars = { workspace = true }
 cw-asset = { workspace = true }
 abstract-app = { workspace = true }
 cw-orch = { workspace = true }
-abstract-ibc-client = { version = "0.23.0-beta.0", default-features = false, path = "../../../../framework/contracts/native/ibc-client" }
+abstract-ibc-client = { version = "0.23.0", default-features = false, path = "../../../../framework/contracts/native/ibc-client" }
 
 [dev-dependencies]
 cw-orch-interchain = { version = "0.3", features = ["daemon"] }


### PR DESCRIPTION
We have some chains migrated to 0.23.0-beta, but some changes were introduced to abstract contracts. This PR bumps abstract versions to allow auto-migration on clone-testing

### Checklist

- [ ] CI is green.
- [x] Changelog updated.

### Failing CI

- [ ] astroport migrated to a new contracts that use stargate, fix: #396
