### PR TITLE
Version Control renamed to Registry in a few doc comments

### DIFF
--- a/framework/contracts/account/src/modules.rs
+++ b/framework/contracts/account/src/modules.rs
@@ -238,7 +238,7 @@ pub fn load_module_addr(storage: &dyn Storage, module_id: &str) -> AccountResult
         .ok_or_else(|| AccountError::ModuleNotFound(module_id.to_string()))
 }
 
-/// Query Version Control for the [`Module`] given the provided [`ContractVersion`]
+/// Query Registry for the [`Module`] given the provided [`ContractVersion`]
 pub fn query_module(
     deps: Deps,
     env: &Env,

--- a/framework/contracts/native/registry/src/commands.rs
+++ b/framework/contracts/native/registry/src/commands.rs
@@ -277,9 +277,9 @@ fn reject_modules(storage: &mut dyn Storage, rejects: Vec<ModuleInfo>) -> VCResu
     Ok(("rejects", rejects.join(",")).into())
 }
 
-/// Remove a module from the Version Control registry.
+/// Remove a module from the Registry registry.
 pub fn remove_module(deps: DepsMut, msg_info: MessageInfo, module: ModuleInfo) -> VCResult {
-    // Only the Version Control Admin can remove modules
+    // Only the Registry Admin can remove modules
     cw_ownable::assert_owner(deps.storage, &msg_info.sender)?;
 
     // Only specific versions may be removed

--- a/framework/packages/abstract-client/src/client.rs
+++ b/framework/packages/abstract-client/src/client.rs
@@ -77,9 +77,9 @@ impl<Chain: CwEnv> AbstractClient<Chain> {
         Ok(Self { abstr })
     }
 
-    /// Version Control contract API
+    /// Registry contract API
     ///
-    /// The Version Control contract is a database contract that stores all module-related information.
+    /// The Registry contract is a database contract that stores all module-related information.
     /// ```
     /// # use abstract_client::AbstractClientError;
     /// # let chain = cw_orch::prelude::MockBech32::new("mock");

--- a/framework/packages/abstract-sdk/src/apis/version_registry.rs
+++ b/framework/packages/abstract-sdk/src/apis/version_registry.rs
@@ -18,7 +18,7 @@ use crate::{
     AbstractSdkError, AbstractSdkResult,
 };
 
-/// Access the Abstract Version Control and access module information.
+/// Access the Abstract Registry and access module information.
 pub trait ModuleRegistryInterface: AbstractRegistryAccess + ModuleIdentification {
     /**
         API for querying module information from the Abstract registry contract.

--- a/framework/packages/abstract-std/src/account.rs
+++ b/framework/packages/abstract-std/src/account.rs
@@ -176,7 +176,7 @@ pub enum ExecuteMsg<Authenticator = Empty> {
     },
     /// Upgrade the module to a new version
     /// If module is `abstract::account` then the contract will do a self-migration.
-    /// Self-migration is protected and only possible to the [`crate::objects::module_reference::ModuleReference::Account`] registered in Version Control
+    /// Self-migration is protected and only possible to the [`crate::objects::module_reference::ModuleReference::Account`] registered in Registry
     Upgrade {
         modules: Vec<(ModuleInfo, Option<Binary>)>,
     },

--- a/framework/packages/abstract-std/src/native/registry.rs
+++ b/framework/packages/abstract-std/src/native/registry.rs
@@ -1,4 +1,4 @@
-//! # Version Control
+//! # Registry
 //!
 //! `abstract_std::registry` stores chain-specific code-ids, addresses and an account_id map.
 //!
@@ -109,7 +109,7 @@ impl From<Account<Addr>> for Account<String> {
     }
 }
 
-/// Version Control Instantiate Msg
+/// Registry Instantiate Msg
 #[cosmwasm_schema::cw_serde]
 pub struct InstantiateMsg {
     pub admin: String,
@@ -121,7 +121,7 @@ pub struct InstantiateMsg {
     pub namespace_registration_fee: Option<Coin>,
 }
 
-/// Version Control Execute Msg
+/// Registry Execute Msg
 #[cw_ownable::cw_ownable_execute]
 #[cosmwasm_schema::cw_serde]
 #[derive(cw_orch::ExecuteFns)]
@@ -201,7 +201,7 @@ pub struct ModuleFilter {
     pub status: Option<ModuleStatus>,
 }
 
-/// Version Control Query Msg
+/// Registry Query Msg
 #[cw_ownable::cw_ownable_query]
 #[cosmwasm_schema::cw_serde]
 #[derive(QueryResponses, cw_orch::QueryFns)]

--- a/framework/packages/abstract-std/src/objects/module_factory.rs
+++ b/framework/packages/abstract-std/src/objects/module_factory.rs
@@ -10,7 +10,7 @@ pub struct ModuleFactoryContract {
 }
 
 impl ModuleFactoryContract {
-    /// Retrieve address of the Version Control
+    /// Retrieve address of the Registry
     pub fn new(api: &dyn Api, env: &Env) -> AbstractResult<Self> {
         let hrp = native_addrs::hrp_from_env(env);
         let address = api.addr_humanize(&native_addrs::module_factory_address(hrp, api)?)?;

--- a/framework/packages/abstract-std/src/objects/registry.rs
+++ b/framework/packages/abstract-std/src/objects/registry.rs
@@ -76,7 +76,7 @@ pub struct RegistryContract {
 }
 
 impl RegistryContract {
-    /// Retrieve address of the Version Control
+    /// Retrieve address of the Registry
     pub fn new(api: &dyn Api, env: &Env) -> AbstractResult<Self> {
         let hrp = native_addrs::hrp_from_env(env);
         let address = api.addr_humanize(&native_addrs::registry_address(hrp, api)?)?;


### PR DESCRIPTION
Small renames that were missing