### PR TITLE
Remove funds from IBC client SendFunds

### DIFF
--- a/framework/contracts/account/src/execution.rs
+++ b/framework/contracts/account/src/execution.rs
@@ -341,7 +341,6 @@ mod test {
                 module_id: IBC_CLIENT.to_owned(),
                 exec_msg: to_json_binary(&abstract_std::ibc_client::ExecuteMsg::SendFunds {
                     host_chain: "juno".parse()?,
-                    funds: funds.clone(),
                     memo: None,
                 })?,
                 funds: funds.clone(),
@@ -387,7 +386,6 @@ mod test {
                     contract_addr: ibc_client_addr.into(),
                     msg: to_json_binary(&abstract_std::ibc_client::ExecuteMsg::SendFunds {
                         host_chain: "juno".parse()?,
-                        funds: funds.clone(),
                         memo: None,
                     })?,
                     funds,

--- a/framework/contracts/native/ibc-client/src/commands.rs
+++ b/framework/contracts/native/ibc-client/src/commands.rs
@@ -371,7 +371,6 @@ pub fn execute_send_funds(
     env: Env,
     info: MessageInfo,
     host_chain: TruncatedChainId,
-    funds: Vec<Coin>,
     memo: Option<String>,
 ) -> IbcClientResult {
     host_chain.verify()?;
@@ -397,7 +396,7 @@ pub fn execute_send_funds(
     let ics20_channel_id = ics20_channel_entry.resolve(&deps.querier, &ans)?;
 
     let mut transfers: Vec<CosmosMsg> = vec![];
-    for coin in funds {
+    for coin in info.funds.into_iter() {
         // construct a packet to send
 
         let ics_20_send = _ics_20_send_msg(

--- a/framework/contracts/native/ibc-client/src/commands.rs
+++ b/framework/contracts/native/ibc-client/src/commands.rs
@@ -396,7 +396,7 @@ pub fn execute_send_funds(
     let ics20_channel_id = ics20_channel_entry.resolve(&deps.querier, &ans)?;
 
     let mut transfers: Vec<CosmosMsg> = vec![];
-    for coin in info.funds.into_iter() {
+    for coin in info.funds {
         // construct a packet to send
 
         let ics_20_send = _ics_20_send_msg(

--- a/framework/contracts/native/ibc-client/src/contract.rs
+++ b/framework/contracts/native/ibc-client/src/contract.rs
@@ -49,12 +49,9 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> I
         ExecuteMsg::RegisterInfrastructure { chain, note, host } => {
             commands::execute_register_infrastructure(deps, env, info, chain, host, note)
         }
-        ExecuteMsg::SendFunds {
-            host_chain,
-            funds,
-            memo,
-        } => commands::execute_send_funds(deps, env, info, host_chain, funds, memo)
-            .map_err(Into::into),
+        ExecuteMsg::SendFunds { host_chain, memo } => {
+            commands::execute_send_funds(deps, env, info, host_chain, memo).map_err(Into::into)
+        }
         ExecuteMsg::Register {
             host_chain,
             namespace,
@@ -113,7 +110,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> IbcClientResult<QueryRespon
         QueryMsg::ListIbcInfrastructures {} => {
             to_json_binary(&queries::list_ibc_counterparts(deps)?)
         }
-        QueryMsg::ListRemoteProxiesByAccountId { account_id } => {
+        QueryMsg::ListRemoteAccountsByAccountId { account_id } => {
             to_json_binary(&queries::list_proxies_by_account_id(deps, account_id)?)
         }
     }
@@ -426,12 +423,12 @@ mod tests {
             let hosts = remote_hosts_response.hosts;
             assert_eq!(vec![(chain_name.clone(), host)], hosts);
 
-            let remote_proxies_response: ListRemoteProxiesResponse = from_json(query(
+            let remote_proxies_response: ListRemoteAccountsResponse = from_json(query(
                 deps.as_ref(),
                 mock_env_validated(deps.api),
                 QueryMsg::ListRemoteProxies {},
             )?)?;
-            let hosts = remote_proxies_response.proxies;
+            let hosts = remote_proxies_response.accounts;
             assert_eq!(vec![(chain_name.clone(), None)], hosts);
 
             let ibc_infratructures_response: ListIbcInfrastructureResponse = from_json(query(
@@ -606,7 +603,7 @@ mod tests {
             objects::{registry::RegistryError, ChannelEntry, TruncatedChainId},
             ICS20,
         };
-        use cosmwasm_std::{coins, Binary, CosmosMsg, IbcMsg};
+        use cosmwasm_std::{coin, coins, Binary, CosmosMsg, IbcMsg};
         use prost::Name;
         use std::str::FromStr;
 
@@ -631,7 +628,6 @@ mod tests {
 
             let msg = ExecuteMsg::SendFunds {
                 host_chain: chain_name,
-                funds: coins(1, "denom"),
                 memo: None,
             };
 
@@ -673,11 +669,11 @@ mod tests {
 
             let msg = ExecuteMsg::SendFunds {
                 host_chain: chain_name.clone(),
-                funds: funds.clone(),
                 memo: None,
             };
 
-            let res = execute_as(&mut deps, account.addr(), msg)?;
+            let env = mock_env_validated(deps.api);
+            let res = execute(deps.as_mut(), env, message_info(account.addr(), &funds.clone()), msg)?;
 
             let transfer_msgs: Vec<CosmosMsg> = funds
                 .into_iter()
@@ -707,7 +703,6 @@ mod tests {
 
             let msg = ExecuteMsg::SendFunds {
                 host_chain: chain_name,
-                funds: funds.clone(),
                 memo: memo.clone(),
             };
 
@@ -1315,17 +1310,17 @@ mod tests {
                 accounts_response
             );
 
-            let proxies_response: ListRemoteProxiesResponse = from_json(query(
+            let proxies_response: ListRemoteAccountsResponse = from_json(query(
                 deps.as_ref(),
                 mock_env_validated(deps.api),
-                QueryMsg::ListRemoteProxiesByAccountId {
+                QueryMsg::ListRemoteAccountsByAccountId {
                     account_id: TEST_ACCOUNT_ID,
                 },
             )?)?;
 
             assert_eq!(
-                ListRemoteProxiesResponse {
-                    proxies: vec![(chain_name, Some(remote_account))]
+                ListRemoteAccountsResponse {
+                    accounts: vec![(chain_name, Some(remote_account))]
                 },
                 proxies_response
             );
@@ -1356,17 +1351,17 @@ mod tests {
             ACCOUNTS.save(deps.as_mut().storage, (&trace, seq, &chain1), &account1)?;
             ACCOUNTS.save(deps.as_mut().storage, (&trace, seq, &chain2), &account2)?;
 
-            let proxies_response: ListRemoteProxiesResponse = from_json(query(
+            let proxies_response: ListRemoteAccountsResponse = from_json(query(
                 deps.as_ref(),
                 mock_env_validated(deps.api),
-                QueryMsg::ListRemoteProxiesByAccountId {
+                QueryMsg::ListRemoteAccountsByAccountId {
                     account_id: TEST_ACCOUNT_ID,
                 },
             )?)?;
 
             assert_eq!(
-                ListRemoteProxiesResponse {
-                    proxies: vec![(chain1, Some(account1)), (chain2, Some(account2))]
+                ListRemoteAccountsResponse {
+                    accounts: vec![(chain1, Some(account1)), (chain2, Some(account2))]
                 },
                 proxies_response
             );
@@ -1406,15 +1401,15 @@ mod tests {
                 &archway_account,
             )?;
 
-            let proxies_response: ListRemoteProxiesResponse = from_json(query(
+            let proxies_response: ListRemoteAccountsResponse = from_json(query(
                 deps.as_ref(),
                 mock_env_validated(deps.api),
-                QueryMsg::ListRemoteProxiesByAccountId { account_id },
+                QueryMsg::ListRemoteAccountsByAccountId { account_id },
             )?)?;
 
             assert_eq!(
-                ListRemoteProxiesResponse {
-                    proxies: vec![
+                ListRemoteAccountsResponse {
+                    accounts: vec![
                         (archway_chain, Some(archway_account)),
                         (terra_chain, Some(terra_account)),
                     ]

--- a/framework/contracts/native/ibc-client/src/contract.rs
+++ b/framework/contracts/native/ibc-client/src/contract.rs
@@ -673,7 +673,12 @@ mod tests {
             };
 
             let env = mock_env_validated(deps.api);
-            let res = execute(deps.as_mut(), env, message_info(account.addr(), &funds.clone()), msg)?;
+            let res = execute(
+                deps.as_mut(),
+                env,
+                message_info(account.addr(), &funds.clone()),
+                msg,
+            )?;
 
             let transfer_msgs: Vec<CosmosMsg> = funds
                 .into_iter()

--- a/framework/contracts/native/ibc-client/src/contract.rs
+++ b/framework/contracts/native/ibc-client/src/contract.rs
@@ -144,7 +144,7 @@ mod tests {
     use cosmwasm_std::{
         from_json,
         testing::{message_info, mock_dependencies},
-        Addr,
+        Addr, Coin,
     };
     use cw2::CONTRACT;
     use cw_ownable::{Ownership, OwnershipError};
@@ -155,6 +155,16 @@ mod tests {
     fn execute_as(deps: &mut MockDeps, sender: &Addr, msg: ExecuteMsg) -> IbcClientResult {
         let env = mock_env_validated(deps.api);
         execute(deps.as_mut(), env, message_info(sender, &[]), msg)
+    }
+
+    fn execute_as_funds(
+        deps: &mut MockDeps,
+        sender: &Addr,
+        msg: ExecuteMsg,
+        funds: &[Coin],
+    ) -> IbcClientResult {
+        let env = mock_env_validated(deps.api);
+        execute(deps.as_mut(), env, message_info(sender, funds), msg)
     }
 
     fn test_only_admin(msg: ExecuteMsg) -> IbcClientTestResult {
@@ -603,7 +613,7 @@ mod tests {
             objects::{registry::RegistryError, ChannelEntry, TruncatedChainId},
             ICS20,
         };
-        use cosmwasm_std::{coin, coins, Binary, CosmosMsg, IbcMsg};
+        use cosmwasm_std::{coins, Binary, CosmosMsg, IbcMsg};
         use prost::Name;
         use std::str::FromStr;
 
@@ -672,13 +682,7 @@ mod tests {
                 memo: None,
             };
 
-            let env = mock_env_validated(deps.api);
-            let res = execute(
-                deps.as_mut(),
-                env,
-                message_info(account.addr(), &funds.clone()),
-                msg,
-            )?;
+            let res = execute_as_funds(&mut deps, account.addr(), msg, &funds)?;
 
             let transfer_msgs: Vec<CosmosMsg> = funds
                 .into_iter()
@@ -711,7 +715,7 @@ mod tests {
                 memo: memo.clone(),
             };
 
-            let res = execute_as(&mut deps, account.addr(), msg)?;
+            let res = execute_as_funds(&mut deps, account.addr(), msg, &funds)?;
 
             use prost::Message;
             #[allow(deprecated)]

--- a/framework/contracts/native/ibc-client/src/queries.rs
+++ b/framework/contracts/native/ibc-client/src/queries.rs
@@ -5,7 +5,7 @@ use abstract_std::{
     ibc_client::{
         state::{ACCOUNTS, IBC_INFRA},
         AccountResponse, ConfigResponse, HostResponse, ListAccountsResponse,
-        ListIbcInfrastructureResponse, ListRemoteHostsResponse, ListRemoteProxiesResponse,
+        ListIbcInfrastructureResponse, ListRemoteHostsResponse, ListRemoteAccountsResponse,
     },
     objects::{
         account::{AccountSequence, AccountTrace},
@@ -50,7 +50,7 @@ pub fn list_accounts(
 pub fn list_proxies_by_account_id(
     deps: Deps,
     account_id: AccountId,
-) -> IbcClientResult<ListRemoteProxiesResponse> {
+) -> IbcClientResult<ListRemoteAccountsResponse> {
     let proxies: Vec<(abstract_std::objects::TruncatedChainId, Option<String>)> =
         cw_paginate::paginate_map_prefix(
             &ACCOUNTS,
@@ -62,7 +62,7 @@ pub fn list_proxies_by_account_id(
             |chain, account| Ok::<_, StdError>((chain, Some(account))),
         )?;
 
-    Ok(ListRemoteProxiesResponse { proxies })
+    Ok(ListRemoteAccountsResponse { accounts: proxies })
 }
 
 // No need for pagination here, not a lot of chains
@@ -75,12 +75,12 @@ pub fn list_remote_hosts(deps: Deps) -> IbcClientResult<ListRemoteHostsResponse>
 }
 
 // No need for pagination here, not a lot of chains
-pub fn list_remote_proxies(deps: Deps) -> IbcClientResult<ListRemoteProxiesResponse> {
+pub fn list_remote_proxies(deps: Deps) -> IbcClientResult<ListRemoteAccountsResponse> {
     let proxies = IBC_INFRA
         .range(deps.storage, None, None, Order::Ascending)
         .map(|c| c.map(|(chain, counterpart)| (chain, counterpart.remote_proxy)))
         .collect::<StdResult<_>>()?;
-    Ok(ListRemoteProxiesResponse { proxies })
+    Ok(ListRemoteAccountsResponse { accounts: proxies })
 }
 
 // No need for pagination here, not a lot of chains

--- a/framework/contracts/native/ibc-client/src/queries.rs
+++ b/framework/contracts/native/ibc-client/src/queries.rs
@@ -5,7 +5,7 @@ use abstract_std::{
     ibc_client::{
         state::{ACCOUNTS, IBC_INFRA},
         AccountResponse, ConfigResponse, HostResponse, ListAccountsResponse,
-        ListIbcInfrastructureResponse, ListRemoteHostsResponse, ListRemoteAccountsResponse,
+        ListIbcInfrastructureResponse, ListRemoteAccountsResponse, ListRemoteHostsResponse,
     },
     objects::{
         account::{AccountSequence, AccountTrace},

--- a/framework/packages/abstract-client/src/interchain/remote_account.rs
+++ b/framework/packages/abstract-client/src/interchain/remote_account.rs
@@ -351,12 +351,15 @@ impl<Chain: IbcQueryHandler, IBC: InterchainEnv<Chain>> RemoteAccount<Chain, IBC
                     .map_err(Into::<CwOrchError>::into)?,
             ),
         )];
-        self.ibc_client_execute(ibc_client::ExecuteMsg::RemoteAction {
-            host_chain: self.host_chain_id(),
-            action: ibc_host::HostAction::Dispatch {
-                account_msgs: vec![account::ExecuteMsg::Upgrade { modules }],
+        self.ibc_client_execute(
+            ibc_client::ExecuteMsg::RemoteAction {
+                host_chain: self.host_chain_id(),
+                action: ibc_host::HostAction::Dispatch {
+                    account_msgs: vec![account::ExecuteMsg::Upgrade { modules }],
+                },
             },
-        }, vec![])
+            vec![],
+        )
     }
 
     /// Returns owner of the account
@@ -391,10 +394,13 @@ impl<Chain: IbcQueryHandler, IBC: InterchainEnv<Chain>> RemoteAccount<Chain, IBC
         &self,
         account_msgs: Vec<account::ExecuteMsg>,
     ) -> AbstractClientResult<IbcTxAnalysisV2<Chain>> {
-        self.ibc_client_execute(ibc_client::ExecuteMsg::RemoteAction {
-            host_chain: self.host_chain_id(),
-            action: ibc_host::HostAction::Dispatch { account_msgs },
-        }, vec![])
+        self.ibc_client_execute(
+            ibc_client::ExecuteMsg::RemoteAction {
+                host_chain: self.host_chain_id(),
+                action: ibc_host::HostAction::Dispatch { account_msgs },
+            },
+            vec![],
+        )
     }
 
     /// Queries a module on the account.
@@ -511,12 +517,15 @@ impl<Chain: IbcQueryHandler, IBC: InterchainEnv<Chain>> RemoteAccount<Chain, IBC
         &self,
         modules: Vec<ModuleInstallConfig>,
     ) -> AbstractClientResult<RemoteApplication<Chain, IBC, M>> {
-        let _ = self.ibc_client_execute(ibc_client::ExecuteMsg::RemoteAction {
-            host_chain: self.host_chain_id(),
-            action: ibc_host::HostAction::Dispatch {
-                account_msgs: vec![account::ExecuteMsg::InstallModules { modules }],
+        let _ = self.ibc_client_execute(
+            ibc_client::ExecuteMsg::RemoteAction {
+                host_chain: self.host_chain_id(),
+                action: ibc_host::HostAction::Dispatch {
+                    account_msgs: vec![account::ExecuteMsg::InstallModules { modules }],
+                },
             },
-        }, vec![])?;
+            vec![],
+        )?;
 
         let module = self.module()?;
         RemoteApplication::new(self.clone(), module)

--- a/framework/packages/abstract-client/src/interchain/remote_application.rs
+++ b/framework/packages/abstract-client/src/interchain/remote_application.rs
@@ -59,7 +59,7 @@ impl<
                         funds,
                     }],
                 },
-            })
+            }, vec![])
     }
 
     /// Queries request on  application
@@ -110,7 +110,7 @@ impl<Chain: IbcQueryHandler, IBC: InterchainEnv<Chain>, M: ContractInstance<Chai
             .ibc_client_execute(ibc_client::ExecuteMsg::RemoteAction {
                 host_chain: self.remote_account.host_chain_id(),
                 action: ibc_host::HostAction::Dispatch { account_msgs },
-            })?;
+            }, vec![])?;
         Ok(())
     }
 }

--- a/framework/packages/abstract-client/src/interchain/remote_application.rs
+++ b/framework/packages/abstract-client/src/interchain/remote_application.rs
@@ -49,8 +49,8 @@ impl<
         execute: &M::ExecuteMsg,
         funds: Vec<Coin>,
     ) -> AbstractClientResult<IbcTxAnalysisV2<Chain>> {
-        self.remote_account
-            .ibc_client_execute(ibc_client::ExecuteMsg::RemoteAction {
+        self.remote_account.ibc_client_execute(
+            ibc_client::ExecuteMsg::RemoteAction {
                 host_chain: self.remote_account.host_chain_id(),
                 action: ibc_host::HostAction::Dispatch {
                     account_msgs: vec![account::ExecuteMsg::ExecuteOnModule {
@@ -59,7 +59,9 @@ impl<
                         funds,
                     }],
                 },
-            }, vec![])
+            },
+            vec![],
+        )
     }
 
     /// Queries request on  application
@@ -105,12 +107,13 @@ impl<Chain: IbcQueryHandler, IBC: InterchainEnv<Chain>, M: ContractInstance<Chai
             })
         }
 
-        let _ = self
-            .remote_account
-            .ibc_client_execute(ibc_client::ExecuteMsg::RemoteAction {
+        let _ = self.remote_account.ibc_client_execute(
+            ibc_client::ExecuteMsg::RemoteAction {
                 host_chain: self.remote_account.host_chain_id(),
                 action: ibc_host::HostAction::Dispatch { account_msgs },
-            }, vec![])?;
+            },
+            vec![],
+        )?;
         Ok(())
     }
 }

--- a/framework/packages/abstract-interface/src/ibc.rs
+++ b/framework/packages/abstract-interface/src/ibc.rs
@@ -1,4 +1,4 @@
-use crate::{Abstract, AbstractInterfaceError, IbcClient, IbcHost, Registry};
+use crate::{AbstractInterfaceError, IbcClient, IbcHost, Registry};
 use abstract_std::{IBC_CLIENT, IBC_HOST};
 use cw_orch::prelude::*;
 pub struct AbstractIbc<Chain: CwEnv> {
@@ -51,6 +51,8 @@ impl<Chain: CwEnv> AbstractIbc<Chain> {
 #[cfg(feature = "interchain")]
 // Helpers to create connection with another chain
 pub mod connection {
+    use crate::Abstract;
+
     use super::*;
     use abstract_std::ibc_client::ExecuteMsgFns as _;
     use abstract_std::ibc_client::QueryMsgFns;

--- a/framework/packages/abstract-sdk/src/apis/ibc.rs
+++ b/framework/packages/abstract-sdk/src/apis/ibc.rs
@@ -265,14 +265,7 @@ impl<'a, T: IbcInterface + AccountExecutor> IbcClient<'a, T> {
         funds: Vec<Coin>,
         memo: Option<String>,
     ) -> AbstractSdkResult<CosmosMsg> {
-        self.execute(
-            &IbcClientMsg::SendFunds {
-                host_chain,
-                funds: funds.clone(),
-                memo,
-            },
-            funds,
-        )
+        self.execute(&IbcClientMsg::SendFunds { host_chain, memo }, funds)
     }
 
     /// A simple helper to install an app on an account
@@ -428,7 +421,6 @@ mod test {
                 module_id: IBC_CLIENT.to_owned(),
                 exec_msg: to_json_binary(&IbcClientMsg::SendFunds {
                     host_chain: TEST_HOST_CHAIN.parse().unwrap(),
-                    funds: expected_funds.clone(),
                     memo: None,
                 })
                 .unwrap(),

--- a/framework/packages/abstract-std/src/native/ibc/ibc_client.rs
+++ b/framework/packages/abstract-std/src/native/ibc/ibc_client.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::QueryResponses;
-use cosmwasm_std::{Addr, Binary, Coin, CosmosMsg, Deps, Empty, QueryRequest, StdError, Uint64};
+use cosmwasm_std::{Addr, Binary, CosmosMsg, Deps, Empty, QueryRequest, StdError, Uint64};
 
 use self::state::IbcInfrastructure;
 use crate::{
@@ -87,7 +87,6 @@ pub enum ExecuteMsg {
         /// host chain to be executed on
         /// Example: "osmosis"
         host_chain: TruncatedChainId,
-        funds: Vec<Coin>,
         memo: Option<String>,
     },
     /// Only callable by Account
@@ -302,15 +301,15 @@ pub enum QueryMsg {
     #[returns(ListRemoteHostsResponse)]
     ListRemoteHosts {},
 
-    /// Get the IBC execution proxies
+    /// Get the Polytone execution proxies
     /// Returns [`ListRemoteProxiesResponse`]
     #[returns(ListRemoteProxiesResponse)]
     ListRemoteProxies {},
 
     /// Get the IBC execution proxies based on the account id passed
-    /// Returns [`ListRemoteProxiesResponse`]
-    #[returns(ListRemoteProxiesResponse)]
-    ListRemoteProxiesByAccountId { account_id: AccountId },
+    /// Returns [`ListRemoteAccountsResponse`]
+    #[returns(ListRemoteAccountsResponse)]
+    ListRemoteAccountsByAccountId { account_id: AccountId },
 
     /// Get the IBC counterparts connected to this abstract ibc client
     /// Returns [`ListIbcInfrastructureResponse`]
@@ -335,9 +334,11 @@ pub struct ListRemoteHostsResponse {
 }
 
 #[cosmwasm_schema::cw_serde]
-pub struct ListRemoteProxiesResponse {
-    pub proxies: Vec<(TruncatedChainId, Option<String>)>,
+pub struct ListRemoteAccountsResponse {
+    pub accounts: Vec<(TruncatedChainId, Option<String>)>,
 }
+
+pub type ListRemoteProxiesResponse = ListRemoteAccountsResponse;
 
 #[cosmwasm_schema::cw_serde]
 pub struct ListIbcInfrastructureResponse {
@@ -353,14 +354,6 @@ pub struct HostResponse {
 #[cosmwasm_schema::cw_serde]
 pub struct AccountResponse {
     pub remote_account_addr: Option<String>,
-}
-
-#[cosmwasm_schema::cw_serde]
-pub struct RemoteProxyResponse {
-    /// last block balance was updated (0 is never)
-    pub channel_id: String,
-    /// address of the remote proxy
-    pub proxy_address: String,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR removes `funds` field from the IBC client SendFunds function. `SendFunds` now uses `msg_info.funds` instead.