### PR TITLE
Remove `mock_dependencies`

### DIFF
--- a/framework/contracts/native/version-control/src/commands.rs
+++ b/framework/contracts/native/version-control/src/commands.rs
@@ -680,7 +680,7 @@ mod tests {
         version_control::*,
         ACCOUNT,
     };
-    use abstract_testing::{mock_querier_builder, prelude::*, MockQuerierOwnership};
+    use abstract_testing::{abstract_mock_querier_builder, prelude::*, MockQuerierOwnership};
     use cosmwasm_std::{
         from_json,
         testing::{message_info, mock_env, MockApi},
@@ -733,7 +733,7 @@ mod tests {
 
         const OWNERSHIP: Item<Ownership<Addr>> = Item::new(OWNERSHIP_STORAGE_KEY);
 
-        mock_querier_builder(api)
+        abstract_mock_querier_builder(api)
             .with_contract_version(&first_acc_addr, ACCOUNT, TEST_VERSION)
             .with_contract_version(&second_acc_addr, ACCOUNT, TEST_VERSION)
             .with_contract_version(&third_acc_addr, ACCOUNT, TEST_VERSION)
@@ -942,7 +942,7 @@ mod tests {
         use super::*;
 
         use abstract_std::AbstractError;
-        use abstract_testing::mock_querier_builder;
+        use abstract_testing::abstract_mock_querier_builder;
         use cosmwasm_std::{coins, SubMsg};
 
         #[test]
@@ -1426,7 +1426,7 @@ mod tests {
 
         use crate::contract::query;
         use abstract_std::{objects::module::Monetization, AbstractError};
-        use abstract_testing::mock_querier_builder;
+        use abstract_testing::abstract_mock_querier_builder;
         use cosmwasm_std::coin;
 
         fn test_module() -> ModuleInfo {

--- a/framework/packages/abstract-adapter/src/endpoints/execute.rs
+++ b/framework/packages/abstract-adapter/src/endpoints/execute.rs
@@ -288,7 +288,7 @@ mod tests {
         #[test]
         fn authorize_address() -> AdapterMockResult {
             let mut deps = mock_dependencies();
-            deps.querier = mock_querier(deps.api);
+            deps.querier = abstract_mock_querier(deps.api);
             let base = test_account_base(deps.api);
 
             mock_init(&mut deps)?;
@@ -318,7 +318,7 @@ mod tests {
         #[test]
         fn revoke_address_authorization() -> AdapterMockResult {
             let mut deps = mock_dependencies();
-            deps.querier = mock_querier(deps.api);
+            deps.querier = abstract_mock_querier(deps.api);
             let base = test_account_base(deps.api);
 
             mock_init(&mut deps)?;
@@ -354,7 +354,7 @@ mod tests {
         #[test]
         fn add_existing_authorized_address() -> AdapterMockResult {
             let mut deps = mock_dependencies();
-            deps.querier = mock_querier(deps.api);
+            deps.querier = abstract_mock_querier(deps.api);
             let base = test_account_base(deps.api);
 
             mock_init(&mut deps)?;
@@ -395,7 +395,7 @@ mod tests {
         #[test]
         fn add_module_id_authorized_address() -> AdapterMockResult {
             let mut deps = mock_dependencies();
-            deps.querier = mock_querier(deps.api);
+            deps.querier = abstract_mock_querier(deps.api);
             let abstr = AbstractMockAddrs::new(deps.api);
 
             mock_init(&mut deps)?;
@@ -423,7 +423,7 @@ mod tests {
         #[test]
         fn remove_authorized_address_dne() -> AdapterMockResult {
             let mut deps = mock_dependencies();
-            deps.querier = mock_querier(deps.api);
+            deps.querier = abstract_mock_querier(deps.api);
             let base = test_account_base(deps.api);
 
             mock_init(&mut deps)?;

--- a/framework/packages/abstract-adapter/src/endpoints/instantiate.rs
+++ b/framework/packages/abstract-adapter/src/endpoints/instantiate.rs
@@ -82,7 +82,7 @@ mod test {
         let abstr = AbstractMockAddrs::new(deps.api);
 
         let info = message_info(&abstr.account.manager, &[]);
-        deps.querier = abstract_testing::mock_querier(deps.api);
+        deps.querier = abstract_testing::abstract_mock_querier(deps.api);
         let init_msg = InstantiateMsg {
             base: BaseInstantiateMsg {
                 ans_host_address: abstr.ans_host.to_string(),

--- a/framework/packages/abstract-adapter/src/endpoints/reply.rs
+++ b/framework/packages/abstract-adapter/src/endpoints/reply.rs
@@ -23,7 +23,7 @@ mod test {
     fn endpoint() -> AdapterMockResult {
         let env = mock_env();
         let mut deps = mock_dependencies();
-        deps.querier = abstract_testing::mock_querier(deps.api);
+        deps.querier = abstract_testing::abstract_mock_querier(deps.api);
         let reply_msg = Reply {
             id: 1,
             #[allow(deprecated)]
@@ -46,7 +46,7 @@ mod test {
     fn no_matching_id() -> AdapterMockResult {
         let env = mock_env();
         let mut deps = mock_dependencies();
-        deps.querier = abstract_testing::mock_querier(deps.api);
+        deps.querier = abstract_testing::abstract_mock_querier(deps.api);
         let reply_msg = Reply {
             id: 0,
             #[allow(deprecated)]

--- a/framework/packages/abstract-adapter/src/endpoints/sudo.rs
+++ b/framework/packages/abstract-adapter/src/endpoints/sudo.rs
@@ -18,7 +18,7 @@ mod tests {
     fn endpoint() -> AdapterMockResult {
         let env = mock_env();
         let mut deps = mock_dependencies();
-        deps.querier = abstract_testing::mock_querier(deps.api);
+        deps.querier = abstract_testing::abstract_mock_querier(deps.api);
         let sudo_msg = crate::mock::MockSudoMsg {};
         let res = sudo(deps.as_mut(), env, sudo_msg)?;
         assert_that!(&res.messages.len()).is_equal_to(0);

--- a/framework/packages/abstract-app/src/features.rs
+++ b/framework/packages/abstract-app/src/features.rs
@@ -60,7 +60,7 @@ impl<
 mod test {
     #![allow(clippy::needless_borrows_for_generic_args)]
     use abstract_sdk::{AccountVerification, ModuleRegistryInterface};
-    use abstract_testing::{mock_querier, prelude::*};
+    use abstract_testing::{abstract_mock_querier, prelude::*};
     use speculoos::prelude::*;
 
     use super::*;
@@ -91,7 +91,7 @@ mod test {
     #[test]
     fn test_traits_generated() -> AppTestResult {
         let mut deps = mock_init();
-        deps.querier = mock_querier(deps.api);
+        deps.querier = abstract_mock_querier(deps.api);
         let abstr = AbstractMockAddrs::new(deps.api);
         let test_account_base = abstr.account;
         // Account identification

--- a/framework/packages/abstract-sdk/src/apis/adapter.rs
+++ b/framework/packages/abstract-sdk/src/apis/adapter.rs
@@ -113,7 +113,7 @@ mod tests {
         fake_module: ModuleId,
     ) {
         let mut deps = mock_dependencies();
-        deps.querier = abstract_testing::mock_querier(deps.api);
+        deps.querier = abstract_testing::abstract_mock_querier(deps.api);
         let app = MockModule::new(deps.api);
 
         let _mods = app.adapters(deps.as_ref());
@@ -143,7 +143,7 @@ mod tests {
         #[test]
         fn expected_adapter_request() {
             let mut deps = mock_dependencies();
-            deps.querier = abstract_testing::mock_querier(deps.api);
+            deps.querier = abstract_testing::abstract_mock_querier(deps.api);
             let app = MockModule::new(deps.api);
             let abstr = AbstractMockAddrs::new(deps.api);
 
@@ -184,7 +184,7 @@ mod tests {
         #[test]
         fn expected_adapter_query() {
             let mut deps = mock_dependencies();
-            deps.querier = abstract_testing::mock_querier(deps.api);
+            deps.querier = abstract_testing::abstract_mock_querier(deps.api);
             let app = MockModule::new(deps.api);
 
             let mods = app.adapters(deps.as_ref());

--- a/framework/packages/abstract-sdk/src/apis/app.rs
+++ b/framework/packages/abstract-sdk/src/apis/app.rs
@@ -108,7 +108,7 @@ mod tests {
         fake_module: ModuleId,
     ) {
         let mut deps = mock_dependencies();
-        deps.querier = abstract_testing::mock_querier(deps.api);
+        deps.querier = abstract_testing::abstract_mock_querier(deps.api);
         let app = MockModule::new(deps.api);
 
         let _mods = app.apps(deps.as_ref());
@@ -138,7 +138,7 @@ mod tests {
         #[test]
         fn expected_app_request() {
             let mut deps = mock_dependencies();
-            deps.querier = abstract_testing::mock_querier(deps.api);
+            deps.querier = abstract_testing::abstract_mock_querier(deps.api);
             let app = MockModule::new(deps.api);
             let abstr = AbstractMockAddrs::new(deps.api);
 
@@ -175,7 +175,7 @@ mod tests {
         #[test]
         fn expected_app_query() {
             let mut deps = mock_dependencies();
-            deps.querier = abstract_testing::mock_querier(deps.api);
+            deps.querier = abstract_testing::abstract_mock_querier(deps.api);
             let app = MockModule::new(deps.api);
 
             let mods = app.apps(deps.as_ref());

--- a/framework/packages/abstract-standalone/src/features.rs
+++ b/framework/packages/abstract-standalone/src/features.rs
@@ -39,7 +39,7 @@ impl Dependencies for StandaloneContract {
 mod test {
     #![allow(clippy::needless_borrows_for_generic_args)]
     use abstract_sdk::{AccountVerification, ModuleRegistryInterface};
-    use abstract_testing::{mock_querier, prelude::*};
+    use abstract_testing::{abstract_mock_querier, prelude::*};
     use speculoos::prelude::*;
 
     use super::*;
@@ -70,7 +70,7 @@ mod test {
     #[test]
     fn test_traits_generated() -> StandaloneTestResult {
         let mut deps = mock_init();
-        deps.querier = mock_querier(deps.api);
+        deps.querier = abstract_mock_querier(deps.api);
         let abstr = AbstractMockAddrs::new(deps.api);
 
         // AbstractNameService

--- a/framework/packages/abstract-testing/src/lib.rs
+++ b/framework/packages/abstract-testing/src/lib.rs
@@ -120,7 +120,7 @@ pub fn mock_querier(mock_api: MockApi) -> MockQuerier {
 /// Abstract-specific mock dependencies.
 ///
 /// Sets the required queries for native contracts and the root Abstract Account.
-pub fn mock_dependencies() -> MockDeps {
+pub fn mock_deps() -> MockDeps {
     let api = MockApi::default();
     let querier = mock_querier(api.clone());
 
@@ -207,7 +207,7 @@ pub mod module {
 }
 
 pub mod prelude {
-    pub use super::{mock_dependencies, mock_querier};
+    pub use super::{mock_deps, mock_querier};
     pub use abstract_mock_querier::AbstractMockQuerier;
     use abstract_std::objects::{AccountId, AccountTrace};
     pub use addresses::*;

--- a/framework/packages/abstract-testing/src/lib.rs
+++ b/framework/packages/abstract-testing/src/lib.rs
@@ -117,21 +117,6 @@ pub fn abstract_mock_querier(mock_api: MockApi) -> MockQuerier {
     abstract_mock_querier_builder(mock_api).build()
 }
 
-/// Abstract-specific mock dependencies.
-///
-/// Sets the required queries for native contracts and the root Abstract Account.
-pub fn abstract_mock_dependencies() -> MockDeps {
-    let api = MockApi::default();
-    let querier = abstract_mock_querier(api.clone());
-
-    OwnedDeps {
-        storage: MockStorage::default(),
-        api,
-        querier,
-        custom_query_type: std::marker::PhantomData,
-    }
-}
-
 /// use the package version as test version, breaks tests otherwise.
 pub const TEST_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub mod addresses {
@@ -207,7 +192,7 @@ pub mod module {
 }
 
 pub mod prelude {
-    pub use super::{abstract_mock_dependencies, abstract_mock_querier};
+    pub use super::{abstract_mock_querier, abstract_mock_querier_builder};
     pub use abstract_mock_querier::AbstractMockQuerier;
     use abstract_std::objects::{AccountId, AccountTrace};
     pub use addresses::*;

--- a/framework/packages/abstract-testing/src/lib.rs
+++ b/framework/packages/abstract-testing/src/lib.rs
@@ -29,7 +29,7 @@ use module::{TEST_MODULE_ID, TEST_MODULE_RESPONSE};
 use prelude::*;
 pub type MockDeps = OwnedDeps<MockStorage, MockApi, MockQuerier>;
 
-pub fn mock_querier_builder(mock_api: MockApi) -> MockQuerierBuilder {
+pub fn abstract_mock_querier_builder(mock_api: MockApi) -> MockQuerierBuilder {
     let raw_handler = move |contract: &Addr, key: &Binary| {
         // TODO: should we do something with the key?
         let str_key = std::str::from_utf8(key.as_slice()).unwrap();
@@ -113,16 +113,16 @@ pub fn mock_querier_builder(mock_api: MockApi) -> MockQuerierBuilder {
 ///   - "account_id" -> TEST_ACCOUNT_ID
 /// - TEST_VERSION_CONTROL
 ///   - "account" -> { TEST_PROXY, TEST_MANAGER }
-pub fn mock_querier(mock_api: MockApi) -> MockQuerier {
-    mock_querier_builder(mock_api).build()
+pub fn abstract_mock_querier(mock_api: MockApi) -> MockQuerier {
+    abstract_mock_querier_builder(mock_api).build()
 }
 
 /// Abstract-specific mock dependencies.
 ///
 /// Sets the required queries for native contracts and the root Abstract Account.
-pub fn mock_deps() -> MockDeps {
+pub fn abstract_mock_dependencies() -> MockDeps {
     let api = MockApi::default();
-    let querier = mock_querier(api.clone());
+    let querier = abstract_mock_querier(api.clone());
 
     OwnedDeps {
         storage: MockStorage::default(),
@@ -207,7 +207,7 @@ pub mod module {
 }
 
 pub mod prelude {
-    pub use super::{mock_deps, mock_querier};
+    pub use super::{abstract_mock_dependencies, abstract_mock_querier};
     pub use abstract_mock_querier::AbstractMockQuerier;
     use abstract_std::objects::{AccountId, AccountTrace};
     pub use addresses::*;

--- a/framework/packages/abstract-testing/src/mock_querier.rs
+++ b/framework/packages/abstract-testing/src/mock_querier.rs
@@ -425,14 +425,14 @@ mod tests {
 
         use abstract_std::version_control::Account;
 
-        use crate::mock_querier_builder;
+        use crate::abstract_mock_querier_builder;
 
         use super::*;
 
         #[test]
         fn should_return_admin_account_address() {
-            let mut deps = mock_deps();
-            deps.querier = mock_querier(deps.api);
+            let mut deps = abstract_mock_dependencies();
+            deps.querier = abstract_mock_querier(deps.api);
             let abstr = AbstractMockAddrs::new(deps.api);
 
             let actual = ACCOUNT_ADDRESSES.query(
@@ -448,9 +448,9 @@ mod tests {
 
         #[test]
         fn should_return_account_address() {
-            let mut deps = mock_deps();
+            let mut deps = abstract_mock_dependencies();
             let account_base = Account::new(deps.api.addr_make("my_account"));
-            deps.querier = mock_querier_builder(deps.api)
+            deps.querier = abstract_mock_querier_builder(deps.api)
                 .account(&account_base, TEST_ACCOUNT_ID)
                 .build();
             let abstr = AbstractMockAddrs::new(deps.api);
@@ -527,14 +527,14 @@ mod tests {
     }
 
     mod account_id {
-        use crate::mock_querier_builder;
+        use crate::abstract_mock_querier_builder;
 
         use super::*;
 
         #[test]
         fn should_return_admin_acct_id() {
-            let mut deps = mock_deps();
-            deps.querier = mock_querier(deps.api);
+            let mut deps = abstract_mock_dependencies();
+            deps.querier = abstract_mock_querier(deps.api);
             let root_base = admin_account(deps.api);
 
             let actual = ACCOUNT_ID.query(&wrap_querier(&deps.querier), root_base.addr().clone());
@@ -544,9 +544,9 @@ mod tests {
 
         #[test]
         fn should_return_test_acct_id() {
-            let mut deps = mock_deps();
+            let mut deps = abstract_mock_dependencies();
             let test_base = test_account_base(deps.api);
-            deps.querier = mock_querier_builder(deps.api)
+            deps.querier = abstract_mock_querier_builder(deps.api)
                 .account(&test_base, TEST_ACCOUNT_ID)
                 .build();
 
@@ -561,8 +561,8 @@ mod tests {
 
         #[test]
         fn should_return_test_module_address_for_test_module() {
-            let mut deps = mock_deps();
-            deps.querier = mock_querier(deps.api);
+            let mut deps = abstract_mock_dependencies();
+            deps.querier = abstract_mock_querier(deps.api);
             let abstr = AbstractMockAddrs::new(deps.api);
 
             let actual = ACCOUNT_MODULES.query(

--- a/framework/packages/abstract-testing/src/mock_querier.rs
+++ b/framework/packages/abstract-testing/src/mock_querier.rs
@@ -420,6 +420,7 @@ mod tests {
     };
 
     use super::*;
+    use cosmwasm_std::testing::mock_dependencies;
 
     mod account {
 
@@ -431,7 +432,7 @@ mod tests {
 
         #[test]
         fn should_return_admin_account_address() {
-            let mut deps = abstract_mock_dependencies();
+            let mut deps = mock_dependencies();
             deps.querier = abstract_mock_querier(deps.api);
             let abstr = AbstractMockAddrs::new(deps.api);
 
@@ -448,7 +449,7 @@ mod tests {
 
         #[test]
         fn should_return_account_address() {
-            let mut deps = abstract_mock_dependencies();
+            let mut deps = mock_dependencies();
             let account_base = Account::new(deps.api.addr_make("my_account"));
             deps.querier = abstract_mock_querier_builder(deps.api)
                 .account(&account_base, TEST_ACCOUNT_ID)
@@ -533,7 +534,7 @@ mod tests {
 
         #[test]
         fn should_return_admin_acct_id() {
-            let mut deps = abstract_mock_dependencies();
+            let mut deps = mock_dependencies();
             deps.querier = abstract_mock_querier(deps.api);
             let root_base = admin_account(deps.api);
 
@@ -544,7 +545,7 @@ mod tests {
 
         #[test]
         fn should_return_test_acct_id() {
-            let mut deps = abstract_mock_dependencies();
+            let mut deps = mock_dependencies();
             let test_base = test_account_base(deps.api);
             deps.querier = abstract_mock_querier_builder(deps.api)
                 .account(&test_base, TEST_ACCOUNT_ID)
@@ -561,7 +562,7 @@ mod tests {
 
         #[test]
         fn should_return_test_module_address_for_test_module() {
-            let mut deps = abstract_mock_dependencies();
+            let mut deps = mock_dependencies();
             deps.querier = abstract_mock_querier(deps.api);
             let abstr = AbstractMockAddrs::new(deps.api);
 

--- a/framework/packages/abstract-testing/src/mock_querier.rs
+++ b/framework/packages/abstract-testing/src/mock_querier.rs
@@ -431,7 +431,7 @@ mod tests {
 
         #[test]
         fn should_return_admin_account_address() {
-            let mut deps = mock_dependencies();
+            let mut deps = mock_deps();
             deps.querier = mock_querier(deps.api);
             let abstr = AbstractMockAddrs::new(deps.api);
 
@@ -448,7 +448,7 @@ mod tests {
 
         #[test]
         fn should_return_account_address() {
-            let mut deps = mock_dependencies();
+            let mut deps = mock_deps();
             let account_base = Account::new(deps.api.addr_make("my_account"));
             deps.querier = mock_querier_builder(deps.api)
                 .account(&account_base, TEST_ACCOUNT_ID)
@@ -533,7 +533,7 @@ mod tests {
 
         #[test]
         fn should_return_admin_acct_id() {
-            let mut deps = mock_dependencies();
+            let mut deps = mock_deps();
             deps.querier = mock_querier(deps.api);
             let root_base = admin_account(deps.api);
 
@@ -544,7 +544,7 @@ mod tests {
 
         #[test]
         fn should_return_test_acct_id() {
-            let mut deps = mock_dependencies();
+            let mut deps = mock_deps();
             let test_base = test_account_base(deps.api);
             deps.querier = mock_querier_builder(deps.api)
                 .account(&test_base, TEST_ACCOUNT_ID)
@@ -561,7 +561,7 @@ mod tests {
 
         #[test]
         fn should_return_test_module_address_for_test_module() {
-            let mut deps = mock_dependencies();
+            let mut deps = mock_deps();
             deps.querier = mock_querier(deps.api);
             let abstr = AbstractMockAddrs::new(deps.api);
 


### PR DESCRIPTION
This PR removes `mock_dependencies` from abstract-testing, because of the name conflict with `cosmwasm_std::testing::mock_dependencies`