### PR TITLE
New feature --> No ID replies

### DIFF
--- a/framework/packages/abstract-adapter/src/endpoints/execute.rs
+++ b/framework/packages/abstract-adapter/src/endpoints/execute.rs
@@ -157,7 +157,8 @@ impl<Error: ContractError, CustomInitMsg, CustomExecMsg, CustomQueryMsg, SudoMsg
                 .map_err(|_| unauthorized_sender())?,
         };
         self.target_account = Some(account);
-        self.execute_handler()?(deps, env, info, self, request.request)
+        self.execute_handler()?(deps, env, info, &self, request.request)
+            .map(|response| response.into_cosmwasm_response(self.contract()))
     }
 
     /// Update authorized addresses from the adapter.

--- a/framework/packages/abstract-adapter/src/features.rs
+++ b/framework/packages/abstract-adapter/src/features.rs
@@ -41,10 +41,10 @@ impl<Error: ContractError, CustomInitMsg, CustomExecMsg, CustomQueryMsg, SudoMsg
 }
 #[cfg(test)]
 mod tests {
-    use abstract_sdk::base::ExecuteEndpoint;
+    use abstract_sdk::base::{response::Response, ExecuteEndpoint};
     use abstract_std::adapter::{AdapterRequestMsg, ExecuteMsg};
     use abstract_testing::prelude::*;
-    use cosmwasm_std::{testing::*, DepsMut, MessageInfo, Response};
+    use cosmwasm_std::{testing::*, DepsMut, MessageInfo};
 
     use super::*;
     use crate::mock::{
@@ -56,9 +56,9 @@ mod tests {
         deps: DepsMut,
         env: Env,
         _info: MessageInfo,
-        module: MockAdapterContract,
+        module: &MockAdapterContract,
         _msg: MockExecMsg,
-    ) -> Result<Response, MockError> {
+    ) -> Result<Response<MockAdapterContract, MockError>, MockError> {
         let mock_api = MockApi::default();
         let expected_account = test_account(mock_api);
         // assert with test values

--- a/framework/packages/abstract-adapter/src/lib.rs
+++ b/framework/packages/abstract-adapter/src/lib.rs
@@ -105,7 +105,9 @@ pub mod mock {
 
                 Ok(Response::new().set_data("mock_init".as_bytes()))
             })
-            .with_execute(|_, _, _, _, _| Ok(Response::new().set_data("mock_exec".as_bytes())))
+            .with_execute(|_, _, _, _, _| {
+                Ok(Response::new().set_data("mock_exec".as_bytes()).into())
+            })
             .with_query(|deps, _, _, msg| match msg {
                 MockQueryMsg::GetReceivedIbcCallbackStatus {} => {
                     to_json_binary(&ReceivedIbcCallbackStatus {
@@ -120,10 +122,12 @@ pub mod mock {
                 IBC_CALLBACK_RECEIVED.save(deps.storage, &true).unwrap();
                 Ok(Response::new().set_data("mock_callback".as_bytes()))
             })
-            .with_replies(&[(1u64, |_, _, _, msg| {
+            .with_replies(&[|_, _, _, msg| {
                 #[allow(deprecated)]
-                Ok(Response::new().set_data(msg.result.unwrap().data.unwrap()))
-            })]);
+                Ok(Response::new()
+                    .set_data(msg.result.unwrap().data.unwrap())
+                    .into())
+            }]);
 
     pub type AdapterMockResult = Result<(), MockError>;
     // export these for upload usage
@@ -176,7 +180,7 @@ pub mod mock {
 
         const MOCK_ADAPTER: ::abstract_adapter::mock::MockAdapterContract = ::abstract_adapter::mock::MockAdapterContract::new($id, $version, None)
         .with_dependencies($deps)
-        .with_execute(|_, _, _, _, _| Ok(::cosmwasm_std::Response::new().set_data("mock_exec".as_bytes())));
+        .with_execute(|_, _, _, _, _| Ok(::cosmwasm_std::Response::new().set_data("mock_exec".as_bytes()).into()));
 
         fn instantiate(
             deps: ::cosmwasm_std::DepsMut,

--- a/framework/packages/abstract-app/src/endpoints/execute.rs
+++ b/framework/packages/abstract-app/src/endpoints/execute.rs
@@ -33,7 +33,8 @@ impl<
         msg: Self::ExecuteMsg,
     ) -> Result<Response, Error> {
         match msg {
-            ExecuteMsg::Module(request) => self.execute_handler()?(deps, env, info, self, request),
+            ExecuteMsg::Module(request) => self.execute_handler()?(deps, env, info, &self, request)
+                .map(|response| response.into_cosmwasm_response(self.contract())),
             ExecuteMsg::Base(exec_msg) => self
                 .base_execute(deps, env, info, exec_msg)
                 .map_err(From::from),

--- a/framework/packages/abstract-app/src/lib.rs
+++ b/framework/packages/abstract-app/src/lib.rs
@@ -128,7 +128,9 @@ pub mod mock {
                 IBC_CALLBACK_RECEIVED.save(deps.storage, &false)?;
                 Ok(Response::new().set_data("mock_init".as_bytes()))
             })
-            .with_execute(|_, _, _, _, _| Ok(Response::new().set_data("mock_exec".as_bytes())))
+            .with_execute(|_, _, _, _, _| {
+                Ok(Response::new().set_data("mock_exec".as_bytes()).into())
+            })
             .with_query(|deps, _, _, msg| match msg {
                 MockQueryMsg::GetSomething {} => {
                     to_json_binary(&MockQueryResponse {}).map_err(Into::into)
@@ -150,10 +152,12 @@ pub mod mock {
                 StaticDependency::new(TEST_MODULE_ID, &[TEST_VERSION]),
                 StaticDependency::new(IBC_CLIENT, &[abstract_std::constants::ABSTRACT_VERSION]),
             ])
-            .with_replies(&[(1u64, |_, _, _, msg| {
+            .with_replies(&[|_, _, _, msg| {
                 #[allow(deprecated)]
-                Ok(Response::new().set_data(msg.result.unwrap().data.unwrap()))
-            })])
+                Ok(Response::new()
+                    .set_data(msg.result.unwrap().data.unwrap())
+                    .into())
+            }])
             .with_migrate(|_, _, _, _| Ok(Response::new().set_data("mock_migrate".as_bytes())));
 
     crate::cw_orch_interface!(MOCK_APP_WITH_DEP, MockAppContract, MockAppWithDepI);
@@ -170,7 +174,9 @@ pub mod mock {
                 .with_instantiate(|_, _, _, _, _| {
                     Ok(Response::new().set_data("mock_init".as_bytes()))
                 })
-                .with_execute(|_, _, _, _, _| Ok(Response::new().set_data("mock_exec".as_bytes())))
+                .with_execute(|_, _, _, _, _| {
+                    Ok(Response::new().set_data("mock_exec".as_bytes()).into())
+                })
                 .with_query(|_, _, _, _| to_json_binary(&MockQueryResponse {}).map_err(Into::into));
 
         crate::cw_orch_interface!(MOCK_APP, MockAppContract, MockAppI);
@@ -283,7 +289,7 @@ pub mod mock {
                 },
                 _ => {},
             }
-            Ok(::cosmwasm_std::Response::new().set_data("mock_exec".as_bytes()))
+            Ok(::cosmwasm_std::Response::new().set_data("mock_exec".as_bytes()).into())
         })
         .with_instantiate(|deps, env, info, module, msg| {
             let mut response = ::cosmwasm_std::Response::new().set_data("mock_init".as_bytes());

--- a/framework/packages/abstract-app/src/state.rs
+++ b/framework/packages/abstract-app/src/state.rs
@@ -131,7 +131,7 @@ impl<
 
     pub const fn with_replies(
         mut self,
-        reply_handlers: &'static [(u64, ReplyHandlerFn<Self, Error>)],
+        reply_handlers: &'static [ReplyHandlerFn<Self, Error>],
     ) -> Self {
         self.contract = self.contract.with_replies([&[], reply_handlers]);
         self
@@ -169,16 +169,20 @@ mod tests {
     fn builder() {
         let app = MockAppContract::new(TEST_MODULE_ID, TEST_VERSION, None)
             .with_instantiate(|_, _, _, _, _| Ok(Response::new().set_data("mock_init".as_bytes())))
-            .with_execute(|_, _, _, _, _| Ok(Response::new().set_data("mock_exec".as_bytes())))
+            .with_execute(|_, _, _, _, _| {
+                Ok(Response::new().set_data("mock_exec".as_bytes()).into())
+            })
             .with_query(|_, _, _, _| cosmwasm_std::to_json_binary("mock_query").map_err(Into::into))
             .with_sudo(|_, _, _, _| Ok(Response::new().set_data("mock_sudo".as_bytes())))
             .with_ibc_callback(|_, _, _, _, _| {
                 Ok(Response::new().set_data("mock_callback".as_bytes()))
             })
-            .with_replies(&[(1u64, |_, _, _, msg| {
+            .with_replies(&[|_, _, _, msg| {
                 #[allow(deprecated)]
-                Ok(Response::new().set_data(msg.result.unwrap().data.unwrap()))
-            })])
+                Ok(Response::new()
+                    .set_data(msg.result.unwrap().data.unwrap())
+                    .into())
+            }])
             .with_migrate(|_, _, _, _| Ok(Response::new().set_data("mock_migrate".as_bytes())));
 
         assert_eq!(app.module_id(), TEST_MODULE_ID);

--- a/framework/packages/abstract-sdk/src/base/endpoints/reply.rs
+++ b/framework/packages/abstract-sdk/src/base/endpoints/reply.rs
@@ -8,6 +8,6 @@ pub trait ReplyEndpoint: Handler {
     fn reply(self, deps: DepsMut, env: Env, msg: Reply) -> Result<Response, Self::Error> {
         let id = msg.id;
         let handler = self.reply_handler(id)?;
-        handler(deps, env, self, msg)
+        handler(deps, env, &self, msg).map(|r| r.into_cosmwasm_response(self.contract()))
     }
 }

--- a/framework/packages/abstract-sdk/src/base/handler.rs
+++ b/framework/packages/abstract-sdk/src/base/handler.rs
@@ -155,14 +155,7 @@ where
     /// Get a reply handler if it exists.
     fn maybe_reply_handler(&self, id: u64) -> Option<ReplyHandlerFn<Self, Self::Error>> {
         let contract = self.contract();
-        for reply_handlers in contract.reply_handlers {
-            for handler in reply_handlers {
-                if handler.0 == id {
-                    return Some(handler.1);
-                }
-            }
-        }
-        None
+        return contract.reply_handlers[0].get(id as usize).cloned();
     }
     /// Get a reply handler or return an error.
     fn reply_handler(&self, id: u64) -> AbstractSdkResult<ReplyHandlerFn<Self, Self::Error>> {

--- a/framework/packages/abstract-sdk/src/base/mod.rs
+++ b/framework/packages/abstract-sdk/src/base/mod.rs
@@ -17,3 +17,6 @@ pub use endpoints::{
     MigrateEndpoint, ModuleIbcEndpoint, QueryEndpoint, ReplyEndpoint, SudoEndpoint,
 };
 pub use handler::Handler;
+
+pub mod response;
+pub mod submsg;

--- a/framework/packages/abstract-sdk/src/base/response.rs
+++ b/framework/packages/abstract-sdk/src/base/response.rs
@@ -1,0 +1,296 @@
+use std::marker::PhantomData;
+
+use cosmwasm_std::Binary;
+
+use cosmwasm_std::{Attribute, CosmosMsg, Empty, Event};
+
+use crate::AbstractSdkError;
+
+use super::submsg::SubMsg;
+use super::{AbstractContract, Handler};
+/// A response of a contract entry point, such as `instantiate`, `execute` or `migrate`.
+///
+/// This type can be constructed directly at the end of the call. Alternatively a
+/// mutable response instance can be created early in the contract's logic and
+/// incrementally be updated.
+///
+/// ## Examples
+///
+/// Direct:
+///
+/// ```
+/// # use cosmwasm_std::{Binary, DepsMut, Env, MessageInfo};
+/// # type InstantiateMsg = ();
+/// #
+/// use cosmwasm_std::{attr, Response, StdResult};
+///
+/// pub fn instantiate(
+///     deps: DepsMut,
+///     _env: Env,
+///     _info: MessageInfo,
+///     msg: InstantiateMsg,
+/// ) -> StdResult<Response> {
+///     // ...
+///
+///     Ok(Response::new().add_attribute("action", "instantiate"))
+/// }
+/// ```
+///
+/// Mutating:
+///
+/// ```
+/// # use cosmwasm_std::{coins, BankMsg, Binary, DepsMut, Env, MessageInfo, SubMsg};
+/// # type InstantiateMsg = ();
+/// # type MyError = ();
+/// #
+/// use cosmwasm_std::Response;
+///
+/// pub fn instantiate(
+///     deps: DepsMut,
+///     _env: Env,
+///     info: MessageInfo,
+///     msg: InstantiateMsg,
+/// ) -> Result<Response, MyError> {
+///     let mut response = Response::new()
+///         .add_attribute("Let the", "hacking begin")
+///         .add_message(BankMsg::Send {
+///             to_address: String::from("recipient"),
+///             amount: coins(128, "uint"),
+///         })
+///         .add_attribute("foo", "bar")
+///         .set_data(b"the result data");
+///     Ok(response)
+/// }
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct Response<Module, Error, T = Empty> {
+    /// Optional list of messages to pass. These will be executed in order.
+    /// If the ReplyOn variant matches the result (Always, Success on Ok, Error on Err),
+    /// the runtime will invoke this contract's `reply` entry point
+    /// after execution. Otherwise, they act like "fire and forget".
+    /// Use `SubMsg::new` to create messages with the older "fire and forget" semantics.
+    pub messages: Vec<SubMsg<Module, Error, T>>,
+    /// The attributes that will be emitted as part of a "wasm" event.
+    ///
+    /// More info about events (and their attributes) can be found in [*Cosmos SDK* docs].
+    ///
+    /// [*Cosmos SDK* docs]: https://docs.cosmos.network/main/learn/advanced/events
+    pub attributes: Vec<Attribute>,
+    /// Extra, custom events separate from the main `wasm` one. These will have
+    /// `wasm-` prepended to the type.
+    ///
+    /// More info about events can be found in [*Cosmos SDK* docs].
+    ///
+    /// [*Cosmos SDK* docs]: https://docs.cosmos.network/main/learn/advanced/events
+    pub events: Vec<Event>,
+    /// The binary payload to include in the response.
+    pub data: Option<Binary>,
+
+    pub ph: PhantomData<Module>,
+}
+
+impl<Module, Error, T> Default for Response<Module, Error, T> {
+    fn default() -> Self {
+        Response {
+            messages: vec![],
+            attributes: vec![],
+            events: vec![],
+            data: None,
+            ph: Default::default(),
+        }
+    }
+}
+
+impl<Module, Error, T> Response<Module, Error, T> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add an attribute included in the main `wasm` event.
+    ///
+    /// For working with optional values or optional attributes, see [`add_attributes`][Self::add_attributes].
+    pub fn add_attribute(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.attributes.push(Attribute::new(key, value));
+        self
+    }
+
+    /// This creates a "fire and forget" message, by using `SubMsg::new()` to wrap it,
+    /// and adds it to the list of messages to process.
+    pub fn add_message(mut self, msg: impl Into<CosmosMsg<T>>) -> Self {
+        self.messages.push(SubMsg::new(msg));
+        self
+    }
+
+    /// This takes an explicit SubMsg (creates via eg. `reply_on_error`)
+    /// and adds it to the list of messages to process.
+    pub fn add_submessage(mut self, msg: SubMsg<Module, Error, T>) -> Self {
+        self.messages.push(msg);
+        self
+    }
+
+    /// Adds an extra event to the response, separate from the main `wasm` event
+    /// that is always created.
+    ///
+    /// The `wasm-` prefix will be appended by the runtime to the provided type
+    /// of event.
+    pub fn add_event(mut self, event: impl Into<Event>) -> Self {
+        self.events.push(event.into());
+        self
+    }
+
+    /// Bulk add attributes included in the main `wasm` event.
+    ///
+    /// Anything that can be turned into an iterator and yields something
+    /// that can be converted into an `Attribute` is accepted.
+    ///
+    /// ## Examples
+    ///
+    /// Adding a list of attributes using the pair notation for key and value:
+    ///
+    /// ```
+    /// use cosmwasm_std::Response;
+    ///
+    /// let attrs = vec![
+    ///     ("action", "reaction"),
+    ///     ("answer", "42"),
+    ///     ("another", "attribute"),
+    /// ];
+    /// let res: Response = Response::new().add_attributes(attrs.clone());
+    /// assert_eq!(res.attributes, attrs);
+    /// ```
+    ///
+    /// Adding an optional value as an optional attribute by turning it into a list of 0 or 1 elements:
+    ///
+    /// ```
+    /// use cosmwasm_std::{Attribute, Response};
+    ///
+    /// // Some value
+    /// let value: Option<String> = Some("sarah".to_string());
+    /// let attribute: Option<Attribute> = value.map(|v| Attribute::new("winner", v));
+    /// let res: Response = Response::new().add_attributes(attribute);
+    /// assert_eq!(res.attributes, [Attribute {
+    ///     key: "winner".to_string(),
+    ///     value: "sarah".to_string(),
+    /// }]);
+    ///
+    /// // No value
+    /// let value: Option<String> = None;
+    /// let attribute: Option<Attribute> = value.map(|v| Attribute::new("winner", v));
+    /// let res: Response = Response::new().add_attributes(attribute);
+    /// assert_eq!(res.attributes.len(), 0);
+    /// ```
+    pub fn add_attributes<A: Into<Attribute>>(
+        mut self,
+        attrs: impl IntoIterator<Item = A>,
+    ) -> Self {
+        self.attributes.extend(attrs.into_iter().map(A::into));
+        self
+    }
+
+    /// Bulk add "fire and forget" messages to the list of messages to process.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use cosmwasm_std::{CosmosMsg, Response};
+    ///
+    /// fn make_response_with_msgs(msgs: Vec<CosmosMsg>) -> Response {
+    ///     Response::new().add_messages(msgs)
+    /// }
+    /// ```
+    pub fn add_messages<M: Into<CosmosMsg<T>>>(self, msgs: impl IntoIterator<Item = M>) -> Self {
+        self.add_submessages(msgs.into_iter().map(SubMsg::new))
+    }
+
+    /// Bulk add explicit SubMsg structs to the list of messages to process.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use cosmwasm_std::{SubMsg, Response};
+    ///
+    /// fn make_response_with_submsgs(msgs: Vec<SubMsg>) -> Response {
+    ///     Response::new().add_submessages(msgs)
+    /// }
+    /// ```
+    pub fn add_submessages(
+        mut self,
+        msgs: impl IntoIterator<Item = SubMsg<Module, Error, T>>,
+    ) -> Self {
+        self.messages.extend(msgs);
+        self
+    }
+
+    /// Bulk add custom events to the response. These are separate from the main
+    /// `wasm` event.
+    ///
+    /// The `wasm-` prefix will be appended by the runtime to the provided types
+    /// of events.
+    pub fn add_events<E>(mut self, events: impl IntoIterator<Item = E>) -> Self
+    where
+        E: Into<Event>,
+    {
+        self.events.extend(events.into_iter().map(|e| e.into()));
+        self
+    }
+
+    /// Set the binary data included in the response.
+    pub fn set_data(mut self, data: impl Into<Binary>) -> Self {
+        self.data = Some(data.into());
+        self
+    }
+}
+
+impl<Module: Handler + 'static, Error: From<AbstractSdkError> + 'static> Response<Module, Error> {
+    pub fn into_cosmwasm_response(
+        self,
+        contract: &AbstractContract<Module, Error>,
+    ) -> cosmwasm_std::Response {
+        let mut response = cosmwasm_std::Response::new();
+
+        if let Some(data) = self.data {
+            response = response.set_data(data)
+        }
+        response
+            .add_attributes(self.attributes)
+            .add_events(self.events)
+            .add_submessages(self.messages.into_iter().map(|m| {
+                const UNUSED_MSG_ID: usize = 0;
+                let id = m
+                    .reply_func
+                    .and_then(|func| {
+                        contract.reply_handlers[0]
+                            .iter()
+                            .position(|reply| reply == &func)
+                    })
+                    .unwrap_or(UNUSED_MSG_ID) as u64;
+                cosmwasm_std::SubMsg {
+                    id,
+                    payload: m.payload,
+                    msg: m.msg,
+                    gas_limit: m.gas_limit,
+                    reply_on: m.reply_on,
+                }
+            }))
+    }
+}
+
+impl<Module, Error> From<cosmwasm_std::Response> for Response<Module, Error> {
+    fn from(value: cosmwasm_std::Response) -> Self {
+        let mut response = Response::new();
+        if let Some(data) = value.data {
+            response = response.set_data(data)
+        }
+        response
+            .add_submessages(value.messages.into_iter().map(|m| SubMsg {
+                reply_func: None,
+                payload: m.payload,
+                msg: m.msg,
+                gas_limit: m.gas_limit,
+                reply_on: cosmwasm_std::ReplyOn::Never,
+            }))
+            .add_attributes(value.attributes)
+            .add_events(value.events)
+    }
+}

--- a/framework/packages/abstract-sdk/src/base/submsg.rs
+++ b/framework/packages/abstract-sdk/src/base/submsg.rs
@@ -1,0 +1,140 @@
+use cosmwasm_std::{Binary, CosmosMsg, DepsMut, Empty, Env, Reply, ReplyOn};
+
+use super::response::Response;
+
+pub type ReplyFunc<Module, Error, T> =
+    fn(DepsMut, Env, &Module, Reply) -> Result<Response<Module, Error, T>, Error>;
+
+/// A submessage that will guarantee a `reply` call on success or error, depending on
+/// the `reply_on` setting. If you do not need to process the result, use regular messages instead.
+///
+/// Note: On error the submessage execution will revert any partial state changes due to this message,
+/// but not revert any state changes in the calling contract. If this is required, it must be done
+/// manually in the `reply` entry point.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SubMsg<Module, Error, T = Empty> {
+    /// An arbitrary ID chosen by the contract.
+    /// This is typically used to match `Reply`s in the `reply` entry point to the submessage.
+    pub reply_func: Option<ReplyFunc<Module, Error, T>>,
+    /// Some arbitrary data that the contract can set in an application specific way.
+    /// This is just passed into the `reply` entry point and is not stored to state.
+    /// Any encoding can be used. If `id` is used to identify a particular action,
+    /// the encoding can also be different for each of those actions since you can match `id`
+    /// first and then start processing the `payload`.
+    ///
+    /// The environment restricts the length of this field in order to avoid abuse. The limit
+    /// is environment specific and can change over time. The initial default is 128 KiB.
+    ///
+    /// Unset/nil/null cannot be differentiated from empty data.
+    ///
+    /// On chains running CosmWasm 1.x this field will be ignored.
+    pub payload: Binary,
+    pub msg: CosmosMsg<T>,
+    /// Gas limit measured in [Cosmos SDK gas](https://github.com/CosmWasm/cosmwasm/blob/main/docs/GAS.md).
+    ///
+    /// Setting this to `None` means unlimited. Then the submessage execution can consume all gas of the
+    /// current execution context.
+    pub gas_limit: Option<u64>,
+    pub reply_on: ReplyOn,
+}
+
+impl<Module, Error, T> SubMsg<Module, Error, T> {
+    /// Creates a "fire and forget" message with the pre-0.14 semantics.
+    /// Since this is just an alias for [`SubMsg::reply_never`] it is somewhat recommended
+    /// to use the latter in order to make the behaviour more explicit in the caller code.
+    /// But that's up to you for now.
+    ///
+    /// By default, the submessage's gas limit will be unlimited. Use [`SubMsg::with_gas_limit`] to change it.
+    /// Setting `payload` is not advised as this will never be used.
+    pub fn new(msg: impl Into<CosmosMsg<T>>) -> Self {
+        Self::reply_never(msg)
+    }
+
+    /// Creates a `SubMsg` that will provide a `reply` with the given `id` if the message returns `Ok`.
+    ///
+    /// By default, the submessage's `payload` will be empty and the gas limit will be unlimited. Use
+    /// [`SubMsg::with_payload`] and [`SubMsg::with_gas_limit`] to change those.
+    pub fn reply_on_success(msg: impl Into<CosmosMsg<T>>, id: ReplyFunc<Module, Error, T>) -> Self {
+        Self::reply_on(msg.into(), id, ReplyOn::Success)
+    }
+
+    /// Creates a `SubMsg` that will provide a `reply` with the given `id` if the message returns `Err`.
+    ///
+    /// By default, the submessage's `payload` will be empty and the gas limit will be unlimited. Use
+    /// [`SubMsg::with_payload`] and [`SubMsg::with_gas_limit`] to change those.
+    pub fn reply_on_error(msg: impl Into<CosmosMsg<T>>, id: ReplyFunc<Module, Error, T>) -> Self {
+        Self::reply_on(msg.into(), id, ReplyOn::Error)
+    }
+
+    /// Create a `SubMsg` that will always provide a `reply` with the given `id`.
+    ///
+    /// By default, the submessage's `payload` will be empty and the gas limit will be unlimited. Use
+    /// [`SubMsg::with_payload`] and [`SubMsg::with_gas_limit`] to change those.
+    pub fn reply_always(msg: impl Into<CosmosMsg<T>>, id: ReplyFunc<Module, Error, T>) -> Self {
+        Self::reply_on(msg.into(), id, ReplyOn::Always)
+    }
+
+    /// Create a `SubMsg` that will never `reply`. This is equivalent to standard message semantics.
+    ///
+    /// By default, the submessage's gas limit will be unlimited. Use [`SubMsg::with_gas_limit`] to change it.
+    /// Setting `payload` is not advised as this will never be used.
+    pub fn reply_never(msg: impl Into<CosmosMsg<T>>) -> Self {
+        SubMsg {
+            reply_func: None,
+            payload: Default::default(),
+            msg: msg.into(),
+            reply_on: ReplyOn::Never,
+            gas_limit: None,
+        }
+    }
+
+    /// Add a gas limit to the submessage.
+    /// This gas limit measured in [Cosmos SDK gas](https://github.com/CosmWasm/cosmwasm/blob/main/docs/GAS.md).
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// # use cosmwasm_std::{coins, BankMsg, ReplyOn, SubMsg};
+    /// # let msg = BankMsg::Send { to_address: String::from("you"), amount: coins(1015, "earth") };
+    /// let sub_msg: SubMsg = SubMsg::reply_always(msg, 1234).with_gas_limit(60_000);
+    /// assert_eq!(sub_msg.id, 1234);
+    /// assert_eq!(sub_msg.gas_limit, Some(60_000));
+    /// assert_eq!(sub_msg.reply_on, ReplyOn::Always);
+    /// ```
+    pub fn with_gas_limit(mut self, limit: u64) -> Self {
+        self.gas_limit = Some(limit);
+        self
+    }
+
+    /// Add a payload to the submessage.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// # use cosmwasm_std::{coins, BankMsg, Binary, ReplyOn, SubMsg};
+    /// # let msg = BankMsg::Send { to_address: String::from("you"), amount: coins(1015, "earth") };
+    /// let sub_msg: SubMsg = SubMsg::reply_always(msg, 1234)
+    ///     .with_payload(vec![1, 2, 3, 4]);
+    /// assert_eq!(sub_msg.id, 1234);
+    /// assert_eq!(sub_msg.payload, Binary::new(vec![1, 2, 3, 4]));
+    /// assert_eq!(sub_msg.reply_on, ReplyOn::Always);
+    /// ```
+    pub fn with_payload(mut self, payload: impl Into<Binary>) -> Self {
+        self.payload = payload.into();
+        self
+    }
+
+    fn reply_on(
+        msg: CosmosMsg<T>,
+        reply_func: ReplyFunc<Module, Error, T>,
+        reply_on: ReplyOn,
+    ) -> Self {
+        SubMsg {
+            reply_func: Some(reply_func),
+            payload: Default::default(),
+            msg,
+            reply_on,
+            gas_limit: None,
+        }
+    }
+}


### PR DESCRIPTION
This PR aims at removing the reply ids all-together from the Abstract Framework. 
The rationale behind that is that they are hard to manage, easy to miss and difficult to maintain.
Instead, the user will register the replies to a specific endpoint by returning the following new structure inside their endpoints: 
```rust
// Old 
// SubMsg::reply_always(cosmos_msg, REPLY_ID)
// New
SubMsg::reply_always(cosmos_msg, reply_func)
``` 

In addition, they will need to register `reply_func` with the `App` object for the rust engine to be able to match it and call it accordingly. 

This allows for code to be easier to read (register a callback function instead of a random ID) and less error-prone.
We could also use this concept for IBC Callbacks 

### Checklist

- [ ] CI is green.
- [ ] Changelog updated.
