### PR TITLE
Remove speculoos from dependency

### DIFF
--- a/framework/Cargo.lock
+++ b/framework/Cargo.lock
@@ -20,6 +20,7 @@ dependencies = [
  "abstract-std",
  "abstract-testing",
  "anyhow",
+ "assertor",
  "base64 0.22.1",
  "bech32 0.9.1",
  "cosmos-sdk-proto 0.24.0-pre",
@@ -43,7 +44,6 @@ dependencies = [
  "semver",
  "serde",
  "sha2 0.10.8",
- "speculoos",
  "thiserror",
  "tiny-keccak",
  "url",
@@ -91,6 +91,7 @@ dependencies = [
  "abstract-sdk",
  "abstract-std",
  "abstract-testing",
+ "assertor",
  "cosmwasm-schema 2.1.4",
  "cosmwasm-std 2.1.4",
  "cw-asset",
@@ -102,7 +103,6 @@ dependencies = [
  "rstest",
  "semver",
  "serde",
- "speculoos",
  "thiserror",
  "workspace-hack",
 ]
@@ -213,6 +213,7 @@ dependencies = [
  "abstract-std",
  "abstract-testing",
  "anyhow",
+ "assertor",
  "clap",
  "cosmwasm-schema 2.1.4",
  "cosmwasm-std 2.1.4",
@@ -226,7 +227,6 @@ dependencies = [
  "schemars",
  "semver",
  "serde",
- "speculoos",
  "thiserror",
  "workspace-hack",
 ]
@@ -240,6 +240,7 @@ dependencies = [
  "abstract-std",
  "abstract-testing",
  "anybuf",
+ "assertor",
  "cosmwasm-schema 2.1.4",
  "cosmwasm-std 2.1.4",
  "cw-ownable",
@@ -251,7 +252,6 @@ dependencies = [
  "prost",
  "semver",
  "serde",
- "speculoos",
  "thiserror",
  "workspace-hack",
 ]
@@ -292,6 +292,7 @@ dependencies = [
  "alloy",
  "alloy-sol-types",
  "anyhow",
+ "assertor",
  "cosmwasm-schema 2.1.4",
  "cosmwasm-std 2.1.4",
  "cw-orch",
@@ -303,7 +304,6 @@ dependencies = [
  "rstest",
  "schemars",
  "serde",
- "speculoos",
  "thiserror",
  "workspace-hack",
 ]
@@ -317,6 +317,7 @@ dependencies = [
  "abstract-sdk",
  "abstract-std",
  "abstract-testing",
+ "assertor",
  "cosmwasm-schema 2.1.4",
  "cosmwasm-std 2.1.4",
  "cw-ownable",
@@ -326,7 +327,6 @@ dependencies = [
  "polytone-evm",
  "semver",
  "serde",
- "speculoos",
  "thiserror",
  "workspace-hack",
 ]
@@ -343,6 +343,7 @@ dependencies = [
  "abstract-std",
  "abstract-testing",
  "anyhow",
+ "assertor",
  "cosmwasm-schema 2.1.4",
  "cosmwasm-std 2.1.4",
  "cw-asset",
@@ -351,7 +352,6 @@ dependencies = [
  "cw2",
  "log",
  "semver",
- "speculoos",
  "workspace-hack",
 ]
 
@@ -368,6 +368,7 @@ dependencies = [
  "abstract-registry",
  "abstract-std",
  "abstract-testing",
+ "assertor",
  "cosmrs 0.19.0",
  "cosmwasm-schema 2.1.4",
  "cosmwasm-std 2.1.4",
@@ -388,7 +389,6 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "speculoos",
  "thiserror",
  "workspace-hack",
 ]
@@ -397,10 +397,10 @@ dependencies = [
 name = "abstract-macros"
 version = "0.24.0"
 dependencies = [
+ "assertor",
  "cosmwasm-std 2.1.4",
  "proc-macro2",
  "quote",
- "speculoos",
  "syn 1.0.109",
 ]
 
@@ -415,6 +415,7 @@ dependencies = [
  "abstract-std",
  "abstract-testing",
  "anyhow",
+ "assertor",
  "cosmwasm-schema 2.1.4",
  "cosmwasm-std 2.1.4",
  "cw-asset",
@@ -426,7 +427,6 @@ dependencies = [
  "protobuf",
  "semver",
  "serde-cw-value",
- "speculoos",
  "thiserror",
  "workspace-hack",
 ]
@@ -519,6 +519,7 @@ dependencies = [
  "abstract-std",
  "abstract-testing",
  "anyhow",
+ "assertor",
  "cosmwasm-schema 2.1.4",
  "cosmwasm-std 2.1.4",
  "cw-orch",
@@ -527,7 +528,6 @@ dependencies = [
  "cw2",
  "semver",
  "serde",
- "speculoos",
  "thiserror",
  "workspace-hack",
 ]
@@ -540,6 +540,7 @@ dependencies = [
  "abstract-sdk",
  "abstract-std",
  "abstract-testing",
+ "assertor",
  "cosmos-sdk-proto 0.24.0",
  "cosmwasm-schema 2.1.4",
  "cosmwasm-std 2.1.4",
@@ -556,7 +557,6 @@ dependencies = [
  "schemars",
  "semver",
  "serde",
- "speculoos",
  "thiserror",
  "workspace-hack",
 ]
@@ -572,6 +572,7 @@ dependencies = [
  "abstract-std",
  "abstract-testing",
  "anyhow",
+ "assertor",
  "clap",
  "cosmwasm-schema 2.1.4",
  "cosmwasm-std 2.1.4",
@@ -585,7 +586,6 @@ dependencies = [
  "schemars",
  "semver",
  "serde",
- "speculoos",
  "thiserror",
  "workspace-hack",
 ]
@@ -600,6 +600,7 @@ dependencies = [
  "abstract-standalone",
  "abstract-std",
  "abstract-testing",
+ "assertor",
  "cosmwasm-schema 2.1.4",
  "cosmwasm-std 2.1.4",
  "cw-asset",
@@ -610,7 +611,6 @@ dependencies = [
  "schemars",
  "semver",
  "serde",
- "speculoos",
  "thiserror",
  "workspace-hack",
 ]
@@ -621,6 +621,7 @@ version = "0.24.0"
 dependencies = [
  "abstract-testing",
  "anyhow",
+ "assertor",
  "bech32 0.11.0",
  "cosmwasm-schema 2.1.4",
  "cosmwasm-std 2.1.4",
@@ -643,7 +644,6 @@ dependencies = [
  "semver",
  "serde",
  "sha2 0.10.8",
- "speculoos",
  "thiserror",
  "workspace-hack",
 ]
@@ -654,6 +654,7 @@ version = "0.24.0"
 dependencies = [
  "abstract-sdk",
  "abstract-std",
+ "assertor",
  "cosmwasm-schema 2.1.4",
  "cosmwasm-std 2.1.4",
  "cw-asset",
@@ -664,7 +665,6 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "speculoos",
  "workspace-hack",
 ]
 
@@ -1035,6 +1035,16 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "assertor"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b02f2af4042fbbed4d5732c517666629512c574c8e2edb5cfe2cf8a86564d52"
+dependencies = [
+ "anyhow",
+ "num-traits",
+]
 
 [[package]]
 name = "async-broadcast"

--- a/framework/Cargo.toml
+++ b/framework/Cargo.toml
@@ -96,7 +96,7 @@ abstract-integration-tests = { path = "packages/abstract-integration-tests" }
 
 ## Testing
 rstest = "0.17.0"
-speculoos = "0.11.0"
+assertor = "0.0.3"
 anyhow = "1"
 
 # Predictable abstract addresses

--- a/framework/contracts/account/Cargo.toml
+++ b/framework/contracts/account/Cargo.toml
@@ -107,7 +107,7 @@ ans-host = { workspace = true }
 registry = { workspace = true }
 module-factory = { workspace = true }
 rstest = { workspace = true }
-speculoos = { workspace = true }
+assertor = { workspace = true, features = ["anyhow"] }
 abstract-sdk = { workspace = true, features = ["test-utils"] }
 abstract-adapter = { workspace = true, features = ["test-utils"] }
 abstract-app = { workspace = true, features = ["test-utils"] }

--- a/framework/contracts/account/src/config.rs
+++ b/framework/contracts/account/src/config.rs
@@ -127,9 +127,9 @@ mod tests {
     };
     use abstract_std::account::ExecuteMsg;
     use abstract_testing::prelude::*;
+    use assertor::*;
     use cosmwasm_std::{testing::*, Addr, StdError};
     use ownership::{GovAction, GovOwnershipError, GovernanceDetails};
-    use speculoos::prelude::*;
 
     mod set_owner_and_gov_type {
 
@@ -165,7 +165,7 @@ mod tests {
             });
 
             let res = execute_as(&mut deps, &owner, msg);
-            assert_that!(res).is_err().matches(|err| {
+            assert_that!(res).err().matches(|err| {
                 matches!(
                     err,
                     AccountError::Ownership(GovOwnershipError::Abstract(
@@ -342,7 +342,7 @@ mod tests {
             };
 
             let res = execute_as(&mut deps, &owner, msg);
-            assert_that!(&res).is_err().matches(|e| {
+            assert_that!(&res).err().matches(|e| {
                 matches!(
                     e,
                     AccountError::Validation(ValidationError::TitleInvalidShort(_))
@@ -356,7 +356,7 @@ mod tests {
             };
 
             let res = execute_as(&mut deps, &owner, msg);
-            assert_that!(&res).is_err().matches(|e| {
+            assert_that!(&res).err().matches(|e| {
                 matches!(
                     e,
                     AccountError::Validation(ValidationError::TitleInvalidLong(_))
@@ -381,7 +381,7 @@ mod tests {
             };
 
             let res = execute_as(&mut deps, &owner, msg);
-            assert_that!(&res).is_err().matches(|e| {
+            assert_that!(&res).err().matches(|e| {
                 matches!(
                     e,
                     AccountError::Validation(ValidationError::LinkInvalidShort(_))
@@ -395,7 +395,7 @@ mod tests {
             };
 
             let res = execute_as(&mut deps, &owner, msg);
-            assert_that!(&res).is_err().matches(|e| {
+            assert_that!(&res).err().matches(|e| {
                 matches!(
                     e,
                     AccountError::Validation(ValidationError::LinkInvalidLong(_))
@@ -424,7 +424,7 @@ mod tests {
             let res = contract::execute(deps.as_mut(), env, message_info(&not_contract, &[]), msg);
 
             assert_that!(&res)
-                .is_err()
+                .err()
                 .matches(|err| matches!(err, AccountError::Std(StdError::GenericErr { .. })));
 
             Ok(())
@@ -471,7 +471,7 @@ mod tests {
             let res = execute_as(&mut deps, &owner, update_info_msg);
 
             assert_that!(&res)
-                .is_err()
+                .err()
                 .is_equal_to(AccountError::AccountSuspended {});
 
             Ok(())
@@ -539,14 +539,14 @@ mod tests {
             let res = execute_as(&mut deps, &bad_sender, msg.clone());
 
             assert_that!(&res)
-                .is_err()
+                .err()
                 .is_equal_to(AccountError::Ownership(GovOwnershipError::NotOwner));
 
             let vc_res = execute_as(&mut deps, &abstr.registry, msg.clone());
-            assert_that!(&vc_res).is_err();
+            assert_that!(&vc_res).err();
 
             let owner_res = execute_as(&mut deps, &owner, msg);
-            assert_that!(&owner_res).is_ok();
+            assert_that!(&owner_res).ok();
 
             Ok(())
         }

--- a/framework/contracts/account/src/execution.rs
+++ b/framework/contracts/account/src/execution.rs
@@ -179,9 +179,9 @@ mod test {
     use abstract_std::account::{state::*, *};
     use abstract_std::{account, IBC_CLIENT};
     use abstract_testing::prelude::*;
+    use assertor::*;
     use cosmwasm_std::testing::*;
     use cosmwasm_std::{coins, CosmosMsg, SubMsg};
-    use speculoos::prelude::*;
 
     mod execute_action {
 
@@ -200,8 +200,8 @@ mod test {
             let env = mock_env_validated(deps.api);
 
             let res = execute(deps.as_mut(), env, info, msg);
-            assert_that(&res)
-                .is_err()
+            assert_that!(&res)
+                .err()
                 .is_equal_to(AccountError::SenderNotWhitelistedOrOwner {});
             Ok(())
         }

--- a/framework/contracts/account/src/lib.rs
+++ b/framework/contracts/account/src/lib.rs
@@ -45,7 +45,7 @@ mod test_common {
     };
     use abstract_testing::prelude::*;
     use cosmwasm_std::{testing::*, Addr, Empty, OwnedDeps};
-    use speculoos::prelude::*;
+    use assertor::*;
 
     use crate::{contract::AccountResult, error::AccountError, msg::ExecuteMsg};
 
@@ -84,7 +84,7 @@ mod test_common {
 
         let res = execute_as(&mut deps, &not_owner, msg);
         assert_that!(&res)
-            .is_err()
+            .err()
             .is_equal_to(AccountError::Ownership(
                 ownership::GovOwnershipError::NotOwner,
             ));

--- a/framework/contracts/account/src/lib.rs
+++ b/framework/contracts/account/src/lib.rs
@@ -44,8 +44,8 @@ mod test_common {
         objects::{account::AccountTrace, gov_type::GovernanceDetails, ownership, AccountId},
     };
     use abstract_testing::prelude::*;
-    use cosmwasm_std::{testing::*, Addr, Empty, OwnedDeps};
     use assertor::*;
+    use cosmwasm_std::{testing::*, Addr, Empty, OwnedDeps};
 
     use crate::{contract::AccountResult, error::AccountError, msg::ExecuteMsg};
 

--- a/framework/contracts/account/src/migrate.rs
+++ b/framework/contracts/account/src/migrate.rs
@@ -19,9 +19,9 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> AccountResult {
 #[cfg(test)]
 mod tests {
     use abstract_testing::mock_env_validated;
+    use assertor::*;
     use cosmwasm_std::testing::*;
     use semver::Version;
-    use speculoos::prelude::*;
 
     use super::*;
     use crate::error::AccountError;
@@ -41,7 +41,7 @@ mod tests {
         let res = super::migrate(deps.as_mut(), env, MigrateMsg {});
 
         assert_that!(res)
-            .is_err()
+            .err()
             .is_equal_to(AccountError::Abstract(
                 AbstractError::CannotDowngradeContract {
                     contract: ACCOUNT.to_string(),
@@ -67,7 +67,7 @@ mod tests {
         let res = super::migrate(deps.as_mut(), env, MigrateMsg {});
 
         assert_that!(res)
-            .is_err()
+            .err()
             .is_equal_to(AccountError::Abstract(
                 AbstractError::CannotDowngradeContract {
                     contract: ACCOUNT.to_string(),
@@ -92,7 +92,7 @@ mod tests {
         let res = super::migrate(deps.as_mut(), env, MigrateMsg {});
 
         assert_that!(res)
-            .is_err()
+            .err()
             .is_equal_to(AccountError::Abstract(
                 AbstractError::ContractNameMismatch {
                     from: old_name.parse().unwrap(),

--- a/framework/contracts/account/src/migrate.rs
+++ b/framework/contracts/account/src/migrate.rs
@@ -40,15 +40,13 @@ mod tests {
 
         let res = super::migrate(deps.as_mut(), env, MigrateMsg {});
 
-        assert_that!(res)
-            .err()
-            .is_equal_to(AccountError::Abstract(
-                AbstractError::CannotDowngradeContract {
-                    contract: ACCOUNT.to_string(),
-                    from: version.clone(),
-                    to: version,
-                },
-            ));
+        assert_that!(res).err().is_equal_to(AccountError::Abstract(
+            AbstractError::CannotDowngradeContract {
+                contract: ACCOUNT.to_string(),
+                from: version.clone(),
+                to: version,
+            },
+        ));
 
         Ok(())
     }
@@ -66,15 +64,13 @@ mod tests {
 
         let res = super::migrate(deps.as_mut(), env, MigrateMsg {});
 
-        assert_that!(res)
-            .err()
-            .is_equal_to(AccountError::Abstract(
-                AbstractError::CannotDowngradeContract {
-                    contract: ACCOUNT.to_string(),
-                    from: big_version.parse().unwrap(),
-                    to: version,
-                },
-            ));
+        assert_that!(res).err().is_equal_to(AccountError::Abstract(
+            AbstractError::CannotDowngradeContract {
+                contract: ACCOUNT.to_string(),
+                from: big_version.parse().unwrap(),
+                to: version,
+            },
+        ));
 
         Ok(())
     }
@@ -91,14 +87,12 @@ mod tests {
 
         let res = super::migrate(deps.as_mut(), env, MigrateMsg {});
 
-        assert_that!(res)
-            .err()
-            .is_equal_to(AccountError::Abstract(
-                AbstractError::ContractNameMismatch {
-                    from: old_name.parse().unwrap(),
-                    to: ACCOUNT.parse().unwrap(),
-                },
-            ));
+        assert_that!(res).err().is_equal_to(AccountError::Abstract(
+            AbstractError::ContractNameMismatch {
+                from: old_name.parse().unwrap(),
+                to: ACCOUNT.parse().unwrap(),
+            },
+        ));
 
         Ok(())
     }

--- a/framework/contracts/account/src/modules.rs
+++ b/framework/contracts/account/src/modules.rs
@@ -355,9 +355,9 @@ mod tests {
     use abstract_std::objects::dependency::Dependency;
     use abstract_testing::module::TEST_MODULE_ID;
     use abstract_testing::prelude::AbstractMockAddrs;
+    use assertor::*;
     use cosmwasm_std::{testing::*, Addr, Order, StdError, Storage};
     use ownership::GovOwnershipError;
-    use speculoos::prelude::*;
 
     fn load_account_modules(storage: &dyn Storage) -> Result<Vec<(String, Addr)>, StdError> {
         ACCOUNT_MODULES
@@ -435,7 +435,7 @@ mod tests {
 
             let res = update_module_addresses(deps.as_mut(), to_add, vec![]);
             assert_that!(&res)
-                .is_err()
+                .err()
                 .is_equal_to(AccountError::InvalidModuleName {});
 
             Ok(())
@@ -483,15 +483,15 @@ mod tests {
 
             // the registry can not call this
             let res = execute_as(&mut deps, &abstr.registry, msg.clone());
-            assert_that!(&res).is_err();
+            assert_that!(&res).err();
 
             // only the owner can
             let res = execute_as(&mut deps, &owner, msg.clone());
-            assert_that!(&res).is_ok();
+            assert_that!(&res).ok();
 
             let res = execute_as(&mut deps, &not_account_factory, msg);
             assert_that!(&res)
-                .is_err()
+                .err()
                 .is_equal_to(AccountError::Ownership(GovOwnershipError::NotOwner));
 
             Ok(())
@@ -517,7 +517,7 @@ mod tests {
 
             let res = execute_as(&mut deps, &not_owner, msg);
             assert_that!(&res)
-                .is_err()
+                .err()
                 .is_equal_to(AccountError::Ownership(GovOwnershipError::NotOwner));
 
             Ok(())
@@ -556,7 +556,7 @@ mod tests {
 
             let res = execute_as(&mut deps, &owner, msg);
             assert_that!(&res)
-                .is_err()
+                .err()
                 .is_equal_to(AccountError::ModuleHasDependents(Vec::from_iter(
                     dependents,
                 )));
@@ -591,7 +591,7 @@ mod tests {
 
             let res = execute_as(&mut deps, &not_owner, msg);
             assert_that!(&res)
-                .is_err()
+                .err()
                 .is_equal_to(AccountError::SenderNotWhitelistedOrOwner {});
             Ok(())
         }
@@ -613,7 +613,7 @@ mod tests {
 
             let res = execute_as(&mut deps, &owner, msg);
             assert_that!(&res)
-                .is_err()
+                .err()
                 .is_equal_to(AccountError::ModuleNotFound(missing_module));
 
             Ok(())

--- a/framework/contracts/account/src/versioning.rs
+++ b/framework/contracts/account/src/versioning.rs
@@ -204,7 +204,7 @@ mod test {
     use std::collections::HashSet;
 
     use cosmwasm_std::testing::mock_dependencies;
-    use speculoos::prelude::*;
+    use assertor::*;
 
     use super::*;
 

--- a/framework/contracts/account/src/versioning.rs
+++ b/framework/contracts/account/src/versioning.rs
@@ -203,8 +203,8 @@ mod test {
     #![allow(clippy::needless_borrows_for_generic_args)]
     use std::collections::HashSet;
 
-    use cosmwasm_std::testing::mock_dependencies;
     use assertor::*;
+    use cosmwasm_std::testing::mock_dependencies;
 
     use super::*;
 

--- a/framework/contracts/account/tests/adapters.rs
+++ b/framework/contracts/account/tests/adapters.rs
@@ -19,10 +19,10 @@ use abstract_std::{
     *,
 };
 use abstract_testing::prelude::*;
+use assertor::*;
 use cosmwasm_std::{coin, coins};
 use cw_orch::prelude::*;
 use mock_modules::{adapter_1, V1, V2};
-use speculoos::{assert_that, result::ResultAssertions, string::StrAssertions};
 
 #[test]
 fn installing_one_adapter_should_succeed() -> AResult {
@@ -35,7 +35,7 @@ fn installing_one_adapter_should_succeed() -> AResult {
 
     let modules = account.expect_modules(vec![staking_adapter.address()?.to_string()])?;
 
-    assert_that(&modules[0]).is_equal_to(&AccountModuleInfo {
+    assert_that!(&modules[0]).is_equal_to(&AccountModuleInfo {
         address: staking_adapter.address()?,
         id: TEST_MODULE_ID.to_string(),
         version: cw2::ContractVersion {
@@ -148,7 +148,7 @@ fn installation_of_duplicate_adapter_should_fail() -> AResult {
 
     // assert account module
     // check staking adapter
-    assert_that(&modules[0]).is_equal_to(&AccountModuleInfo {
+    assert_that!(&modules[0]).is_equal_to(&AccountModuleInfo {
         address: staking_adapter.address()?,
         id: TEST_MODULE_ID.to_string(),
         version: cw2::ContractVersion {
@@ -160,8 +160,9 @@ fn installation_of_duplicate_adapter_should_fail() -> AResult {
     // install again
     let second_install_res = install_adapter(&account, TEST_MODULE_ID);
     assert_that!(second_install_res)
-        .is_err()
-        .matches(|e| e.to_string().contains("test-module-id"));
+        .err()
+        .as_string()
+        .contains("test-module-id");
 
     account.expect_modules(vec![staking_adapter.address()?.to_string()])?;
 
@@ -181,7 +182,7 @@ fn reinstalling_adapter_should_be_allowed() -> AResult {
     let modules = account.expect_modules(vec![staking_adapter.address()?.to_string()])?;
 
     // check staking adapter
-    assert_that(&modules[0]).is_equal_to(&AccountModuleInfo {
+    assert_that!(&modules[0]).is_equal_to(&AccountModuleInfo {
         address: staking_adapter.address()?,
         id: TEST_MODULE_ID.to_string(),
         version: cw2::ContractVersion {
@@ -226,7 +227,7 @@ fn reinstalling_new_version_should_install_latest() -> AResult {
     let modules = account.expect_modules(vec![adapter1.address()?.to_string()])?;
 
     // check staking adapter
-    assert_that(&modules[0]).is_equal_to(&AccountModuleInfo {
+    assert_that!(&modules[0]).is_equal_to(&AccountModuleInfo {
         address: adapter1.address()?,
         id: adapter1.id(),
         version: cw2::ContractVersion {
@@ -303,7 +304,7 @@ fn unauthorized_exec() -> AResult {
     let res = staking_adapter
         .execute(&MockExecMsg {}.into(), &[])
         .unwrap_err();
-    assert_that!(&res.root().to_string()).contains(format!(
+    assert_that!(res.root().to_string()).contains(format!(
         "Sender: {} of request to tester:test-module-id is not an Account or Authorized Address",
         chain.sender_addr()
     ));

--- a/framework/contracts/account/tests/apps.rs
+++ b/framework/contracts/account/tests/apps.rs
@@ -14,10 +14,10 @@ use abstract_std::{
     registry::ModuleFilter,
 };
 use abstract_testing::prelude::*;
+use assertor::*;
 use cosmwasm_std::{coin, CosmosMsg};
 use cw_controllers::{AdminError, AdminResponse};
 use cw_orch::prelude::*;
-use assertor::*;
 
 const APP_ID: &str = "tester:app";
 const APP_VERSION: &str = "1.0.0";

--- a/framework/contracts/account/tests/apps.rs
+++ b/framework/contracts/account/tests/apps.rs
@@ -17,7 +17,7 @@ use abstract_testing::prelude::*;
 use cosmwasm_std::{coin, CosmosMsg};
 use cw_controllers::{AdminError, AdminResponse};
 use cw_orch::prelude::*;
-use speculoos::prelude::*;
+use assertor::*;
 
 const APP_ID: &str = "tester:app";
 const APP_VERSION: &str = "1.0.0";

--- a/framework/contracts/account/tests/create.rs
+++ b/framework/contracts/account/tests/create.rs
@@ -8,8 +8,8 @@ use abstract_std::{
     ABSTRACT_EVENT_TYPE, ACCOUNT,
 };
 use abstract_testing::prelude::*;
-use cw_orch::prelude::*;
 use assertor::*;
+use cw_orch::prelude::*;
 
 type AResult = anyhow::Result<()>; // alias for Result<(), anyhow::Error>
 

--- a/framework/contracts/account/tests/create.rs
+++ b/framework/contracts/account/tests/create.rs
@@ -80,7 +80,7 @@ fn create_one_account() -> AResult {
 
     let account_list = registry.account(TEST_ACCOUNT_ID)?;
 
-    assert_that!(&account_list.account.into()).is_equal_to(Account::new(account));
+    assert_that!(Account::new(account)).is_equal_to(account_list.account.into());
 
     Ok(())
 }
@@ -285,7 +285,7 @@ fn create_one_account_with_namespace() -> AResult {
         .registry
         .namespace(Namespace::new(namespace_to_claim)?)?;
 
-    assert_that!(&namespace).is_equal_to(NamespaceResponse::Claimed(NamespaceInfo {
+    assert_that!(namespace).is_equal_to(NamespaceResponse::Claimed(NamespaceInfo {
         account_id: TEST_ACCOUNT_ID,
         account: Account::new(Addr::unchecked(account_addr)),
     }));

--- a/framework/contracts/account/tests/create.rs
+++ b/framework/contracts/account/tests/create.rs
@@ -9,7 +9,7 @@ use abstract_std::{
 };
 use abstract_testing::prelude::*;
 use cw_orch::prelude::*;
-use speculoos::prelude::*;
+use assertor::*;
 
 type AResult = anyhow::Result<()>; // alias for Result<(), anyhow::Error>
 

--- a/framework/contracts/account/tests/ibc-client.rs
+++ b/framework/contracts/account/tests/ibc-client.rs
@@ -2,8 +2,8 @@ use abstract_integration_tests::{create_default_account, AResult};
 use abstract_interface::{Abstract, AccountI, AccountQueryFns};
 use abstract_std::IBC_CLIENT;
 use anyhow::bail;
-use cw_orch::prelude::*;
 use assertor::*;
+use cw_orch::prelude::*;
 
 pub fn ibc_client_installed<Chain: CwEnv>(account: &AccountI<Chain>) -> AResult {
     let ibc_addr = account.module_addresses(vec![IBC_CLIENT.to_string()])?;

--- a/framework/contracts/account/tests/ibc-client.rs
+++ b/framework/contracts/account/tests/ibc-client.rs
@@ -3,7 +3,7 @@ use abstract_interface::{Abstract, AccountI, AccountQueryFns};
 use abstract_std::IBC_CLIENT;
 use anyhow::bail;
 use cw_orch::prelude::*;
-use speculoos::{assert_that, result::ResultAssertions};
+use assertor::*;
 
 pub fn ibc_client_installed<Chain: CwEnv>(account: &AccountI<Chain>) -> AResult {
     let ibc_addr = account.module_addresses(vec![IBC_CLIENT.to_string()])?;
@@ -23,7 +23,7 @@ fn throws_if_enabling_when_already_enabled() -> AResult {
     account.set_ibc_status(true)?;
     let res = account.set_ibc_status(true);
 
-    assert_that!(&res).is_err();
+    assert_that!(res).is_err();
 
     Ok(())
 }
@@ -37,7 +37,7 @@ fn throws_if_disabling_without_ibc_client_installed() -> AResult {
 
     let res = account.set_ibc_status(false);
 
-    assert_that!(&res).is_err();
+    assert_that!(res).is_err();
 
     Ok(())
 }

--- a/framework/contracts/account/tests/proxy.rs
+++ b/framework/contracts/account/tests/proxy.rs
@@ -16,9 +16,9 @@ use abstract_std::{
     registry::{NamespaceResponse, UpdateModule},
 };
 use abstract_testing::prelude::*;
+use assertor::*;
 use cosmwasm_std::{coin, CosmosMsg};
 use cw_orch::prelude::*;
-use assertor::*;
 
 // /// Deploys and mints an NFT to *sender*.
 // fn deploy_and_mint_nft(

--- a/framework/contracts/account/tests/proxy.rs
+++ b/framework/contracts/account/tests/proxy.rs
@@ -18,7 +18,7 @@ use abstract_std::{
 use abstract_testing::prelude::*;
 use cosmwasm_std::{coin, CosmosMsg};
 use cw_orch::prelude::*;
-use speculoos::prelude::*;
+use assertor::*;
 
 // /// Deploys and mints an NFT to *sender*.
 // fn deploy_and_mint_nft(

--- a/framework/contracts/account/tests/proxy.rs
+++ b/framework/contracts/account/tests/proxy.rs
@@ -82,7 +82,7 @@ fn instantiate() -> AResult {
     let modules = account.module_infos(None, None)?.module_infos;
 
     // assert account module
-    assert_that!(&modules).has_length(0);
+    assert_that!(modules).has_length(0);
 
     // assert account config
     assert_that!(account.config()?).is_equal_to(abstract_std::account::ConfigResponse {

--- a/framework/contracts/account/tests/upgrades.rs
+++ b/framework/contracts/account/tests/upgrades.rs
@@ -24,7 +24,7 @@ use abstract_testing::prelude::*;
 use cosmwasm_std::coin;
 use cw2::ContractVersion;
 use cw_orch::prelude::*;
-use speculoos::prelude::*;
+use assertor::*;
 
 #[test]
 fn install_app_successful() -> AResult {

--- a/framework/contracts/account/tests/upgrades.rs
+++ b/framework/contracts/account/tests/upgrades.rs
@@ -21,10 +21,10 @@ use abstract_std::{
     AbstractError, IBC_CLIENT,
 };
 use abstract_testing::prelude::*;
+use assertor::*;
 use cosmwasm_std::coin;
 use cw2::ContractVersion;
 use cw_orch::prelude::*;
-use assertor::*;
 
 #[test]
 fn install_app_successful() -> AResult {

--- a/framework/contracts/native/ans-host/Cargo.toml
+++ b/framework/contracts/native/ans-host/Cargo.toml
@@ -38,7 +38,7 @@ workspace-hack = { version = "0.1", path = "../../../workspace-hack" }
 cw20 = { workspace = true }
 cosmwasm-schema = { workspace = true }
 rstest = { workspace = true }
-speculoos = { workspace = true }
+assertor = { workspace = true }
 abstract-testing = { workspace = true }
 
 [profile.release]

--- a/framework/contracts/native/ans-host/src/commands.rs
+++ b/framework/contracts/native/ans-host/src/commands.rs
@@ -1273,10 +1273,10 @@ mod test {
             let expected_pairing_count = 20;
 
             let actual_pairings = load_asset_pairings(&deps.storage)?;
-            assert_that!(&actual_pairings).has_length(expected_pairing_count);
+            assert_that!(actual_pairings).has_length(expected_pairing_count);
 
             for (_pairing, ref_vec) in actual_pairings {
-                assert_that!(&ref_vec).has_length(1);
+                assert_that!(ref_vec).has_length(1);
                 // check the pool id is correct
                 assert_that!(&UncheckedPoolAddress::from(&ref_vec[0].pool_address))
                     .is_equal_to(&unchecked_pool_id);
@@ -1302,14 +1302,14 @@ mod test {
 
             let res = execute_update(&mut deps, (vec![entry], vec![]), &abstr.owner);
 
-            assert_that!(&res)
+            assert_that!(res)
                 .err()
                 .is_equal_to(AnsHostError::UnregisteredDex {
                     dex: unregistered_dex.into(),
                 });
 
             let actual_pools = load_pool_metadata(&deps.storage)?;
-            assert_that!(&actual_pools).is_empty();
+            assert_that!(actual_pools).is_empty();
 
             Ok(())
         }

--- a/framework/contracts/native/ans-host/src/commands.rs
+++ b/framework/contracts/native/ans-host/src/commands.rs
@@ -365,8 +365,8 @@ fn validate_pool_assets(
 mod test {
     #![allow(clippy::needless_borrows_for_generic_args)]
     use abstract_testing::{map_tester::CwMapTester, prelude::*};
+    use assertor::*;
     use cosmwasm_std::{testing::*, Addr};
-    use speculoos::prelude::*;
 
     use super::*;
     use crate::{contract, error::AnsHostError, test_common::*};
@@ -1203,7 +1203,7 @@ mod test {
             let actual_pools: Result<Vec<PoolMetadataMapEntry>, _> =
                 load_pool_metadata(&deps.storage);
 
-            assert_that(&actual_pools?).is_equal_to(&expected_pools);
+            assert_that!(&actual_pools?).is_equal_to(&expected_pools);
 
             let _pairing =
                 DexAssetPairing::<AssetEntry>::new("juno".into(), "osmo".into(), "junoswap");
@@ -1226,7 +1226,7 @@ mod test {
             ];
             let actual_pairings: Result<Vec<AssetPairingMapEntry>, _> =
                 load_asset_pairings(&deps.storage);
-            assert_that(&actual_pairings?).is_equal_to(&expected_pairings);
+            assert_that!(&actual_pairings?).is_equal_to(&expected_pairings);
 
             Ok(())
         }
@@ -1261,7 +1261,7 @@ mod test {
             let actual_pools: Result<Vec<PoolMetadataMapEntry>, _> =
                 load_pool_metadata(&deps.storage);
 
-            assert_that(&actual_pools?).is_equal_to(&expected_pools);
+            assert_that!(&actual_pools?).is_equal_to(&expected_pools);
 
             let _pairing =
                 DexAssetPairing::<AssetEntry>::new("juno".into(), "osmo".into(), "junoswap");
@@ -1273,12 +1273,12 @@ mod test {
             let expected_pairing_count = 20;
 
             let actual_pairings = load_asset_pairings(&deps.storage)?;
-            assert_that(&actual_pairings).has_length(expected_pairing_count);
+            assert_that!(&actual_pairings).has_length(expected_pairing_count);
 
             for (_pairing, ref_vec) in actual_pairings {
-                assert_that(&ref_vec).has_length(1);
+                assert_that!(&ref_vec).has_length(1);
                 // check the pool id is correct
-                assert_that(&UncheckedPoolAddress::from(&ref_vec[0].pool_address))
+                assert_that!(&UncheckedPoolAddress::from(&ref_vec[0].pool_address))
                     .is_equal_to(&unchecked_pool_id);
             }
 
@@ -1302,14 +1302,14 @@ mod test {
 
             let res = execute_update(&mut deps, (vec![entry], vec![]), &abstr.owner);
 
-            assert_that(&res)
-                .is_err()
+            assert_that!(&res)
+                .err()
                 .is_equal_to(AnsHostError::UnregisteredDex {
                     dex: unregistered_dex.into(),
                 });
 
             let actual_pools = load_pool_metadata(&deps.storage)?;
-            assert_that(&actual_pools).is_empty();
+            assert_that!(&actual_pools).is_empty();
 
             Ok(())
         }
@@ -1340,11 +1340,11 @@ mod test {
 
             // metadata should be emtpy
             let actual_pools = load_pool_metadata(&deps.storage)?;
-            assert_that(&actual_pools).is_empty();
+            assert_that!(&actual_pools).is_empty();
 
             // all pairs should be empty
             let actual_pairs = load_asset_pairings(&deps.storage)?;
-            assert_that(&actual_pairs).is_empty();
+            assert_that!(&actual_pairs).is_empty();
 
             Ok(())
         }
@@ -1361,15 +1361,15 @@ mod test {
                 &abstr.owner,
             );
 
-            assert_that(&res).is_ok();
+            assert_that!(&res).is_ok();
 
             // metadata should be empty
             let actual_pools = load_pool_metadata(&deps.storage)?;
-            assert_that(&actual_pools).is_empty();
+            assert_that!(&actual_pools).is_empty();
 
             // all pairs should be empty
             let actual_pairs = load_asset_pairings(&deps.storage)?;
-            assert_that(&actual_pairs).is_empty();
+            assert_that!(&actual_pairs).is_empty();
 
             Ok(())
         }
@@ -1391,10 +1391,10 @@ mod test {
 
             let res = execute_update(&mut deps, (vec![entry], vec![]), &abstr.owner);
 
-            assert_that(&res).is_err();
+            assert_that!(&res).is_err();
 
-            assert_that(&res)
-                .is_err()
+            assert_that!(&res)
+                .err()
                 .is_equal_to(AnsHostError::UnregisteredAsset {
                     asset: "juno".to_string(),
                 });
@@ -1439,8 +1439,8 @@ mod test {
             let deps = mock_dependencies();
             let res = validate_pool_assets(&deps.storage, &mut assets);
 
-            assert_that(&res)
-                .is_err()
+            assert_that!(&res)
+                .err()
                 .is_equal_to(AnsHostError::UnregisteredAsset {
                     asset: "a".to_string(),
                 });
@@ -1457,7 +1457,7 @@ mod test {
 
             let res = validate_pool_assets(&deps.storage, &mut assets);
 
-            assert_that(&res).is_ok();
+            assert_that!(&res).is_ok();
 
             let mut assets: Vec<AssetEntry> = vec!["a", "b", "c", "d", "e"]
                 .into_iter()
@@ -1467,7 +1467,7 @@ mod test {
             register_assets_helper(&mut deps, assets.clone(), &abstr.owner).unwrap();
             let res = validate_pool_assets(&deps.storage, &mut assets);
 
-            assert_that(&res).is_ok();
+            assert_that!(&res).is_ok();
         }
 
         #[test]

--- a/framework/contracts/native/ans-host/src/contract.rs
+++ b/framework/contracts/native/ans-host/src/contract.rs
@@ -122,7 +122,7 @@ pub fn migrate(deps: DepsMut, env: Env, msg: MigrateMsg) -> AnsHostResult {
 #[cfg(test)]
 mod tests {
     use cosmwasm_std::testing::*;
-    use speculoos::prelude::*;
+    use assertor::*;
 
     use super::*;
     use crate::test_common::*;

--- a/framework/contracts/native/ans-host/src/contract.rs
+++ b/framework/contracts/native/ans-host/src/contract.rs
@@ -121,8 +121,8 @@ pub fn migrate(deps: DepsMut, env: Env, msg: MigrateMsg) -> AnsHostResult {
 
 #[cfg(test)]
 mod tests {
-    use cosmwasm_std::testing::*;
     use assertor::*;
+    use cosmwasm_std::testing::*;
 
     use super::*;
     use crate::test_common::*;

--- a/framework/contracts/native/ans-host/src/queries.rs
+++ b/framework/contracts/native/ans-host/src/queries.rs
@@ -309,9 +309,9 @@ mod test {
         objects::{pool_id::PoolAddressBase, PoolType, TruncatedChainId},
     };
     use abstract_testing::{addresses::AbstractMockAddrs, mock_env_validated};
+    use assertor::*;
     use cosmwasm_std::{from_json, testing::*, Addr, DepsMut, OwnedDeps};
     use cw_asset::AssetInfo;
-    use assertor::*;
     use std::str::FromStr;
 
     type AnsHostTestResult = Result<(), AnsHostError>;

--- a/framework/contracts/native/ans-host/src/queries.rs
+++ b/framework/contracts/native/ans-host/src/queries.rs
@@ -311,7 +311,7 @@ mod test {
     use abstract_testing::{addresses::AbstractMockAddrs, mock_env_validated};
     use cosmwasm_std::{from_json, testing::*, Addr, DepsMut, OwnedDeps};
     use cw_asset::AssetInfo;
-    use speculoos::prelude::*;
+    use assertor::*;
     use std::str::FromStr;
 
     type AnsHostTestResult = Result<(), AnsHostError>;

--- a/framework/contracts/native/ans-host/src/tests/instantiate.rs
+++ b/framework/contracts/native/ans-host/src/tests/instantiate.rs
@@ -1,7 +1,7 @@
 use abstract_std::ans_host::*;
 use abstract_testing::{mock_env_validated, prelude::AbstractMockAddrs};
 use cosmwasm_std::{testing::*, MessageInfo, OwnedDeps};
-use speculoos::prelude::*;
+use assertor::*;
 
 use crate::{
     contract::instantiate,

--- a/framework/contracts/native/ans-host/src/tests/instantiate.rs
+++ b/framework/contracts/native/ans-host/src/tests/instantiate.rs
@@ -1,7 +1,7 @@
 use abstract_std::ans_host::*;
 use abstract_testing::{mock_env_validated, prelude::AbstractMockAddrs};
-use cosmwasm_std::{testing::*, MessageInfo, OwnedDeps};
 use assertor::*;
+use cosmwasm_std::{testing::*, MessageInfo, OwnedDeps};
 
 use crate::{
     contract::instantiate,

--- a/framework/contracts/native/ibc-client/Cargo.toml
+++ b/framework/contracts/native/ibc-client/Cargo.toml
@@ -36,7 +36,7 @@ workspace-hack = { version = "0.1", path = "../../../workspace-hack" }
 [dev-dependencies]
 cosmwasm-schema = { workspace = true }
 abstract-testing = { workspace = true }
-speculoos = { workspace = true }
+assertor = { workspace = true }
 
 ibc-proto = { version = "0.47.0", default-features = false }
 prost = { version = "0.13.1", default-features = false }

--- a/framework/contracts/native/ibc-client/src/contract.rs
+++ b/framework/contracts/native/ibc-client/src/contract.rs
@@ -151,7 +151,7 @@ mod tests {
     };
     use cw2::CONTRACT;
     use cw_ownable::{Ownership, OwnershipError};
-    use speculoos::prelude::*;
+    use assertor::*;
 
     type IbcClientTestResult = Result<(), IbcClientError>;
 

--- a/framework/contracts/native/ibc-client/src/contract.rs
+++ b/framework/contracts/native/ibc-client/src/contract.rs
@@ -144,6 +144,7 @@ mod tests {
     use crate::test_common::mock_init;
     use abstract_std::{account, ibc_client::state::*, registry};
     use abstract_testing::prelude::*;
+    use assertor::*;
     use cosmwasm_std::{
         from_json,
         testing::{message_info, mock_dependencies},
@@ -151,7 +152,6 @@ mod tests {
     };
     use cw2::CONTRACT;
     use cw_ownable::{Ownership, OwnershipError};
-    use assertor::*;
 
     type IbcClientTestResult = Result<(), IbcClientError>;
 

--- a/framework/contracts/native/ibc-client/src/contract.rs
+++ b/framework/contracts/native/ibc-client/src/contract.rs
@@ -166,9 +166,9 @@ mod tests {
         let not_admin = deps.api.addr_make("not_admin");
 
         let res = execute_as(&mut deps, &not_admin, msg);
-        assert_that!(&res)
-            .is_err()
-            .matches(|e| matches!(e, IbcClientError::Ownership(OwnershipError::NotOwner)));
+        assert_that!(res)
+            .err()
+            .is_equal_to(IbcClientError::Ownership(OwnershipError::NotOwner));
 
         Ok(())
     }
@@ -214,7 +214,7 @@ mod tests {
             let res = contract::migrate(deps.as_mut(), env, MigrateMsg::Migrate {});
 
             assert_that!(res)
-                .is_err()
+                .err()
                 .is_equal_to(IbcClientError::Abstract(
                     AbstractError::CannotDowngradeContract {
                         contract: IBC_CLIENT.to_string(),
@@ -240,7 +240,7 @@ mod tests {
             let res = contract::migrate(deps.as_mut(), env, MigrateMsg::Migrate {});
 
             assert_that!(res)
-                .is_err()
+                .err()
                 .is_equal_to(IbcClientError::Abstract(
                     AbstractError::CannotDowngradeContract {
                         contract: IBC_CLIENT.to_string(),
@@ -265,7 +265,7 @@ mod tests {
             let res = contract::migrate(deps.as_mut(), env, MigrateMsg::Migrate {});
 
             assert_that!(res)
-                .is_err()
+                .err()
                 .is_equal_to(IbcClientError::Abstract(
                     AbstractError::ContractNameMismatch {
                         from: old_name.parse().unwrap(),
@@ -343,9 +343,9 @@ mod tests {
             };
 
             let res = execute_as(&mut deps, &abstr.owner, msg);
-            assert_that!(&res)
-                .is_err()
-                .matches(|e| matches!(e, IbcClientError::HostAddressExists {}));
+            assert_that!(res)
+                .err()
+                .is_equal_to(IbcClientError::HostAddressExists {});
 
             Ok(())
         }
@@ -492,12 +492,12 @@ mod tests {
 
             let res = execute_as(&mut deps, &not_account, msg);
 
-            assert_that!(res).is_err().matches(|e| {
-                matches!(
-                    e,
-                    IbcClientError::RegistryError(RegistryError::NotAccount(..))
-                )
-            });
+            assert_that!(res)
+                .err()
+                .is_equal_to(IbcClientError::RegistryError(RegistryError::NotAccount(
+                    not_account,
+                    TEST_ACCOUNT_ID,
+                )));
             Ok(())
         }
 
@@ -526,8 +526,8 @@ mod tests {
             let res = execute_as(&mut deps, account.addr(), msg);
 
             assert_that!(res)
-                .is_err()
-                .matches(|e| matches!(e, IbcClientError::ForbiddenInternalCall {}));
+                .err()
+                .is_equal_to(IbcClientError::ForbiddenInternalCall {});
             Ok(())
         }
 
@@ -791,12 +791,12 @@ mod tests {
 
             let res = execute_as(&mut deps, &not_account, msg);
 
-            assert_that!(res).is_err().matches(|e| {
-                matches!(
-                    e,
-                    IbcClientError::RegistryError(RegistryError::NotAccount(..))
-                )
-            });
+            assert_that!(res)
+                .err()
+                .is_equal_to(IbcClientError::RegistryError(RegistryError::NotAccount(
+                    not_account,
+                    TEST_ACCOUNT_ID,
+                )));
             Ok(())
         }
 
@@ -976,9 +976,9 @@ mod tests {
 
             let res = execute_as(&mut deps, &note_addr, msg);
 
-            assert_that!(&res)
-                .is_err()
-                .matches(|e| matches!(e, IbcClientError::Unauthorized { .. }));
+            assert_that!(res)
+                .err()
+                .is_equal_to(IbcClientError::Unauthorized {});
 
             Ok(())
         }
@@ -1004,9 +1004,9 @@ mod tests {
             let not_note = deps.api.addr_make("not_note");
             let res = execute_as(&mut deps, &not_note, msg);
 
-            assert_that!(&res)
-                .is_err()
-                .matches(|e| matches!(e, IbcClientError::Unauthorized { .. }));
+            assert_that!(res)
+                .err()
+                .is_equal_to(IbcClientError::Unauthorized {});
 
             Ok(())
         }
@@ -1032,9 +1032,9 @@ mod tests {
 
             let res = execute_as(&mut deps, &note_addr, msg);
 
-            assert_that!(&res)
-                .is_err()
-                .matches(|e| matches!(e, IbcClientError::UnregisteredChain { .. }));
+            assert_that!(res)
+                .err()
+                .is_equal_to(IbcClientError::UnregisteredChain(TEST_CHAIN.to_string()));
 
             Ok(())
         }
@@ -1069,9 +1069,9 @@ mod tests {
 
             let res = execute_as(&mut deps, &note_addr, msg);
 
-            assert_that!(&res)
-                .is_err()
-                .matches(|e| matches!(e, IbcClientError::IbcFailed(_callback_msg)));
+            assert_that!(res)
+                .err()
+                .is_equal_to(IbcClientError::IbcFailed(callback_msg));
 
             Ok(())
         }
@@ -1152,9 +1152,9 @@ mod tests {
 
             let res = execute_as(&mut deps, &note_addr, msg);
 
-            assert_that!(&res)
-                .is_err()
-                .matches(|e| matches!(e, IbcClientError::IbcFailed(_callback_msg)));
+            assert_that!(res)
+                .err()
+                .is_equal_to(IbcClientError::IbcFailed(callback_msg));
 
             Ok(())
         }
@@ -1190,9 +1190,9 @@ mod tests {
 
             let res = execute_as(&mut deps, &note_addr, msg);
 
-            assert_that!(&res)
-                .is_err()
-                .matches(|e| matches!(e, IbcClientError::IbcFailed(_callback_msg)));
+            assert_that!(res)
+                .err()
+                .is_equal_to(IbcClientError::IbcFailed(callback_msg));
 
             Ok(())
         }
@@ -1228,9 +1228,9 @@ mod tests {
 
             let res = execute_as(&mut deps, &note_addr, msg);
 
-            assert_that!(&res)
-                .is_err()
-                .matches(|e| matches!(e, IbcClientError::IbcFailed(_callback_msg)));
+            assert_that!(res)
+                .err()
+                .is_equal_to(IbcClientError::IbcFailed(callback_msg));
 
             Ok(())
         }

--- a/framework/contracts/native/ica-client/Cargo.toml
+++ b/framework/contracts/native/ica-client/Cargo.toml
@@ -38,7 +38,7 @@ workspace-hack = { version = "0.1", path = "../../../workspace-hack" }
 [dev-dependencies]
 cosmwasm-schema = { workspace = true }
 abstract-testing = { workspace = true }
-speculoos = { workspace = true }
+assertor = { workspace = true }
 
 [profile.release]
 overflow-checks = true

--- a/framework/contracts/native/ica-client/src/contract.rs
+++ b/framework/contracts/native/ica-client/src/contract.rs
@@ -84,6 +84,7 @@ mod tests {
 
     use crate::test_common::mock_init;
     use abstract_testing::{mock_env_validated, prelude::*};
+    use assertor::*;
     use cosmwasm_std::{
         from_json,
         testing::{message_info, mock_dependencies},
@@ -91,7 +92,6 @@ mod tests {
     };
     use cw2::CONTRACT;
     use cw_ownable::Ownership;
-    use speculoos::prelude::*;
 
     #[test]
     fn instantiate_works() -> IcaClientResult<()> {
@@ -136,7 +136,7 @@ mod tests {
             let res = contract::migrate(deps.as_mut(), env, MigrateMsg::Migrate {});
 
             assert_that!(res)
-                .is_err()
+                .err()
                 .is_equal_to(IcaClientError::Abstract(
                     AbstractError::CannotDowngradeContract {
                         contract: ICA_CLIENT.to_string(),
@@ -162,7 +162,7 @@ mod tests {
             let res = contract::migrate(deps.as_mut(), env, MigrateMsg::Migrate {});
 
             assert_that!(res)
-                .is_err()
+                .err()
                 .is_equal_to(IcaClientError::Abstract(
                     AbstractError::CannotDowngradeContract {
                         contract: ICA_CLIENT.to_string(),
@@ -187,7 +187,7 @@ mod tests {
             let res = contract::migrate(deps.as_mut(), env, MigrateMsg::Migrate {});
 
             assert_that!(res)
-                .is_err()
+                .err()
                 .is_equal_to(IcaClientError::Abstract(
                     AbstractError::ContractNameMismatch {
                         from: old_name.parse().unwrap(),

--- a/framework/contracts/native/ica-client/src/queries.rs
+++ b/framework/contracts/native/ica-client/src/queries.rs
@@ -94,7 +94,7 @@ mod tests {
 
     use evm::types;
     use polytone_evm::EVM_NOTE_ID;
-    use speculoos::prelude::*;
+    use assertor::*;
 
     type IbcClientTestResult = Result<(), IcaClientError>;
 

--- a/framework/contracts/native/ica-client/src/queries.rs
+++ b/framework/contracts/native/ica-client/src/queries.rs
@@ -92,9 +92,9 @@ mod tests {
         Addr, HexBinary,
     };
 
+    use assertor::*;
     use evm::types;
     use polytone_evm::EVM_NOTE_ID;
-    use assertor::*;
 
     type IbcClientTestResult = Result<(), IcaClientError>;
 

--- a/framework/contracts/native/module-factory/Cargo.toml
+++ b/framework/contracts/native/module-factory/Cargo.toml
@@ -44,7 +44,7 @@ workspace-hack = { version = "0.1", path = "../../../workspace-hack" }
 abstract-interface = { workspace = true }
 cw-orch = { workspace = true }
 anyhow = { workspace = true }
-speculoos = { workspace = true }
+assertor = { workspace = true }
 abstract-testing = { workspace = true }
 abstract-integration-tests = { workspace = true }
 

--- a/framework/contracts/native/module-factory/src/commands.rs
+++ b/framework/contracts/native/module-factory/src/commands.rs
@@ -232,11 +232,11 @@ mod test {
     #![allow(clippy::needless_borrows_for_generic_args)]
     use abstract_std::module_factory::ExecuteMsg;
     use abstract_testing::{mock_env_validated, MockDeps};
+    use assertor::*;
     use cosmwasm_std::{
         testing::{message_info, mock_dependencies},
         to_json_binary,
     };
-    use assertor::*;
 
     use super::*;
     use crate::{contract::execute, test_common::*};

--- a/framework/contracts/native/module-factory/src/commands.rs
+++ b/framework/contracts/native/module-factory/src/commands.rs
@@ -236,7 +236,7 @@ mod test {
         testing::{message_info, mock_dependencies},
         to_json_binary,
     };
-    use speculoos::prelude::*;
+    use assertor::*;
 
     use super::*;
     use crate::{contract::execute, test_common::*};

--- a/framework/contracts/native/module-factory/src/contract.rs
+++ b/framework/contracts/native/module-factory/src/contract.rs
@@ -131,8 +131,8 @@ pub fn migrate(deps: DepsMut, env: Env, msg: MigrateMsg) -> ModuleFactoryResult 
 
 #[cfg(test)]
 mod tests {
-    use cosmwasm_std::testing::*;
     use assertor::*;
+    use cosmwasm_std::testing::*;
 
     use super::*;
     use crate::{contract, test_common::*};

--- a/framework/contracts/native/module-factory/src/contract.rs
+++ b/framework/contracts/native/module-factory/src/contract.rs
@@ -132,7 +132,7 @@ pub fn migrate(deps: DepsMut, env: Env, msg: MigrateMsg) -> ModuleFactoryResult 
 #[cfg(test)]
 mod tests {
     use cosmwasm_std::testing::*;
-    use speculoos::prelude::*;
+    use assertor::*;
 
     use super::*;
     use crate::{contract, test_common::*};

--- a/framework/contracts/native/module-factory/tests/direct_calls.rs
+++ b/framework/contracts/native/module-factory/tests/direct_calls.rs
@@ -4,7 +4,7 @@ use abstract_std::{
 };
 use cosmwasm_std::Binary;
 use cw_orch::prelude::*;
-use speculoos::prelude::*;
+use assertor::*;
 
 type AResult = anyhow::Result<()>; // alias for Result<(), anyhow::Error>
 

--- a/framework/contracts/native/module-factory/tests/direct_calls.rs
+++ b/framework/contracts/native/module-factory/tests/direct_calls.rs
@@ -2,9 +2,9 @@ use abstract_interface::*;
 use abstract_std::{
     module_factory, module_factory::FactoryModuleInstallConfig, objects::module::ModuleInfo,
 };
+use assertor::*;
 use cosmwasm_std::Binary;
 use cw_orch::prelude::*;
-use assertor::*;
 
 type AResult = anyhow::Result<()>; // alias for Result<(), anyhow::Error>
 

--- a/framework/contracts/native/registry/Cargo.toml
+++ b/framework/contracts/native/registry/Cargo.toml
@@ -40,7 +40,7 @@ cosmwasm-schema = { workspace = true }
 abstract-interface = { workspace = true }
 cw-orch = { workspace = true }
 anyhow = { workspace = true }
-speculoos = { workspace = true }
+assertor = { workspace = true }
 abstract-testing = { workspace = true }
 
 [profile.release]

--- a/framework/contracts/native/registry/src/commands.rs
+++ b/framework/contracts/native/registry/src/commands.rs
@@ -669,6 +669,7 @@ mod tests {
     use abstract_sdk::namespaces::OWNERSHIP_STORAGE_KEY;
     use abstract_std::{objects::account::AccountTrace, registry::*, ACCOUNT};
     use abstract_testing::{abstract_mock_querier_builder, prelude::*};
+    use assertor::*;
     use cosmwasm_std::{
         from_json,
         testing::{message_info, mock_dependencies, MockApi},
@@ -677,7 +678,6 @@ mod tests {
     use cw_ownable::OwnershipError;
     use cw_storage_plus::Item;
     use ownership::{GovernanceDetails, Ownership};
-    use assertor::*;
 
     use super::*;
     use crate::contract;

--- a/framework/contracts/native/registry/src/commands.rs
+++ b/framework/contracts/native/registry/src/commands.rs
@@ -677,7 +677,7 @@ mod tests {
     use cw_ownable::OwnershipError;
     use cw_storage_plus::Item;
     use ownership::{GovernanceDetails, Ownership};
-    use speculoos::prelude::*;
+    use assertor::*;
 
     use super::*;
     use crate::contract;

--- a/framework/contracts/native/registry/src/contract.rs
+++ b/framework/contracts/native/registry/src/contract.rs
@@ -142,11 +142,11 @@ mod tests {
     mod testing {
         use abstract_std::registry;
         use abstract_testing::prelude::*;
+        use assertor::*;
         use cosmwasm_std::{
             testing::{message_info, mock_dependencies, MockApi},
             OwnedDeps, Response,
         };
-        use assertor::*;
 
         use crate::{contract, error::RegistryError};
 

--- a/framework/contracts/native/registry/src/contract.rs
+++ b/framework/contracts/native/registry/src/contract.rs
@@ -146,7 +146,7 @@ mod tests {
             testing::{message_info, mock_dependencies, MockApi},
             OwnedDeps, Response,
         };
-        use speculoos::prelude::*;
+        use assertor::*;
 
         use crate::{contract, error::RegistryError};
 

--- a/framework/contracts/native/registry/src/queries.rs
+++ b/framework/contracts/native/registry/src/queries.rs
@@ -272,7 +272,7 @@ mod test {
         testing::{message_info, mock_dependencies, MockApi},
         Addr, Binary, StdError,
     };
-    use speculoos::prelude::*;
+    use assertor::*;
 
     type RegistryTestResult = Result<(), RegistryError>;
 

--- a/framework/contracts/native/registry/src/queries.rs
+++ b/framework/contracts/native/registry/src/queries.rs
@@ -268,11 +268,11 @@ mod test {
     use crate::contract;
     use abstract_std::{account, objects::account::AccountTrace, registry::*};
     use abstract_testing::{prelude::*, MockQuerierOwnership};
+    use assertor::*;
     use cosmwasm_std::{
         testing::{message_info, mock_dependencies, MockApi},
         Addr, Binary, StdError,
     };
-    use assertor::*;
 
     type RegistryTestResult = Result<(), RegistryError>;
 

--- a/framework/contracts/native/registry/tests/direct_calls.rs
+++ b/framework/contracts/native/registry/tests/direct_calls.rs
@@ -4,7 +4,7 @@ use abstract_std::{
 };
 use cosmwasm_std::Binary;
 use cw_orch::prelude::*;
-use speculoos::prelude::*;
+use assertor::*;
 
 type AResult = anyhow::Result<()>; // alias for Result<(), anyhow::Error>
 

--- a/framework/contracts/native/registry/tests/direct_calls.rs
+++ b/framework/contracts/native/registry/tests/direct_calls.rs
@@ -2,9 +2,9 @@ use abstract_interface::*;
 use abstract_std::{
     module_factory, module_factory::FactoryModuleInstallConfig, objects::module::ModuleInfo,
 };
+use assertor::*;
 use cosmwasm_std::Binary;
 use cw_orch::prelude::*;
-use assertor::*;
 
 type AResult = anyhow::Result<()>; // alias for Result<(), anyhow::Error>
 

--- a/framework/packages/abstract-ica/Cargo.toml
+++ b/framework/packages/abstract-ica/Cargo.toml
@@ -34,7 +34,7 @@ alloy-sol-types = { version = "0.7.7", default-features = false }
 workspace-hack = { version = "0.1", path = "../../workspace-hack" }
 
 [dev-dependencies]
-speculoos = { workspace = true }
+assertor = { workspace = true }
 rstest = { workspace = true }
 anyhow = { workspace = true }
 abstract-testing = { path = "../abstract-testing" }

--- a/framework/packages/abstract-integration-tests/Cargo.toml
+++ b/framework/packages/abstract-integration-tests/Cargo.toml
@@ -16,7 +16,6 @@ semver = { workspace = true }
 cw-ownable = { workspace = true }
 cw-orch = { workspace = true }
 log = "0.4.14"
-speculoos = { workspace = true }
 abstract-std.workspace = true
 abstract-sdk.workspace = true
 anyhow.workspace = true
@@ -24,6 +23,7 @@ abstract-testing.workspace = true
 cosmwasm-schema = { workspace = true }
 cw2 = { workspace = true }
 cw-asset = { workspace = true }
+assertor = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 workspace-hack = { version = "0.1", path = "../../workspace-hack" }

--- a/framework/packages/abstract-integration-tests/src/account.rs
+++ b/framework/packages/abstract-integration-tests/src/account.rs
@@ -18,10 +18,10 @@ use abstract_std::{
     registry::UpdateModule,
 };
 use abstract_testing::prelude::*;
+use assertor::*;
 use cosmwasm_std::{coin, coins, wasm_execute, Uint128};
 use cw2::ContractVersion;
 use cw_orch::{environment::MutCwEnv, prelude::*};
-use assertor::*;
 
 use crate::{
     add_mock_adapter_install_fee, create_default_account, init_mock_adapter, install_adapter,

--- a/framework/packages/abstract-integration-tests/src/account.rs
+++ b/framework/packages/abstract-integration-tests/src/account.rs
@@ -21,7 +21,7 @@ use abstract_testing::prelude::*;
 use cosmwasm_std::{coin, coins, wasm_execute, Uint128};
 use cw2::ContractVersion;
 use cw_orch::{environment::MutCwEnv, prelude::*};
-use speculoos::prelude::*;
+use assertor::*;
 
 use crate::{
     add_mock_adapter_install_fee, create_default_account, init_mock_adapter, install_adapter,

--- a/framework/packages/abstract-interface/Cargo.toml
+++ b/framework/packages/abstract-interface/Cargo.toml
@@ -39,7 +39,7 @@ cw-orch = { workspace = true }
 cw-orch-interchain = { workspace = true, optional = true }
 log = "0.4.14"
 serde_json = "1.0.79"
-speculoos = { workspace = true }
+assertor = { workspace = true }
 cw-orch-polytone = { workspace = true, optional = true }
 
 # Embed state.json in binary in release mode

--- a/framework/packages/abstract-interface/src/account.rs
+++ b/framework/packages/abstract-interface/src/account.rs
@@ -33,7 +33,7 @@ use cw2::{ContractVersion, CONTRACT};
 use cw_orch::{environment::Environment, interface, prelude::*};
 use semver::{Version, VersionReq};
 use serde::Serialize;
-use speculoos::prelude::*;
+use assertor::*;
 use std::{collections::HashSet, fmt::Debug};
 
 /// A helper struct that contains fields from [`abstract_std::account::state::AccountInfo`]

--- a/framework/packages/abstract-interface/src/account.rs
+++ b/framework/packages/abstract-interface/src/account.rs
@@ -27,13 +27,13 @@ use abstract_std::{
     registry::{state::LOCAL_ACCOUNT_SEQUENCE, ExecuteMsgFns, ModuleFilter, QueryMsgFns},
     ABSTRACT_EVENT_TYPE, ACCOUNT, IBC_CLIENT,
 };
+use assertor::*;
 use cosmwasm_std::{from_json, to_json_binary};
 use cosmwasm_std::{Binary, Empty};
 use cw2::{ContractVersion, CONTRACT};
 use cw_orch::{environment::Environment, interface, prelude::*};
 use semver::{Version, VersionReq};
 use serde::Serialize;
-use assertor::*;
 use std::{collections::HashSet, fmt::Debug};
 
 /// A helper struct that contains fields from [`abstract_std::account::state::AccountInfo`]

--- a/framework/packages/abstract-macros/Cargo.toml
+++ b/framework/packages/abstract-macros/Cargo.toml
@@ -20,4 +20,4 @@ syn = { version = "1", features = ["full", "extra-traits"] }
 
 [dev-dependencies]
 cosmwasm-std = { workspace = true }
-speculoos = { workspace = true }
+assertor = { workspace = true }

--- a/framework/packages/abstract-macros/tests/abstract_response.rs
+++ b/framework/packages/abstract-macros/tests/abstract_response.rs
@@ -2,7 +2,7 @@
 mod tests {
     use abstract_macros::abstract_response;
     use cosmwasm_std::Response;
-    use speculoos::prelude::*;
+    use assertor::*;
 
     const TEST_CONTRACT: &str = "test:contract";
 

--- a/framework/packages/abstract-macros/tests/abstract_response.rs
+++ b/framework/packages/abstract-macros/tests/abstract_response.rs
@@ -1,8 +1,8 @@
 #[cfg(test)]
 mod tests {
     use abstract_macros::abstract_response;
-    use cosmwasm_std::Response;
     use assertor::*;
+    use cosmwasm_std::Response;
 
     const TEST_CONTRACT: &str = "test:contract";
 

--- a/framework/packages/abstract-macros/tests/with_abstract_event.rs
+++ b/framework/packages/abstract-macros/tests/with_abstract_event.rs
@@ -1,8 +1,8 @@
 #[cfg(test)]
 mod tests {
     use abstract_macros::with_abstract_event;
-    use cosmwasm_std::Response;
     use assertor::*;
+    use cosmwasm_std::Response;
 
     #[test]
     fn test_abstract_response() {

--- a/framework/packages/abstract-macros/tests/with_abstract_event.rs
+++ b/framework/packages/abstract-macros/tests/with_abstract_event.rs
@@ -2,7 +2,7 @@
 mod tests {
     use abstract_macros::with_abstract_event;
     use cosmwasm_std::Response;
-    use speculoos::prelude::*;
+    use assertor::*;
 
     #[test]
     fn test_abstract_response() {

--- a/framework/packages/abstract-sdk/Cargo.toml
+++ b/framework/packages/abstract-sdk/Cargo.toml
@@ -46,7 +46,7 @@ workspace-hack = { version = "0.1", path = "../../workspace-hack" }
 
 
 [dev-dependencies]
-speculoos = { workspace = true }
+assertor = { workspace = true }
 cosmwasm-schema = { workspace = true }
 doc-comment = "0.3.3"
 # Set our own feature when running tests!

--- a/framework/packages/abstract-sdk/src/ans_resolve.rs
+++ b/framework/packages/abstract-sdk/src/ans_resolve.rs
@@ -132,11 +132,11 @@ mod tests {
 
     use abstract_std::ans_host::state::ASSET_ADDRESSES;
     use abstract_testing::prelude::*;
+    use assertor::*;
     use cosmwasm_std::{
         testing::{mock_dependencies, MockApi},
         Binary, Empty,
     };
-    use speculoos::prelude::*;
     use std::fmt::Debug;
 
     fn default_test_querier(ans_host: &AnsHost) -> MockQuerier {

--- a/framework/packages/abstract-sdk/src/apis/adapter.rs
+++ b/framework/packages/abstract-sdk/src/apis/adapter.rs
@@ -106,8 +106,8 @@ impl<'a, T: AdapterInterface> Adapters<'a, T> {
 mod tests {
 
     use abstract_testing::prelude::*;
+    use assertor::*;
     use cosmwasm_std::*;
-    use speculoos::{assert_that, result::ResultAssertions};
 
     use super::*;
     use crate::mock_module::*;
@@ -123,8 +123,9 @@ mod tests {
         let res = modules_fn(&app, deps.as_ref());
 
         assert_that!(res)
-            .is_err()
-            .matches(|e| e.to_string().contains(&fake_module.to_string()));
+            .err()
+            .as_string()
+            .contains(&fake_module.to_string());
     }
     mod adapter_request {
         use super::*;
@@ -158,7 +159,7 @@ mod tests {
                 });
 
             assert_that!(res)
-                .is_ok()
+                .ok()
                 .is_equal_to(CosmosMsg::Wasm(WasmMsg::Execute {
                     contract_addr: abstr.module_address.to_string(),
                     msg: to_json_binary(&expected_msg).unwrap(),
@@ -192,7 +193,7 @@ mod tests {
             let res = mods.query::<_, String>(TEST_MODULE_ID, inner_msg);
 
             assert_that!(res)
-                .is_ok()
+                .ok()
                 .is_equal_to(TEST_MODULE_RESPONSE.to_string());
         }
     }

--- a/framework/packages/abstract-sdk/src/apis/app.rs
+++ b/framework/packages/abstract-sdk/src/apis/app.rs
@@ -120,8 +120,9 @@ mod tests {
         let res = modules_fn(&app, deps.as_ref());
 
         assert_that!(res)
-            .is_err()
-            .matches(|e| e.to_string().contains(&fake_module.to_string()));
+            .err()
+            .as_string()
+            .contains(&fake_module.to_string());
     }
 
     mod app_request {
@@ -152,7 +153,7 @@ mod tests {
             let expected_msg: app::ExecuteMsg<_> = app::ExecuteMsg::Module(MockModuleExecuteMsg {});
 
             assert_that!(res)
-                .is_ok()
+                .ok()
                 .is_equal_to(CosmosMsg::Wasm(WasmMsg::Execute {
                     contract_addr: abstr.module_address.into(),
                     msg: to_json_binary(&expected_msg).unwrap(),
@@ -184,7 +185,7 @@ mod tests {
             let res = mods.query::<_, String>(TEST_MODULE_ID, Empty {});
 
             assert_that!(res)
-                .is_ok()
+                .ok()
                 .is_equal_to(TEST_MODULE_RESPONSE.to_string());
         }
     }

--- a/framework/packages/abstract-sdk/src/apis/app.rs
+++ b/framework/packages/abstract-sdk/src/apis/app.rs
@@ -102,8 +102,8 @@ impl<'a, T: AppInterface> Apps<'a, T> {
 mod tests {
     use abstract_std::registry::Account;
     use abstract_testing::{abstract_mock_querier_builder, prelude::*};
+    use assertor::*;
     use cosmwasm_std::{testing::*, *};
-    use speculoos::prelude::*;
 
     pub use super::*;
     use crate::mock_module::*;

--- a/framework/packages/abstract-sdk/src/apis/bank.rs
+++ b/framework/packages/abstract-sdk/src/apis/bank.rs
@@ -286,8 +286,8 @@ mod test {
     #![allow(clippy::needless_borrows_for_generic_args)]
     use abstract_testing::mock_env_validated;
     use abstract_testing::prelude::*;
+    use assertor::*;
     use cosmwasm_std::*;
-    use speculoos::prelude::*;
 
     use super::*;
     use crate::mock_module::*;

--- a/framework/packages/abstract-sdk/src/apis/distribution.rs
+++ b/framework/packages/abstract-sdk/src/apis/distribution.rs
@@ -145,7 +145,7 @@ impl Distribution {
 #[cfg(test)]
 mod test {
     #![allow(clippy::needless_borrows_for_generic_args)]
-    use speculoos::prelude::*;
+    use assertor::*;
 
     use super::*;
     use crate::mock_module::*;

--- a/framework/packages/abstract-sdk/src/apis/execution.rs
+++ b/framework/packages/abstract-sdk/src/apis/execution.rs
@@ -189,8 +189,8 @@ mod test {
     #![allow(clippy::needless_borrows_for_generic_args)]
     use abstract_std::account::ExecuteMsg;
     use abstract_testing::prelude::*;
+    use assertor::*;
     use cosmwasm_std::*;
-    use speculoos::prelude::*;
 
     use super::*;
     use crate::mock_module::*;

--- a/framework/packages/abstract-sdk/src/apis/ibc.rs
+++ b/framework/packages/abstract-sdk/src/apis/ibc.rs
@@ -359,7 +359,7 @@ mod test {
     #![allow(clippy::needless_borrows_for_generic_args)]
     use abstract_testing::prelude::*;
     use cosmwasm_std::*;
-    use speculoos::prelude::*;
+    use assertor::*;
 
     use super::*;
     use crate::mock_module::*;

--- a/framework/packages/abstract-sdk/src/apis/ibc.rs
+++ b/framework/packages/abstract-sdk/src/apis/ibc.rs
@@ -358,8 +358,8 @@ impl<'a, T: IbcInterface + AccountExecutor> IbcClient<'a, T> {
 mod test {
     #![allow(clippy::needless_borrows_for_generic_args)]
     use abstract_testing::prelude::*;
-    use cosmwasm_std::*;
     use assertor::*;
+    use cosmwasm_std::*;
 
     use super::*;
     use crate::mock_module::*;

--- a/framework/packages/abstract-sdk/src/apis/modules.rs
+++ b/framework/packages/abstract-sdk/src/apis/modules.rs
@@ -124,7 +124,7 @@ impl<'a, T: ModuleInterface> Modules<'a, T> {
 mod test {
     #![allow(clippy::needless_borrows_for_generic_args)]
     use abstract_testing::prelude::*;
-    use speculoos::prelude::*;
+    use assertor::*;
 
     use super::*;
     use crate::mock_module::*;

--- a/framework/packages/abstract-sdk/src/apis/verify.rs
+++ b/framework/packages/abstract-sdk/src/apis/verify.rs
@@ -142,8 +142,8 @@ mod test {
         registry::state::ACCOUNT_ADDRESSES,
     };
     use abstract_testing::prelude::*;
+    use assertor::*;
     use cosmwasm_std::testing::*;
-    use speculoos::prelude::*;
 
     struct MockBinding {}
 

--- a/framework/packages/abstract-sdk/src/base/features/identification.rs
+++ b/framework/packages/abstract-sdk/src/base/features/identification.rs
@@ -23,8 +23,8 @@ pub trait AccountIdentification: Sized {
 mod test {
     #![allow(clippy::needless_borrows_for_generic_args)]
     use abstract_testing::prelude::*;
+    use assertor::*;
     use cosmwasm_std::testing::MockApi;
-    use speculoos::prelude::*;
 
     use super::*;
 

--- a/framework/packages/abstract-sdk/src/cw_helpers/cosmwasm_std/abstract_attributes.rs
+++ b/framework/packages/abstract-sdk/src/cw_helpers/cosmwasm_std/abstract_attributes.rs
@@ -39,7 +39,7 @@ mod test {
     #![allow(clippy::needless_borrows_for_generic_args)]
     use super::*;
 
-    use speculoos::prelude::*;
+    use assertor::*;
 
     #[test]
     fn test_add_abstract_attributes_no_abstract_event() {

--- a/framework/packages/abstract-sdk/src/cw_helpers/cw_storage_plus.rs
+++ b/framework/packages/abstract-sdk/src/cw_helpers/cw_storage_plus.rs
@@ -25,11 +25,11 @@ where
 #[cfg(test)]
 mod test {
     #![allow(clippy::needless_borrows_for_generic_args)]
+    use assertor::*;
     use cosmwasm_std::{
         testing::{mock_dependencies, MockApi, MockQuerier, MockStorage},
         OwnedDeps,
     };
-    use speculoos::prelude::*;
 
     use super::*;
 

--- a/framework/packages/abstract-sdk/src/feature_objects.rs
+++ b/framework/packages/abstract-sdk/src/feature_objects.rs
@@ -47,7 +47,7 @@ impl crate::features::AbstractNameService for AnsHost {
 #[cfg(test)]
 mod tests {
     use abstract_testing::prelude::*;
-    use speculoos::prelude::*;
+    use assertor::*;
 
     use super::*;
 

--- a/framework/packages/abstract-standalone/Cargo.toml
+++ b/framework/packages/abstract-standalone/Cargo.toml
@@ -39,6 +39,6 @@ workspace-hack = { version = "0.1", path = "../../workspace-hack" }
 
 [dev-dependencies]
 cosmwasm-schema = { workspace = true }
-speculoos = { workspace = true }
+assertor = { workspace = true }
 abstract-standalone = { path = ".", features = ["test-utils"] }
 abstract-integration-tests = { workspace = true }

--- a/framework/packages/abstract-standalone/src/features.rs
+++ b/framework/packages/abstract-standalone/src/features.rs
@@ -40,7 +40,7 @@ mod test {
     #![allow(clippy::needless_borrows_for_generic_args)]
     use abstract_sdk::{AccountVerification, ModuleRegistryInterface};
     use abstract_testing::prelude::*;
-    use speculoos::prelude::*;
+    use assertor::*;
 
     use super::*;
     use crate::mock::*;

--- a/framework/packages/abstract-std/Cargo.toml
+++ b/framework/packages/abstract-std/Cargo.toml
@@ -41,7 +41,7 @@ function_name = { version = "0.3.0" }
 workspace-hack = { version = "0.1", path = "../../workspace-hack" }
 
 [dev-dependencies]
-speculoos = { workspace = true }
+assertor = { workspace = true }
 rstest = { workspace = true }
 anyhow = { workspace = true }
 abstract-testing = { path = "../abstract-testing" }

--- a/framework/packages/abstract-std/src/native/ibc/ibc_client.rs
+++ b/framework/packages/abstract-std/src/native/ibc/ibc_client.rs
@@ -365,8 +365,8 @@ pub struct RemoteProxyResponse {
 
 #[cfg(test)]
 mod tests {
-    use cosmwasm_std::{to_json_binary, CosmosMsg, Empty};
     use assertor::*;
+    use cosmwasm_std::{to_json_binary, CosmosMsg, Empty};
 
     use crate::app::ExecuteMsg;
     use crate::ibc::{Callback, IbcResponseMsg, IbcResult};

--- a/framework/packages/abstract-std/src/native/ibc/ibc_client.rs
+++ b/framework/packages/abstract-std/src/native/ibc/ibc_client.rs
@@ -366,7 +366,7 @@ pub struct RemoteProxyResponse {
 #[cfg(test)]
 mod tests {
     use cosmwasm_std::{to_json_binary, CosmosMsg, Empty};
-    use speculoos::prelude::*;
+    use assertor::*;
 
     use crate::app::ExecuteMsg;
     use crate::ibc::{Callback, IbcResponseMsg, IbcResult};

--- a/framework/packages/abstract-std/src/objects/ans_asset.rs
+++ b/framework/packages/abstract-std/src/objects/ans_asset.rs
@@ -30,7 +30,7 @@ impl fmt::Display for AnsAsset {
 #[cfg(test)]
 mod test {
     #![allow(clippy::needless_borrows_for_generic_args)]
-    use speculoos::prelude::*;
+    use assertor::*;
 
     use super::*;
 

--- a/framework/packages/abstract-std/src/objects/dependency.rs
+++ b/framework/packages/abstract-std/src/objects/dependency.rs
@@ -76,7 +76,7 @@ impl From<Dependency> for DependencyResponse {
 #[cfg(test)]
 mod test {
     #![allow(clippy::needless_borrows_for_generic_args)]
-    use speculoos::prelude::*;
+    use assertor::*;
 
     use super::*;
 

--- a/framework/packages/abstract-std/src/objects/entry/asset_entry.rs
+++ b/framework/packages/abstract-std/src/objects/entry/asset_entry.rs
@@ -113,8 +113,8 @@ impl KeyDeserialize for &AssetEntry {
 #[cfg(test)]
 mod test {
     #![allow(clippy::needless_borrows_for_generic_args)]
-    use rstest::rstest;
     use assertor::*;
+    use rstest::rstest;
 
     use super::*;
 

--- a/framework/packages/abstract-std/src/objects/entry/asset_entry.rs
+++ b/framework/packages/abstract-std/src/objects/entry/asset_entry.rs
@@ -114,7 +114,7 @@ impl KeyDeserialize for &AssetEntry {
 mod test {
     #![allow(clippy::needless_borrows_for_generic_args)]
     use rstest::rstest;
-    use speculoos::prelude::*;
+    use assertor::*;
 
     use super::*;
 

--- a/framework/packages/abstract-std/src/objects/entry/lp_token.rs
+++ b/framework/packages/abstract-std/src/objects/entry/lp_token.rs
@@ -52,7 +52,7 @@ impl Display for LpToken {
 #[cfg(test)]
 mod test {
     #![allow(clippy::needless_borrows_for_generic_args)]
-    use speculoos::prelude::*;
+    use assertor::*;
 
     use super::*;
 

--- a/framework/packages/abstract-std/src/objects/gov_type.rs
+++ b/framework/packages/abstract-std/src/objects/gov_type.rs
@@ -262,7 +262,7 @@ mod test {
     use super::*;
 
     use cosmwasm_std::testing::mock_dependencies;
-    use speculoos::prelude::*;
+    use assertor::*;
 
     #[test]
     fn test_verify() {

--- a/framework/packages/abstract-std/src/objects/gov_type.rs
+++ b/framework/packages/abstract-std/src/objects/gov_type.rs
@@ -261,8 +261,8 @@ mod test {
     #![allow(clippy::needless_borrows_for_generic_args)]
     use super::*;
 
-    use cosmwasm_std::testing::mock_dependencies;
     use assertor::*;
+    use cosmwasm_std::testing::mock_dependencies;
 
     #[test]
     fn test_verify() {

--- a/framework/packages/abstract-std/src/objects/module.rs
+++ b/framework/packages/abstract-std/src/objects/module.rs
@@ -515,9 +515,9 @@ pub type ModuleMetadata = String;
 #[cfg(test)]
 mod test {
     #![allow(clippy::needless_borrows_for_generic_args)]
+    use assertor::*;
     use cosmwasm_std::{testing::mock_dependencies, Addr, Order};
     use cw_storage_plus::Map;
-    use assertor::*;
 
     use super::*;
 

--- a/framework/packages/abstract-std/src/objects/module.rs
+++ b/framework/packages/abstract-std/src/objects/module.rs
@@ -517,7 +517,7 @@ mod test {
     #![allow(clippy::needless_borrows_for_generic_args)]
     use cosmwasm_std::{testing::mock_dependencies, Addr, Order};
     use cw_storage_plus::Map;
-    use speculoos::prelude::*;
+    use assertor::*;
 
     use super::*;
 

--- a/framework/packages/abstract-std/src/objects/module_reference.rs
+++ b/framework/packages/abstract-std/src/objects/module_reference.rs
@@ -117,8 +117,8 @@ impl ModuleReference {
 #[cfg(test)]
 mod test {
     #![allow(clippy::needless_borrows_for_generic_args)]
-    use cosmwasm_std::testing::mock_dependencies;
     use assertor::*;
+    use cosmwasm_std::testing::mock_dependencies;
 
     use super::*;
 

--- a/framework/packages/abstract-std/src/objects/module_reference.rs
+++ b/framework/packages/abstract-std/src/objects/module_reference.rs
@@ -118,7 +118,7 @@ impl ModuleReference {
 mod test {
     #![allow(clippy::needless_borrows_for_generic_args)]
     use cosmwasm_std::testing::mock_dependencies;
-    use speculoos::prelude::*;
+    use assertor::*;
 
     use super::*;
 

--- a/framework/packages/abstract-std/src/objects/namespace.rs
+++ b/framework/packages/abstract-std/src/objects/namespace.rs
@@ -119,7 +119,7 @@ impl KeyDeserialize for Namespace {
 #[cfg(test)]
 mod test {
     #![allow(clippy::needless_borrows_for_generic_args)]
-    use speculoos::prelude::*;
+    use assertor::*;
 
     use super::*;
 

--- a/framework/packages/abstract-std/src/objects/pool/pool_id.rs
+++ b/framework/packages/abstract-std/src/objects/pool/pool_id.rs
@@ -177,8 +177,8 @@ impl fmt::Display for PoolAddress {
 #[cfg(test)]
 mod test {
     #![allow(clippy::needless_borrows_for_generic_args)]
-    use cosmwasm_std::testing::MockApi;
     use assertor::*;
+    use cosmwasm_std::testing::MockApi;
 
     use super::*;
 

--- a/framework/packages/abstract-std/src/objects/pool/pool_id.rs
+++ b/framework/packages/abstract-std/src/objects/pool/pool_id.rs
@@ -178,7 +178,7 @@ impl fmt::Display for PoolAddress {
 mod test {
     #![allow(clippy::needless_borrows_for_generic_args)]
     use cosmwasm_std::testing::MockApi;
-    use speculoos::prelude::*;
+    use assertor::*;
 
     use super::*;
 

--- a/framework/packages/abstract-std/src/objects/pool/pool_metadata.rs
+++ b/framework/packages/abstract-std/src/objects/pool/pool_metadata.rs
@@ -117,7 +117,7 @@ impl fmt::Display for PoolMetadata {
 
 #[cfg(test)]
 mod tests {
-    use speculoos::prelude::*;
+    use assertor::*;
 
     use super::*;
 

--- a/framework/packages/abstract-std/src/objects/truncated_chain_id.rs
+++ b/framework/packages/abstract-std/src/objects/truncated_chain_id.rs
@@ -134,7 +134,7 @@ impl KeyDeserialize for &TruncatedChainId {
 mod test {
     #![allow(clippy::needless_borrows_for_generic_args)]
     use cosmwasm_std::testing::mock_env;
-    use speculoos::prelude::*;
+    use assertor::*;
 
     use super::*;
 

--- a/framework/packages/abstract-std/src/objects/truncated_chain_id.rs
+++ b/framework/packages/abstract-std/src/objects/truncated_chain_id.rs
@@ -133,8 +133,8 @@ impl KeyDeserialize for &TruncatedChainId {
 #[cfg(test)]
 mod test {
     #![allow(clippy::needless_borrows_for_generic_args)]
-    use cosmwasm_std::testing::mock_env;
     use assertor::*;
+    use cosmwasm_std::testing::mock_env;
 
     use super::*;
 

--- a/framework/packages/abstract-std/src/objects/validation/verifiers.rs
+++ b/framework/packages/abstract-std/src/objects/validation/verifiers.rs
@@ -63,8 +63,8 @@ pub fn validate_description(maybe_description: Option<&str>) -> Result<(), Valid
 
 #[cfg(test)]
 mod tests {
-    use rstest::rstest;
     use assertor::*;
+    use rstest::rstest;
 
     use super::*;
 

--- a/framework/packages/abstract-std/src/objects/validation/verifiers.rs
+++ b/framework/packages/abstract-std/src/objects/validation/verifiers.rs
@@ -64,7 +64,7 @@ pub fn validate_description(maybe_description: Option<&str>) -> Result<(), Valid
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
-    use speculoos::prelude::*;
+    use assertor::*;
 
     use super::*;
 

--- a/framework/packages/abstract-testing/Cargo.toml
+++ b/framework/packages/abstract-testing/Cargo.toml
@@ -17,7 +17,7 @@ serde = { workspace = true }
 derive_builder = "0.12.0"
 abstract-std = { workspace = true }
 cosmwasm-schema = { workspace = true }
-speculoos = { workspace = true }
+assertor = { workspace = true }
 serde_json = "1.0.79"
 cw2 = { workspace = true }
 cw-asset = { workspace = true }

--- a/framework/packages/abstract-testing/src/map_tester.rs
+++ b/framework/packages/abstract-testing/src/map_tester.rs
@@ -1,11 +1,11 @@
 use std::fmt::Debug;
 
+use assertor::*;
 use cosmwasm_std::{testing::mock_env, DepsMut, Env, MessageInfo, Order, Response, Storage};
 use cw_storage_plus::{KeyDeserialize, Map, PrimaryKey};
 use derive_builder::Builder;
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::json;
-use speculoos::prelude::*;
 
 use crate::MockDeps;
 

--- a/framework/packages/standards/dex/Cargo.toml
+++ b/framework/packages/standards/dex/Cargo.toml
@@ -46,7 +46,7 @@ workspace-hack = { version = "0.1", path = "../../../workspace-hack" }
 abstract-interface = { workspace = true, features = ["daemon"] }
 semver = { workspace = true }
 anyhow = { workspace = true }
-speculoos = { workspace = true }
+assertor = { workspace = true }
 dotenv = "0.15.0"
 env_logger = "0.11.3"
 clap = { workspace = true }

--- a/framework/packages/standards/staking/Cargo.toml
+++ b/framework/packages/standards/staking/Cargo.toml
@@ -41,7 +41,7 @@ workspace-hack = { version = "0.1", path = "../../../workspace-hack" }
 abstract-interface = { workspace = true, features = ["daemon"] }
 semver = { workspace = true }
 anyhow = { workspace = true }
-speculoos = { workspace = true }
+assertor = { workspace = true }
 dotenv = "0.15.0"
 env_logger = "0.11.3"
 clap = { workspace = true }

--- a/interchain/Cargo.toml
+++ b/interchain/Cargo.toml
@@ -83,7 +83,7 @@ abstract-money-market-adapter = { path = "../modules/contracts/adapters/money-ma
 
 ## Testing
 rstest = "0.17.0"
-speculoos = "0.11.0"
+assertor = "0.0.3"
 anyhow = "1"
 
 # Do not remove, none of interchain packages are deployed

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -85,7 +85,7 @@ abstract-dex-adapter = { path = "./contracts/adapters/dex", default-features = f
 
 ## Testing
 rstest = "0.17.0"
-speculoos = "0.11.0"
+assertor = "0.0.3"
 anyhow = "1"
 
 # this ensures local compatability when compiling locally

--- a/modules/contracts/adapters/cw-staking/Cargo.toml
+++ b/modules/contracts/adapters/cw-staking/Cargo.toml
@@ -111,7 +111,7 @@ semver = { version = "1.0" }
 dotenv = "0.15.0"
 env_logger = "0.11.3"
 log = "0.4.14"
-speculoos = { workspace = true }
+assertor = { workspace = true }
 cw-orch = { workspace = true, features = ["daemon"] }
 clap = { workspace = true }
 cw-staking = { path = ".", package = "abstract-cw-staking", features = [

--- a/modules/contracts/adapters/cw-staking/tests/osmosis_stake.rs
+++ b/modules/contracts/adapters/cw-staking/tests/osmosis_stake.rs
@@ -49,7 +49,7 @@ mod osmosis_test {
     use cw_orch_osmosis_test_tube::OsmosisTestTube;
 
     use cw_orch::{interface, prelude::*};
-    use speculoos::prelude::*;
+    use assertor::*;
 
     const OSMOSIS: &str = "osmosis";
     const DENOM: &str = "uosmo";

--- a/modules/contracts/adapters/dex/Cargo.toml
+++ b/modules/contracts/adapters/dex/Cargo.toml
@@ -112,7 +112,7 @@ abstract-interface = { workspace = true, features = ["daemon"] }
 tokio = { workspace = true }
 semver = { workspace = true }
 anyhow = { workspace = true }
-speculoos = { workspace = true }
+assertor = { workspace = true }
 dotenv = "0.15.0"
 env_logger = "0.11.3"
 clap = { workspace = true }

--- a/modules/contracts/adapters/dex/src/api.rs
+++ b/modules/contracts/adapters/dex/src/api.rs
@@ -350,7 +350,7 @@ mod test {
         abstract_testing::prelude::AbstractMockAddrs, sdk::mock_module::MockModule,
     };
     use cosmwasm_std::{testing::mock_dependencies, wasm_execute, Addr};
-    use speculoos::prelude::*;
+    use assertor::*;
 
     pub const POOL: u64 = 1278734;
 

--- a/modules/contracts/adapters/money-market/Cargo.toml
+++ b/modules/contracts/adapters/money-market/Cargo.toml
@@ -75,7 +75,7 @@ abstract-interface = { workspace = true, features = ["daemon"] }
 tokio = { workspace = true }
 semver = { workspace = true }
 anyhow = { workspace = true }
-speculoos = { workspace = true }
+assertor = { workspace = true }
 dotenv = "0.15.0"
 env_logger = "0.11.3"
 clap = { workspace = true }

--- a/modules/contracts/adapters/money-market/src/api.rs
+++ b/modules/contracts/adapters/money-market/src/api.rs
@@ -490,7 +490,7 @@ mod test {
     use abstract_adapter::sdk::mock_module::MockModule;
     use abstract_adapter::std::adapter::AdapterRequestMsg;
     use cosmwasm_std::{testing::mock_dependencies, wasm_execute};
-    use speculoos::prelude::*;
+    use assertor::*;
 
     fn expected_request_with_test_account(
         request: MoneyMarketExecuteMsg,

--- a/modules/contracts/apps/calendar/Cargo.toml
+++ b/modules/contracts/apps/calendar/Cargo.toml
@@ -51,7 +51,7 @@ cw-orch = { workspace = true }
 calendar-app = { path = ".", features = ["testing"] }
 abstract-interface = { workspace = true, features = ["daemon"] }
 abstract-client = { workspace = true, features = ["test-utils"] }
-speculoos = { workspace = true }
+assertor = { workspace = true }
 semver = { workspace = true }
 dotenv = "0.15.0"
 env_logger = "0.11.3"

--- a/modules/contracts/apps/challenge/Cargo.toml
+++ b/modules/contracts/apps/challenge/Cargo.toml
@@ -47,7 +47,7 @@ cw-orch = { workspace = true }
 [dev-dependencies]
 challenge-app = { path = "." }
 abstract-app = { workspace = true, features = ["test-utils"] }
-speculoos = "0.11.0"
+speculoos = { workspace = true }
 semver = "1.0"
 dotenv = "0.15.0"
 env_logger = "0.11.3"

--- a/modules/contracts/apps/croncat/Cargo.toml
+++ b/modules/contracts/apps/croncat/Cargo.toml
@@ -69,7 +69,7 @@ croncat-manager = { version = "1.0.4", features = ["library"] }
 croncat-app = { path = "." }
 abstract-interface = { workspace = true, features = ["daemon"] }
 abstract-app = { workspace = true, features = ["test-utils"] }
-speculoos = "0.11.0"
+speculoos = { workspace = true }
 semver = "1.0"
 dotenv = "0.15.0"
 env_logger = "0.11.3"

--- a/modules/contracts/apps/croncat/src/api.rs
+++ b/modules/contracts/apps/croncat/src/api.rs
@@ -188,7 +188,7 @@ mod test {
     use cosmwasm_std::{coins, testing::mock_dependencies, wasm_execute, BankMsg};
     use croncat_integration_utils::*;
     use cw_asset::AssetList;
-    use speculoos::prelude::*;
+    use assertor::*;
 
     use super::*;
     use crate::msg::ExecuteMsg;

--- a/modules/contracts/apps/dca/Cargo.toml
+++ b/modules/contracts/apps/dca/Cargo.toml
@@ -52,7 +52,7 @@ dca-app = { path = "." }
 abstract-interface = { workspace = true, features = ["daemon"] }
 abstract-client = { workspace = true }
 abstract-app = { workspace = true, features = ["test-utils"] }
-speculoos = "0.11.0"
+speculoos = { workspace = true }
 semver = "1.0"
 dotenv = "0.15.0"
 env_logger = "0.11.3"

--- a/modules/contracts/apps/payment/Cargo.toml
+++ b/modules/contracts/apps/payment/Cargo.toml
@@ -44,7 +44,7 @@ cw-orch = { workspace = true }
 [dev-dependencies]
 abstract-interface = { workspace = true, features = ["daemon"] }
 abstract-app = { workspace = true, features = ["test-utils"] }
-speculoos = "0.11.0"
+speculoos = { workspace = true }
 semver = "1.0"
 dotenv = "0.15.0"
 env_logger = "0.11.3"


### PR DESCRIPTION
This PR aims at removing speculoos from the testing framework and replacing it with assertor that has very similar syntax and is well maintained for now (although not stable).

The changes are wide, so a lot of changes are needed

### Checklist

- [ ] CI is green.
- [ ] Changelog updated.
