### PR TITLE
Remove account callback and replace by reply

### DIFF
--- a/framework/contracts/account/src/config.rs
+++ b/framework/contracts/account/src/config.rs
@@ -121,10 +121,7 @@ pub fn update_info(
 mod tests {
     use super::*;
     use crate::test_common::test_only_owner;
-    use crate::{
-        contract,
-        test_common::{execute_as, mock_init},
-    };
+    use crate::test_common::{execute_as, mock_init};
     use abstract_std::account::ExecuteMsg;
     use abstract_testing::prelude::*;
     use cosmwasm_std::{testing::*, Addr, StdError};
@@ -401,31 +398,6 @@ mod tests {
                     AccountError::Validation(ValidationError::LinkInvalidLong(_))
                 )
             });
-
-            Ok(())
-        }
-    }
-
-    mod handle_callback {
-        use abstract_std::account::CallbackMsg;
-
-        use super::*;
-
-        #[test]
-        fn only_by_contract() -> anyhow::Result<()> {
-            let mut deps = mock_dependencies();
-            let env = mock_env_validated(deps.api);
-            let not_contract = deps.api.addr_make("not_contract");
-            mock_init(&mut deps)?;
-            let callback = CallbackMsg {};
-
-            let msg = ExecuteMsg::Callback(callback);
-
-            let res = contract::execute(deps.as_mut(), env, message_info(&not_contract, &[]), msg);
-
-            assert_that!(&res)
-                .is_err()
-                .matches(|err| matches!(err, AccountError::Std(StdError::GenericErr { .. })));
 
             Ok(())
         }

--- a/framework/contracts/account/src/contract.rs
+++ b/framework/contracts/account/src/contract.rs
@@ -36,7 +36,7 @@ use crate::{
     },
     modules::{
         _install_modules, install_modules,
-        migration::{handle_callback, upgrade_modules},
+        migration::{assert_modules_dependency_requirements, upgrade_modules},
         uninstall_module, MIGRATE_CONTEXT,
     },
     msg::{ExecuteMsg, InstantiateMsg, QueryMsg},
@@ -62,6 +62,7 @@ pub const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const FORWARD_RESPONSE_REPLY_ID: u64 = 1;
 pub const ADMIN_ACTION_REPLY_ID: u64 = 2;
 pub const REGISTER_MODULES_DEPENDENCIES_REPLY_ID: u64 = 3;
+pub const ASSERT_MODULE_DEPENDENCIES_REQUIREMENTS_REPLY_ID: u64 = 4;
 
 #[cfg_attr(feature = "export", cosmwasm_std::entry_point)]
 pub fn instantiate(
@@ -373,7 +374,6 @@ pub fn execute(mut deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) 
                 }
                 #[allow(unused)]
                 ExecuteMsg::RemoveAuthMethod { id } => remove_auth_method(deps, env, id),
-                ExecuteMsg::Callback(_) => handle_callback(deps, env, info),
             }
         }
     }
@@ -385,6 +385,9 @@ pub fn reply(deps: DepsMut, _env: Env, msg: Reply) -> AccountResult {
         FORWARD_RESPONSE_REPLY_ID => forward_response_reply(msg),
         ADMIN_ACTION_REPLY_ID => admin_action_reply(deps),
         REGISTER_MODULES_DEPENDENCIES_REPLY_ID => register_dependencies(deps),
+        ASSERT_MODULE_DEPENDENCIES_REQUIREMENTS_REPLY_ID => {
+            assert_modules_dependency_requirements(deps)
+        }
 
         _ => Err(AccountError::UnexpectedReply {}),
     }

--- a/framework/packages/abstract-std/src/account.rs
+++ b/framework/packages/abstract-std/src/account.rs
@@ -224,8 +224,6 @@ pub enum ExecuteMsg<Authenticator = Empty> {
     RemoveAuthMethod {
         id: u8,
     },
-    /// Callback endpoint
-    Callback(CallbackMsg),
 }
 
 #[cosmwasm_schema::cw_serde]


### PR DESCRIPTION
This PR aims at removing the Account Callback endpoint and replacing it by replies to simplify access control and contract API

### Checklist

- [ ] CI is green.
- [ ] Changelog updated.
