### PR TITLE
Ibc client and ibc host removal of predictable addresses

### DIFF
--- a/framework/Cargo.lock
+++ b/framework/Cargo.lock
@@ -102,6 +102,7 @@ name = "abstract-app"
 version = "0.24.1"
 dependencies = [
  "abstract-app",
+ "abstract-ibc-client",
  "abstract-ibc-host",
  "abstract-integration-tests",
  "abstract-interface",

--- a/framework/contracts/account/tests/snapshots/adapters__account_install_adapter.snap
+++ b/framework/contracts/account/tests/snapshots/adapters__account_install_adapter.snap
@@ -19,17 +19,17 @@ expression: all_storage
     - "{\"owner\":{\"monarchy\":{\"monarch\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\"}},\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:account-local-1":
   - - "\u0000\u0002actester:mock-adapter1"
-    - "\"mock14xc5dkz0rn8j99lxz69mkv3wzawmadg7xurkzy49m9yefmqx5c6s4lc5ql\""
+    - "\"mock1ds5m6wwuu0cr35kmhxmq3up2w0tamsplnna3wm0dkxnyu5x8k03sux5d63\""
   - - aa
     - "false"
   - - ab
     - "{\"name\":\"Default Abstract Account\"}"
   - - af
-    - "[\"mock14xc5dkz0rn8j99lxz69mkv3wzawmadg7xurkzy49m9yefmqx5c6s4lc5ql\"]"
+    - "[\"mock1ds5m6wwuu0cr35kmhxmq3up2w0tamsplnna3wm0dkxnyu5x8k03sux5d63\"]"
   - - ag
     - "{\"trace\":\"local\",\"seq\":1}"
   - - ah
-    - "[[{\"info\":{\"namespace\":\"tester\",\"name\":\"mock-adapter1\",\"version\":{\"version\":\"1.0.0\"}},\"reference\":{\"adapter\":\"mock14xc5dkz0rn8j99lxz69mkv3wzawmadg7xurkzy49m9yefmqx5c6s4lc5ql\"}},null]]"
+    - "[[{\"info\":{\"namespace\":\"tester\",\"name\":\"mock-adapter1\",\"version\":{\"version\":\"1.0.0\"}},\"reference\":{\"adapter\":\"mock1ds5m6wwuu0cr35kmhxmq3up2w0tamsplnna3wm0dkxnyu5x8k03sux5d63\"}},null]]"
   - - ai
     - "[]"
   - - contract_info
@@ -42,7 +42,7 @@ expression: all_storage
   - - cfg
     - "{\"next_unique_pool_id\":1}"
   - - contract_info
-    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.24.1\"}"
+    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.24.2\"}"
   - - ownership
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ibc-client":
@@ -64,17 +64,17 @@ expression: all_storage
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:registry":
   - - "\u0000\u0002cb\u0000\u0006tester\u0000\rmock-adapter11.0.0"
-    - "{\"adapter\":\"mock14xc5dkz0rn8j99lxz69mkv3wzawmadg7xurkzy49m9yefmqx5c6s4lc5ql\"}"
+    - "{\"adapter\":\"mock1ds5m6wwuu0cr35kmhxmq3up2w0tamsplnna3wm0dkxnyu5x8k03sux5d63\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\u0007account0.24.1"
     - "{\"account\":5}"
-  - - "\u0000\u0002cb\u0000\babstract\u0000\bans-host0.24.1"
+  - - "\u0000\u0002cb\u0000\babstract\u0000\bans-host0.24.2"
     - "{\"native\":\"mock1wx0qjtlz799pfxl73y2f4dv28nukztpmq2ztavk60v534tat9cds0pnytz\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\bibc-host0.24.1"
-    - "{\"native\":\"mock1ldaf3e9zxja5mrcw3clcu873wggmqhwfvqw9djjcjxxjwv59crqsc6n7r3\"}"
-  - - "\u0000\u0002cb\u0000\babstract\u0000\bregistry0.24.1"
+    - "{\"native\":\"mock1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcns7ctvz5\"}"
+  - - "\u0000\u0002cb\u0000\babstract\u0000\bregistry0.24.2"
     - "{\"native\":\"mock1cag6cwygef6fuddgq2l44py7crpscufrza4mt3rum2axueemenmqapxshc\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\nibc-client0.24.1"
-    - "{\"native\":\"mock1g86ckugm7v9vvpadq9szg6rlf72pdl4a6n0d8apltq5t0grecpwqtrcaj0\"}"
+    - "{\"native\":\"mock16jzpxp0e8550c9aht6q9svcux30vtyyyyxv5w2l2djjra46580wsgtnl4n\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\u000emodule-factory0.24.1"
     - "{\"native\":\"mock1vnj802lyyupfaez73w7axfs3xveraxen370vhcnumaufj29r5rxqwxdk4n\"}"
   - - "\u0000\u0002ch\u0000\u0005local\u0000\u0000\u0000\u0000"
@@ -92,7 +92,7 @@ expression: all_storage
   - - ci
     - "2"
   - - contract_info
-    - "{\"contract\":\"abstract:registry\",\"version\":\"0.24.1\"}"
+    - "{\"contract\":\"abstract:registry\",\"version\":\"0.24.2\"}"
   - - ownership
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"
 "tester:mock-adapter1":

--- a/framework/contracts/account/tests/snapshots/adapters__install_one_adapter.snap
+++ b/framework/contracts/account/tests/snapshots/adapters__install_one_adapter.snap
@@ -19,17 +19,17 @@ expression: all_storage
     - "{\"owner\":{\"monarchy\":{\"monarch\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\"}},\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:account-local-1":
   - - "\u0000\u0002actester:test-module-id"
-    - "\"mock14xc5dkz0rn8j99lxz69mkv3wzawmadg7xurkzy49m9yefmqx5c6s4lc5ql\""
+    - "\"mock1ds5m6wwuu0cr35kmhxmq3up2w0tamsplnna3wm0dkxnyu5x8k03sux5d63\""
   - - aa
     - "false"
   - - ab
     - "{\"name\":\"Default Abstract Account\"}"
   - - af
-    - "[\"mock14xc5dkz0rn8j99lxz69mkv3wzawmadg7xurkzy49m9yefmqx5c6s4lc5ql\"]"
+    - "[\"mock1ds5m6wwuu0cr35kmhxmq3up2w0tamsplnna3wm0dkxnyu5x8k03sux5d63\"]"
   - - ag
     - "{\"trace\":\"local\",\"seq\":1}"
   - - ah
-    - "[[{\"info\":{\"namespace\":\"tester\",\"name\":\"test-module-id\",\"version\":{\"version\":\"0.24.1\"}},\"reference\":{\"adapter\":\"mock14xc5dkz0rn8j99lxz69mkv3wzawmadg7xurkzy49m9yefmqx5c6s4lc5ql\"}},null]]"
+    - "[[{\"info\":{\"namespace\":\"tester\",\"name\":\"test-module-id\",\"version\":{\"version\":\"0.24.1\"}},\"reference\":{\"adapter\":\"mock1ds5m6wwuu0cr35kmhxmq3up2w0tamsplnna3wm0dkxnyu5x8k03sux5d63\"}},null]]"
   - - ai
     - "[]"
   - - contract_info
@@ -42,7 +42,7 @@ expression: all_storage
   - - cfg
     - "{\"next_unique_pool_id\":1}"
   - - contract_info
-    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.24.1\"}"
+    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.24.2\"}"
   - - ownership
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ibc-client":
@@ -64,17 +64,17 @@ expression: all_storage
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:registry":
   - - "\u0000\u0002cb\u0000\u0006tester\u0000\u000etest-module-id0.24.1"
-    - "{\"adapter\":\"mock14xc5dkz0rn8j99lxz69mkv3wzawmadg7xurkzy49m9yefmqx5c6s4lc5ql\"}"
+    - "{\"adapter\":\"mock1ds5m6wwuu0cr35kmhxmq3up2w0tamsplnna3wm0dkxnyu5x8k03sux5d63\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\u0007account0.24.1"
     - "{\"account\":5}"
-  - - "\u0000\u0002cb\u0000\babstract\u0000\bans-host0.24.1"
+  - - "\u0000\u0002cb\u0000\babstract\u0000\bans-host0.24.2"
     - "{\"native\":\"mock1wx0qjtlz799pfxl73y2f4dv28nukztpmq2ztavk60v534tat9cds0pnytz\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\bibc-host0.24.1"
-    - "{\"native\":\"mock1ldaf3e9zxja5mrcw3clcu873wggmqhwfvqw9djjcjxxjwv59crqsc6n7r3\"}"
-  - - "\u0000\u0002cb\u0000\babstract\u0000\bregistry0.24.1"
+    - "{\"native\":\"mock1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcns7ctvz5\"}"
+  - - "\u0000\u0002cb\u0000\babstract\u0000\bregistry0.24.2"
     - "{\"native\":\"mock1cag6cwygef6fuddgq2l44py7crpscufrza4mt3rum2axueemenmqapxshc\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\nibc-client0.24.1"
-    - "{\"native\":\"mock1g86ckugm7v9vvpadq9szg6rlf72pdl4a6n0d8apltq5t0grecpwqtrcaj0\"}"
+    - "{\"native\":\"mock16jzpxp0e8550c9aht6q9svcux30vtyyyyxv5w2l2djjra46580wsgtnl4n\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\u000emodule-factory0.24.1"
     - "{\"native\":\"mock1vnj802lyyupfaez73w7axfs3xveraxen370vhcnumaufj29r5rxqwxdk4n\"}"
   - - "\u0000\u0002ch\u0000\u0005local\u0000\u0000\u0000\u0000"
@@ -92,7 +92,7 @@ expression: all_storage
   - - ci
     - "2"
   - - contract_info
-    - "{\"contract\":\"abstract:registry\",\"version\":\"0.24.1\"}"
+    - "{\"contract\":\"abstract:registry\",\"version\":\"0.24.2\"}"
   - - ownership
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"
 "tester:test-module-id":

--- a/framework/contracts/account/tests/snapshots/adapters__install_one_adapter_with_fee.snap
+++ b/framework/contracts/account/tests/snapshots/adapters__install_one_adapter_with_fee.snap
@@ -19,17 +19,17 @@ expression: all_storage
     - "{\"owner\":{\"monarchy\":{\"monarch\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\"}},\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:account-local-1":
   - - "\u0000\u0002actester:test-module-id"
-    - "\"mock14xc5dkz0rn8j99lxz69mkv3wzawmadg7xurkzy49m9yefmqx5c6s4lc5ql\""
+    - "\"mock1ds5m6wwuu0cr35kmhxmq3up2w0tamsplnna3wm0dkxnyu5x8k03sux5d63\""
   - - aa
     - "false"
   - - ab
     - "{\"name\":\"Default Abstract Account\"}"
   - - af
-    - "[\"mock14xc5dkz0rn8j99lxz69mkv3wzawmadg7xurkzy49m9yefmqx5c6s4lc5ql\"]"
+    - "[\"mock1ds5m6wwuu0cr35kmhxmq3up2w0tamsplnna3wm0dkxnyu5x8k03sux5d63\"]"
   - - ag
     - "{\"trace\":\"local\",\"seq\":1}"
   - - ah
-    - "[[{\"info\":{\"namespace\":\"tester\",\"name\":\"test-module-id\",\"version\":{\"version\":\"0.24.1\"}},\"reference\":{\"adapter\":\"mock14xc5dkz0rn8j99lxz69mkv3wzawmadg7xurkzy49m9yefmqx5c6s4lc5ql\"}},null]]"
+    - "[[{\"info\":{\"namespace\":\"tester\",\"name\":\"test-module-id\",\"version\":{\"version\":\"0.24.1\"}},\"reference\":{\"adapter\":\"mock1ds5m6wwuu0cr35kmhxmq3up2w0tamsplnna3wm0dkxnyu5x8k03sux5d63\"}},null]]"
   - - ai
     - "[]"
   - - contract_info
@@ -42,7 +42,7 @@ expression: all_storage
   - - cfg
     - "{\"next_unique_pool_id\":1}"
   - - contract_info
-    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.24.1\"}"
+    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.24.2\"}"
   - - ownership
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ibc-client":
@@ -64,17 +64,17 @@ expression: all_storage
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:registry":
   - - "\u0000\u0002cb\u0000\u0006tester\u0000\u000etest-module-id0.24.1"
-    - "{\"adapter\":\"mock14xc5dkz0rn8j99lxz69mkv3wzawmadg7xurkzy49m9yefmqx5c6s4lc5ql\"}"
+    - "{\"adapter\":\"mock1ds5m6wwuu0cr35kmhxmq3up2w0tamsplnna3wm0dkxnyu5x8k03sux5d63\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\u0007account0.24.1"
     - "{\"account\":5}"
-  - - "\u0000\u0002cb\u0000\babstract\u0000\bans-host0.24.1"
+  - - "\u0000\u0002cb\u0000\babstract\u0000\bans-host0.24.2"
     - "{\"native\":\"mock1wx0qjtlz799pfxl73y2f4dv28nukztpmq2ztavk60v534tat9cds0pnytz\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\bibc-host0.24.1"
-    - "{\"native\":\"mock1ldaf3e9zxja5mrcw3clcu873wggmqhwfvqw9djjcjxxjwv59crqsc6n7r3\"}"
-  - - "\u0000\u0002cb\u0000\babstract\u0000\bregistry0.24.1"
+    - "{\"native\":\"mock1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcns7ctvz5\"}"
+  - - "\u0000\u0002cb\u0000\babstract\u0000\bregistry0.24.2"
     - "{\"native\":\"mock1cag6cwygef6fuddgq2l44py7crpscufrza4mt3rum2axueemenmqapxshc\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\nibc-client0.24.1"
-    - "{\"native\":\"mock1g86ckugm7v9vvpadq9szg6rlf72pdl4a6n0d8apltq5t0grecpwqtrcaj0\"}"
+    - "{\"native\":\"mock16jzpxp0e8550c9aht6q9svcux30vtyyyyxv5w2l2djjra46580wsgtnl4n\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\u000emodule-factory0.24.1"
     - "{\"native\":\"mock1vnj802lyyupfaez73w7axfs3xveraxen370vhcnumaufj29r5rxqwxdk4n\"}"
   - - "\u0000\u0002cf\u0000\u0006tester\u0000\u000etest-module-id0.24.1"
@@ -94,7 +94,7 @@ expression: all_storage
   - - ci
     - "2"
   - - contract_info
-    - "{\"contract\":\"abstract:registry\",\"version\":\"0.24.1\"}"
+    - "{\"contract\":\"abstract:registry\",\"version\":\"0.24.2\"}"
   - - ownership
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"
 "tester:test-module-id":

--- a/framework/contracts/account/tests/snapshots/adapters__installing_specific_version_should_install_expected.snap
+++ b/framework/contracts/account/tests/snapshots/adapters__installing_specific_version_should_install_expected.snap
@@ -19,17 +19,17 @@ expression: all_storage
     - "{\"owner\":{\"monarchy\":{\"monarch\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\"}},\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:account-local-1":
   - - "\u0000\u0002actester:mock-adapter1"
-    - "\"mock14xc5dkz0rn8j99lxz69mkv3wzawmadg7xurkzy49m9yefmqx5c6s4lc5ql\""
+    - "\"mock1ds5m6wwuu0cr35kmhxmq3up2w0tamsplnna3wm0dkxnyu5x8k03sux5d63\""
   - - aa
     - "false"
   - - ab
     - "{\"name\":\"Default Abstract Account\"}"
   - - af
-    - "[\"mock14xc5dkz0rn8j99lxz69mkv3wzawmadg7xurkzy49m9yefmqx5c6s4lc5ql\"]"
+    - "[\"mock1ds5m6wwuu0cr35kmhxmq3up2w0tamsplnna3wm0dkxnyu5x8k03sux5d63\"]"
   - - ag
     - "{\"trace\":\"local\",\"seq\":1}"
   - - ah
-    - "[[{\"info\":{\"namespace\":\"tester\",\"name\":\"mock-adapter1\",\"version\":{\"version\":\"1.0.0\"}},\"reference\":{\"adapter\":\"mock14xc5dkz0rn8j99lxz69mkv3wzawmadg7xurkzy49m9yefmqx5c6s4lc5ql\"}},null]]"
+    - "[[{\"info\":{\"namespace\":\"tester\",\"name\":\"mock-adapter1\",\"version\":{\"version\":\"1.0.0\"}},\"reference\":{\"adapter\":\"mock1ds5m6wwuu0cr35kmhxmq3up2w0tamsplnna3wm0dkxnyu5x8k03sux5d63\"}},null]]"
   - - ai
     - "[]"
   - - contract_info
@@ -42,7 +42,7 @@ expression: all_storage
   - - cfg
     - "{\"next_unique_pool_id\":1}"
   - - contract_info
-    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.24.1\"}"
+    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.24.2\"}"
   - - ownership
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ibc-client":
@@ -64,19 +64,19 @@ expression: all_storage
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:registry":
   - - "\u0000\u0002cb\u0000\u0006tester\u0000\rmock-adapter11.0.0"
-    - "{\"adapter\":\"mock14xc5dkz0rn8j99lxz69mkv3wzawmadg7xurkzy49m9yefmqx5c6s4lc5ql\"}"
+    - "{\"adapter\":\"mock1ds5m6wwuu0cr35kmhxmq3up2w0tamsplnna3wm0dkxnyu5x8k03sux5d63\"}"
   - - "\u0000\u0002cb\u0000\u0006tester\u0000\rmock-adapter12.0.0"
-    - "{\"adapter\":\"mock15zqqgwe6cpfmmyzmp3t8lkqctq3vym7srnn6fzgz0x9vfvtv7zhqehpsve\"}"
+    - "{\"adapter\":\"mock13nrd2qag9dww078z9a2way4kvzpr0k5dkv54e2xfmp2e2decfmjq4g06hw\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\u0007account0.24.1"
     - "{\"account\":5}"
-  - - "\u0000\u0002cb\u0000\babstract\u0000\bans-host0.24.1"
+  - - "\u0000\u0002cb\u0000\babstract\u0000\bans-host0.24.2"
     - "{\"native\":\"mock1wx0qjtlz799pfxl73y2f4dv28nukztpmq2ztavk60v534tat9cds0pnytz\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\bibc-host0.24.1"
-    - "{\"native\":\"mock1ldaf3e9zxja5mrcw3clcu873wggmqhwfvqw9djjcjxxjwv59crqsc6n7r3\"}"
-  - - "\u0000\u0002cb\u0000\babstract\u0000\bregistry0.24.1"
+    - "{\"native\":\"mock1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcns7ctvz5\"}"
+  - - "\u0000\u0002cb\u0000\babstract\u0000\bregistry0.24.2"
     - "{\"native\":\"mock1cag6cwygef6fuddgq2l44py7crpscufrza4mt3rum2axueemenmqapxshc\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\nibc-client0.24.1"
-    - "{\"native\":\"mock1g86ckugm7v9vvpadq9szg6rlf72pdl4a6n0d8apltq5t0grecpwqtrcaj0\"}"
+    - "{\"native\":\"mock16jzpxp0e8550c9aht6q9svcux30vtyyyyxv5w2l2djjra46580wsgtnl4n\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\u000emodule-factory0.24.1"
     - "{\"native\":\"mock1vnj802lyyupfaez73w7axfs3xveraxen370vhcnumaufj29r5rxqwxdk4n\"}"
   - - "\u0000\u0002ch\u0000\u0005local\u0000\u0000\u0000\u0000"
@@ -94,7 +94,7 @@ expression: all_storage
   - - ci
     - "2"
   - - contract_info
-    - "{\"contract\":\"abstract:registry\",\"version\":\"0.24.1\"}"
+    - "{\"contract\":\"abstract:registry\",\"version\":\"0.24.2\"}"
   - - ownership
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"
 "tester:mock-adapter1":

--- a/framework/contracts/account/tests/snapshots/adapters__reinstalling_adapter_should_be_allowed.snap
+++ b/framework/contracts/account/tests/snapshots/adapters__reinstalling_adapter_should_be_allowed.snap
@@ -19,17 +19,17 @@ expression: all_storage
     - "{\"owner\":{\"monarchy\":{\"monarch\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\"}},\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:account-local-1":
   - - "\u0000\u0002actester:test-module-id"
-    - "\"mock14xc5dkz0rn8j99lxz69mkv3wzawmadg7xurkzy49m9yefmqx5c6s4lc5ql\""
+    - "\"mock1ds5m6wwuu0cr35kmhxmq3up2w0tamsplnna3wm0dkxnyu5x8k03sux5d63\""
   - - aa
     - "false"
   - - ab
     - "{\"name\":\"Default Abstract Account\"}"
   - - af
-    - "[\"mock14xc5dkz0rn8j99lxz69mkv3wzawmadg7xurkzy49m9yefmqx5c6s4lc5ql\"]"
+    - "[\"mock1ds5m6wwuu0cr35kmhxmq3up2w0tamsplnna3wm0dkxnyu5x8k03sux5d63\"]"
   - - ag
     - "{\"trace\":\"local\",\"seq\":1}"
   - - ah
-    - "[[{\"info\":{\"namespace\":\"tester\",\"name\":\"test-module-id\",\"version\":{\"version\":\"0.24.1\"}},\"reference\":{\"adapter\":\"mock14xc5dkz0rn8j99lxz69mkv3wzawmadg7xurkzy49m9yefmqx5c6s4lc5ql\"}},null]]"
+    - "[[{\"info\":{\"namespace\":\"tester\",\"name\":\"test-module-id\",\"version\":{\"version\":\"0.24.1\"}},\"reference\":{\"adapter\":\"mock1ds5m6wwuu0cr35kmhxmq3up2w0tamsplnna3wm0dkxnyu5x8k03sux5d63\"}},null]]"
   - - ai
     - "[]"
   - - contract_info
@@ -42,7 +42,7 @@ expression: all_storage
   - - cfg
     - "{\"next_unique_pool_id\":1}"
   - - contract_info
-    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.24.1\"}"
+    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.24.2\"}"
   - - ownership
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ibc-client":
@@ -64,17 +64,17 @@ expression: all_storage
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:registry":
   - - "\u0000\u0002cb\u0000\u0006tester\u0000\u000etest-module-id0.24.1"
-    - "{\"adapter\":\"mock14xc5dkz0rn8j99lxz69mkv3wzawmadg7xurkzy49m9yefmqx5c6s4lc5ql\"}"
+    - "{\"adapter\":\"mock1ds5m6wwuu0cr35kmhxmq3up2w0tamsplnna3wm0dkxnyu5x8k03sux5d63\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\u0007account0.24.1"
     - "{\"account\":5}"
-  - - "\u0000\u0002cb\u0000\babstract\u0000\bans-host0.24.1"
+  - - "\u0000\u0002cb\u0000\babstract\u0000\bans-host0.24.2"
     - "{\"native\":\"mock1wx0qjtlz799pfxl73y2f4dv28nukztpmq2ztavk60v534tat9cds0pnytz\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\bibc-host0.24.1"
-    - "{\"native\":\"mock1ldaf3e9zxja5mrcw3clcu873wggmqhwfvqw9djjcjxxjwv59crqsc6n7r3\"}"
-  - - "\u0000\u0002cb\u0000\babstract\u0000\bregistry0.24.1"
+    - "{\"native\":\"mock1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcns7ctvz5\"}"
+  - - "\u0000\u0002cb\u0000\babstract\u0000\bregistry0.24.2"
     - "{\"native\":\"mock1cag6cwygef6fuddgq2l44py7crpscufrza4mt3rum2axueemenmqapxshc\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\nibc-client0.24.1"
-    - "{\"native\":\"mock1g86ckugm7v9vvpadq9szg6rlf72pdl4a6n0d8apltq5t0grecpwqtrcaj0\"}"
+    - "{\"native\":\"mock16jzpxp0e8550c9aht6q9svcux30vtyyyyxv5w2l2djjra46580wsgtnl4n\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\u000emodule-factory0.24.1"
     - "{\"native\":\"mock1vnj802lyyupfaez73w7axfs3xveraxen370vhcnumaufj29r5rxqwxdk4n\"}"
   - - "\u0000\u0002ch\u0000\u0005local\u0000\u0000\u0000\u0000"
@@ -92,7 +92,7 @@ expression: all_storage
   - - ci
     - "2"
   - - contract_info
-    - "{\"contract\":\"abstract:registry\",\"version\":\"0.24.1\"}"
+    - "{\"contract\":\"abstract:registry\",\"version\":\"0.24.2\"}"
   - - ownership
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"
 "tester:test-module-id":

--- a/framework/contracts/account/tests/snapshots/adapters__reinstalling_new_version_should_install_latest.snap
+++ b/framework/contracts/account/tests/snapshots/adapters__reinstalling_new_version_should_install_latest.snap
@@ -19,17 +19,17 @@ expression: all_storage
     - "{\"owner\":{\"monarchy\":{\"monarch\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\"}},\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:account-local-1":
   - - "\u0000\u0002actester:mock-adapter1"
-    - "\"mock15zqqgwe6cpfmmyzmp3t8lkqctq3vym7srnn6fzgz0x9vfvtv7zhqehpsve\""
+    - "\"mock13nrd2qag9dww078z9a2way4kvzpr0k5dkv54e2xfmp2e2decfmjq4g06hw\""
   - - aa
     - "false"
   - - ab
     - "{\"name\":\"Default Abstract Account\"}"
   - - af
-    - "[\"mock15zqqgwe6cpfmmyzmp3t8lkqctq3vym7srnn6fzgz0x9vfvtv7zhqehpsve\"]"
+    - "[\"mock13nrd2qag9dww078z9a2way4kvzpr0k5dkv54e2xfmp2e2decfmjq4g06hw\"]"
   - - ag
     - "{\"trace\":\"local\",\"seq\":1}"
   - - ah
-    - "[[{\"info\":{\"namespace\":\"tester\",\"name\":\"mock-adapter1\",\"version\":{\"version\":\"2.0.0\"}},\"reference\":{\"adapter\":\"mock15zqqgwe6cpfmmyzmp3t8lkqctq3vym7srnn6fzgz0x9vfvtv7zhqehpsve\"}},null]]"
+    - "[[{\"info\":{\"namespace\":\"tester\",\"name\":\"mock-adapter1\",\"version\":{\"version\":\"2.0.0\"}},\"reference\":{\"adapter\":\"mock13nrd2qag9dww078z9a2way4kvzpr0k5dkv54e2xfmp2e2decfmjq4g06hw\"}},null]]"
   - - ai
     - "[]"
   - - contract_info
@@ -42,7 +42,7 @@ expression: all_storage
   - - cfg
     - "{\"next_unique_pool_id\":1}"
   - - contract_info
-    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.24.1\"}"
+    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.24.2\"}"
   - - ownership
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ibc-client":
@@ -64,19 +64,19 @@ expression: all_storage
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:registry":
   - - "\u0000\u0002cb\u0000\u0006tester\u0000\rmock-adapter11.0.0"
-    - "{\"adapter\":\"mock14xc5dkz0rn8j99lxz69mkv3wzawmadg7xurkzy49m9yefmqx5c6s4lc5ql\"}"
+    - "{\"adapter\":\"mock1ds5m6wwuu0cr35kmhxmq3up2w0tamsplnna3wm0dkxnyu5x8k03sux5d63\"}"
   - - "\u0000\u0002cb\u0000\u0006tester\u0000\rmock-adapter12.0.0"
-    - "{\"adapter\":\"mock15zqqgwe6cpfmmyzmp3t8lkqctq3vym7srnn6fzgz0x9vfvtv7zhqehpsve\"}"
+    - "{\"adapter\":\"mock13nrd2qag9dww078z9a2way4kvzpr0k5dkv54e2xfmp2e2decfmjq4g06hw\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\u0007account0.24.1"
     - "{\"account\":5}"
-  - - "\u0000\u0002cb\u0000\babstract\u0000\bans-host0.24.1"
+  - - "\u0000\u0002cb\u0000\babstract\u0000\bans-host0.24.2"
     - "{\"native\":\"mock1wx0qjtlz799pfxl73y2f4dv28nukztpmq2ztavk60v534tat9cds0pnytz\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\bibc-host0.24.1"
-    - "{\"native\":\"mock1ldaf3e9zxja5mrcw3clcu873wggmqhwfvqw9djjcjxxjwv59crqsc6n7r3\"}"
-  - - "\u0000\u0002cb\u0000\babstract\u0000\bregistry0.24.1"
+    - "{\"native\":\"mock1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcns7ctvz5\"}"
+  - - "\u0000\u0002cb\u0000\babstract\u0000\bregistry0.24.2"
     - "{\"native\":\"mock1cag6cwygef6fuddgq2l44py7crpscufrza4mt3rum2axueemenmqapxshc\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\nibc-client0.24.1"
-    - "{\"native\":\"mock1g86ckugm7v9vvpadq9szg6rlf72pdl4a6n0d8apltq5t0grecpwqtrcaj0\"}"
+    - "{\"native\":\"mock16jzpxp0e8550c9aht6q9svcux30vtyyyyxv5w2l2djjra46580wsgtnl4n\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\u000emodule-factory0.24.1"
     - "{\"native\":\"mock1vnj802lyyupfaez73w7axfs3xveraxen370vhcnumaufj29r5rxqwxdk4n\"}"
   - - "\u0000\u0002ch\u0000\u0005local\u0000\u0000\u0000\u0000"
@@ -94,7 +94,7 @@ expression: all_storage
   - - ci
     - "2"
   - - contract_info
-    - "{\"contract\":\"abstract:registry\",\"version\":\"0.24.1\"}"
+    - "{\"contract\":\"abstract:registry\",\"version\":\"0.24.2\"}"
   - - ownership
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"
 "tester:mock-adapter1":

--- a/framework/contracts/account/tests/snapshots/apps__account_install_app.snap
+++ b/framework/contracts/account/tests/snapshots/apps__account_install_app.snap
@@ -19,17 +19,17 @@ expression: all_storage
     - "{\"owner\":{\"monarchy\":{\"monarch\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\"}},\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:account-local-1":
   - - "\u0000\u0002actester:app"
-    - "\"mock1lm2a943wja2nk9gpx8ky4cv4gj47903rus3cflypq7q3kqf05gmsfvzt67\""
+    - "\"mock1es2ml3pd5y9z2gme2qzea0gzx7dewv24mf0jj63vwtxdhsh3jrqsr65c3z\""
   - - aa
     - "false"
   - - ab
     - "{\"name\":\"Default Abstract Account\"}"
   - - af
-    - "[\"mock1lm2a943wja2nk9gpx8ky4cv4gj47903rus3cflypq7q3kqf05gmsfvzt67\"]"
+    - "[\"mock1es2ml3pd5y9z2gme2qzea0gzx7dewv24mf0jj63vwtxdhsh3jrqsr65c3z\"]"
   - - ag
     - "{\"trace\":\"local\",\"seq\":1}"
   - - ah
-    - "[[{\"info\":{\"namespace\":\"tester\",\"name\":\"app\",\"version\":{\"version\":\"1.0.0\"}},\"reference\":{\"app\":13}},\"mock1lm2a943wja2nk9gpx8ky4cv4gj47903rus3cflypq7q3kqf05gmsfvzt67\"]]"
+    - "[[{\"info\":{\"namespace\":\"tester\",\"name\":\"app\",\"version\":{\"version\":\"1.0.0\"}},\"reference\":{\"app\":11}},\"mock1es2ml3pd5y9z2gme2qzea0gzx7dewv24mf0jj63vwtxdhsh3jrqsr65c3z\"]]"
   - - ai
     - "[]"
   - - contract_info
@@ -42,7 +42,7 @@ expression: all_storage
   - - cfg
     - "{\"next_unique_pool_id\":1}"
   - - contract_info
-    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.24.1\"}"
+    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.24.2\"}"
   - - ownership
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ibc-client":
@@ -64,17 +64,17 @@ expression: all_storage
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:registry":
   - - "\u0000\u0002cb\u0000\u0006tester\u0000\u0003app1.0.0"
-    - "{\"app\":13}"
+    - "{\"app\":11}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\u0007account0.24.1"
     - "{\"account\":5}"
-  - - "\u0000\u0002cb\u0000\babstract\u0000\bans-host0.24.1"
+  - - "\u0000\u0002cb\u0000\babstract\u0000\bans-host0.24.2"
     - "{\"native\":\"mock1wx0qjtlz799pfxl73y2f4dv28nukztpmq2ztavk60v534tat9cds0pnytz\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\bibc-host0.24.1"
-    - "{\"native\":\"mock1ldaf3e9zxja5mrcw3clcu873wggmqhwfvqw9djjcjxxjwv59crqsc6n7r3\"}"
-  - - "\u0000\u0002cb\u0000\babstract\u0000\bregistry0.24.1"
+    - "{\"native\":\"mock1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcns7ctvz5\"}"
+  - - "\u0000\u0002cb\u0000\babstract\u0000\bregistry0.24.2"
     - "{\"native\":\"mock1cag6cwygef6fuddgq2l44py7crpscufrza4mt3rum2axueemenmqapxshc\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\nibc-client0.24.1"
-    - "{\"native\":\"mock1g86ckugm7v9vvpadq9szg6rlf72pdl4a6n0d8apltq5t0grecpwqtrcaj0\"}"
+    - "{\"native\":\"mock16jzpxp0e8550c9aht6q9svcux30vtyyyyxv5w2l2djjra46580wsgtnl4n\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\u000emodule-factory0.24.1"
     - "{\"native\":\"mock1vnj802lyyupfaez73w7axfs3xveraxen370vhcnumaufj29r5rxqwxdk4n\"}"
   - - "\u0000\u0002ch\u0000\u0005local\u0000\u0000\u0000\u0000"
@@ -92,7 +92,7 @@ expression: all_storage
   - - ci
     - "2"
   - - contract_info
-    - "{\"contract\":\"abstract:registry\",\"version\":\"0.24.1\"}"
+    - "{\"contract\":\"abstract:registry\",\"version\":\"0.24.2\"}"
   - - ownership
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"
 "tester:app":

--- a/framework/contracts/account/tests/snapshots/apps__execute_on_account.snap
+++ b/framework/contracts/account/tests/snapshots/apps__execute_on_account.snap
@@ -38,7 +38,7 @@ expression: all_storage
   - - cfg
     - "{\"next_unique_pool_id\":1}"
   - - contract_info
-    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.24.1\"}"
+    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.24.2\"}"
   - - ownership
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ibc-client":
@@ -61,14 +61,14 @@ expression: all_storage
 "abstract:registry":
   - - "\u0000\u0002cb\u0000\babstract\u0000\u0007account0.24.1"
     - "{\"account\":5}"
-  - - "\u0000\u0002cb\u0000\babstract\u0000\bans-host0.24.1"
+  - - "\u0000\u0002cb\u0000\babstract\u0000\bans-host0.24.2"
     - "{\"native\":\"mock1wx0qjtlz799pfxl73y2f4dv28nukztpmq2ztavk60v534tat9cds0pnytz\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\bibc-host0.24.1"
-    - "{\"native\":\"mock1ldaf3e9zxja5mrcw3clcu873wggmqhwfvqw9djjcjxxjwv59crqsc6n7r3\"}"
-  - - "\u0000\u0002cb\u0000\babstract\u0000\bregistry0.24.1"
+    - "{\"native\":\"mock1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcns7ctvz5\"}"
+  - - "\u0000\u0002cb\u0000\babstract\u0000\bregistry0.24.2"
     - "{\"native\":\"mock1cag6cwygef6fuddgq2l44py7crpscufrza4mt3rum2axueemenmqapxshc\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\nibc-client0.24.1"
-    - "{\"native\":\"mock1g86ckugm7v9vvpadq9szg6rlf72pdl4a6n0d8apltq5t0grecpwqtrcaj0\"}"
+    - "{\"native\":\"mock16jzpxp0e8550c9aht6q9svcux30vtyyyyxv5w2l2djjra46580wsgtnl4n\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\u000emodule-factory0.24.1"
     - "{\"native\":\"mock1vnj802lyyupfaez73w7axfs3xveraxen370vhcnumaufj29r5rxqwxdk4n\"}"
   - - "\u0000\u0002ch\u0000\u0005local\u0000\u0000\u0000\u0000"
@@ -82,6 +82,6 @@ expression: all_storage
   - - ci
     - "2"
   - - contract_info
-    - "{\"contract\":\"abstract:registry\",\"version\":\"0.24.1\"}"
+    - "{\"contract\":\"abstract:registry\",\"version\":\"0.24.2\"}"
   - - ownership
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"

--- a/framework/contracts/account/tests/snapshots/install_modules__adds_module_to_account_modules.snap
+++ b/framework/contracts/account/tests/snapshots/install_modules__adds_module_to_account_modules.snap
@@ -19,17 +19,17 @@ expression: all_storage
     - "{\"owner\":{\"monarchy\":{\"monarch\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\"}},\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:account-local-1":
   - - "\u0000\u0002actester:mock-adapter1"
-    - "\"mock14xc5dkz0rn8j99lxz69mkv3wzawmadg7xurkzy49m9yefmqx5c6s4lc5ql\""
+    - "\"mock1ds5m6wwuu0cr35kmhxmq3up2w0tamsplnna3wm0dkxnyu5x8k03sux5d63\""
   - - aa
     - "false"
   - - ab
     - "{\"name\":\"Default Abstract Account\"}"
   - - af
-    - "[\"mock14xc5dkz0rn8j99lxz69mkv3wzawmadg7xurkzy49m9yefmqx5c6s4lc5ql\"]"
+    - "[\"mock1ds5m6wwuu0cr35kmhxmq3up2w0tamsplnna3wm0dkxnyu5x8k03sux5d63\"]"
   - - ag
     - "{\"trace\":\"local\",\"seq\":1}"
   - - ah
-    - "[[{\"info\":{\"namespace\":\"tester\",\"name\":\"mock-adapter1\",\"version\":{\"version\":\"1.0.0\"}},\"reference\":{\"adapter\":\"mock14xc5dkz0rn8j99lxz69mkv3wzawmadg7xurkzy49m9yefmqx5c6s4lc5ql\"}},null]]"
+    - "[[{\"info\":{\"namespace\":\"tester\",\"name\":\"mock-adapter1\",\"version\":{\"version\":\"1.0.0\"}},\"reference\":{\"adapter\":\"mock1ds5m6wwuu0cr35kmhxmq3up2w0tamsplnna3wm0dkxnyu5x8k03sux5d63\"}},null]]"
   - - ai
     - "[]"
   - - contract_info
@@ -42,7 +42,7 @@ expression: all_storage
   - - cfg
     - "{\"next_unique_pool_id\":1}"
   - - contract_info
-    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.24.1\"}"
+    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.24.2\"}"
   - - ownership
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ibc-client":
@@ -64,27 +64,27 @@ expression: all_storage
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:registry":
   - - "\u0000\u0002cb\u0000\u0006tester\u0000\tmock-app11.0.0"
-    - "{\"app\":17}"
+    - "{\"app\":15}"
   - - "\u0000\u0002cb\u0000\u0006tester\u0000\tmock-app12.0.0"
-    - "{\"app\":18}"
+    - "{\"app\":16}"
   - - "\u0000\u0002cb\u0000\u0006tester\u0000\rmock-adapter11.0.0"
-    - "{\"adapter\":\"mock14xc5dkz0rn8j99lxz69mkv3wzawmadg7xurkzy49m9yefmqx5c6s4lc5ql\"}"
+    - "{\"adapter\":\"mock1ds5m6wwuu0cr35kmhxmq3up2w0tamsplnna3wm0dkxnyu5x8k03sux5d63\"}"
   - - "\u0000\u0002cb\u0000\u0006tester\u0000\rmock-adapter12.0.0"
-    - "{\"adapter\":\"mock15zqqgwe6cpfmmyzmp3t8lkqctq3vym7srnn6fzgz0x9vfvtv7zhqehpsve\"}"
+    - "{\"adapter\":\"mock13nrd2qag9dww078z9a2way4kvzpr0k5dkv54e2xfmp2e2decfmjq4g06hw\"}"
   - - "\u0000\u0002cb\u0000\u0006tester\u0000\rmock-adapter21.0.0"
-    - "{\"adapter\":\"mock1cyd63pk2wuvjkqmhlvp9884z4h89rqtn8w8xgz9m28hjd2kzj2cqfhpe4r\"}"
+    - "{\"adapter\":\"mock1k9z7fvd3307ynapnk5gjffn706mz8qck502f7qwgt2a2a35kgqlqsv5ehm\"}"
   - - "\u0000\u0002cb\u0000\u0006tester\u0000\rmock-adapter22.0.0"
-    - "{\"adapter\":\"mock12lgc6d44c0y0tnef8fwjq8d9arrw5jgvrg8ydju5kz7nek9px72qvyct8w\"}"
+    - "{\"adapter\":\"mock1d2wr6ej95xepd3wmmpgrkyxwjns6gt5tfscrr3jcuetz7m7z0req77w6zq\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\u0007account0.24.1"
     - "{\"account\":5}"
-  - - "\u0000\u0002cb\u0000\babstract\u0000\bans-host0.24.1"
+  - - "\u0000\u0002cb\u0000\babstract\u0000\bans-host0.24.2"
     - "{\"native\":\"mock1wx0qjtlz799pfxl73y2f4dv28nukztpmq2ztavk60v534tat9cds0pnytz\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\bibc-host0.24.1"
-    - "{\"native\":\"mock1ldaf3e9zxja5mrcw3clcu873wggmqhwfvqw9djjcjxxjwv59crqsc6n7r3\"}"
-  - - "\u0000\u0002cb\u0000\babstract\u0000\bregistry0.24.1"
+    - "{\"native\":\"mock1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcns7ctvz5\"}"
+  - - "\u0000\u0002cb\u0000\babstract\u0000\bregistry0.24.2"
     - "{\"native\":\"mock1cag6cwygef6fuddgq2l44py7crpscufrza4mt3rum2axueemenmqapxshc\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\nibc-client0.24.1"
-    - "{\"native\":\"mock1g86ckugm7v9vvpadq9szg6rlf72pdl4a6n0d8apltq5t0grecpwqtrcaj0\"}"
+    - "{\"native\":\"mock16jzpxp0e8550c9aht6q9svcux30vtyyyyxv5w2l2djjra46580wsgtnl4n\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\u000emodule-factory0.24.1"
     - "{\"native\":\"mock1vnj802lyyupfaez73w7axfs3xveraxen370vhcnumaufj29r5rxqwxdk4n\"}"
   - - "\u0000\u0002ch\u0000\u0005local\u0000\u0000\u0000\u0000"
@@ -102,7 +102,7 @@ expression: all_storage
   - - ci
     - "2"
   - - contract_info
-    - "{\"contract\":\"abstract:registry\",\"version\":\"0.24.1\"}"
+    - "{\"contract\":\"abstract:registry\",\"version\":\"0.24.2\"}"
   - - ownership
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"
 "tester:mock-adapter1":

--- a/framework/contracts/account/tests/snapshots/proxy__account_install_multiple_modules.snap
+++ b/framework/contracts/account/tests/snapshots/proxy__account_install_multiple_modules.snap
@@ -4,9 +4,9 @@ expression: all_storage
 ---
 "abstract:account-local-0":
   - - "\u0000\u0002acabstract:standalone1"
-    - "\"mock12hm8apxqfskv44wgapew6dptfyc44vfrvvkac0c2aq8h7mzvnygst0wqrf\""
+    - "\"mock14vstyxa45gs7xw99kkhykm3dwdnr6ynstnwn5ha8dz9smghcadusly9vqm\""
   - - "\u0000\u0002acabstract:standalone2"
-    - "\"mock1fmsfc9fz2gkc52k885szysmyeunghp07dhg94ll4qqpqhm3t85vsf9xwld\""
+    - "\"mock19654yrhptg06cku2lccahmtf7a7087zpdmdrfjwuz0s2ex6x938q90eqm5\""
   - - aa
     - "false"
   - - ab
@@ -16,7 +16,7 @@ expression: all_storage
   - - ag
     - "{\"trace\":\"local\",\"seq\":0}"
   - - ah
-    - "[[{\"info\":{\"namespace\":\"abstract\",\"name\":\"standalone1\",\"version\":{\"version\":\"1.0.0\"}},\"reference\":{\"standalone\":13}},\"mock12hm8apxqfskv44wgapew6dptfyc44vfrvvkac0c2aq8h7mzvnygst0wqrf\"],[{\"info\":{\"namespace\":\"abstract\",\"name\":\"standalone2\",\"version\":{\"version\":\"1.0.0\"}},\"reference\":{\"standalone\":14}},\"mock1fmsfc9fz2gkc52k885szysmyeunghp07dhg94ll4qqpqhm3t85vsf9xwld\"]]"
+    - "[[{\"info\":{\"namespace\":\"abstract\",\"name\":\"standalone1\",\"version\":{\"version\":\"1.0.0\"}},\"reference\":{\"standalone\":11}},\"mock14vstyxa45gs7xw99kkhykm3dwdnr6ynstnwn5ha8dz9smghcadusly9vqm\"],[{\"info\":{\"namespace\":\"abstract\",\"name\":\"standalone2\",\"version\":{\"version\":\"1.0.0\"}},\"reference\":{\"standalone\":12}},\"mock19654yrhptg06cku2lccahmtf7a7087zpdmdrfjwuz0s2ex6x938q90eqm5\"]]"
   - - ai
     - "[]"
   - - contract_info
@@ -29,7 +29,7 @@ expression: all_storage
   - - cfg
     - "{\"next_unique_pool_id\":1}"
   - - contract_info
-    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.24.1\"}"
+    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.24.2\"}"
   - - ownership
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ibc-client":
@@ -54,23 +54,23 @@ expression: all_storage
 "abstract:registry":
   - - "\u0000\u0002cb\u0000\babstract\u0000\u0007account0.24.1"
     - "{\"account\":5}"
-  - - "\u0000\u0002cb\u0000\babstract\u0000\bans-host0.24.1"
+  - - "\u0000\u0002cb\u0000\babstract\u0000\bans-host0.24.2"
     - "{\"native\":\"mock1wx0qjtlz799pfxl73y2f4dv28nukztpmq2ztavk60v534tat9cds0pnytz\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\bibc-host0.24.1"
-    - "{\"native\":\"mock1ldaf3e9zxja5mrcw3clcu873wggmqhwfvqw9djjcjxxjwv59crqsc6n7r3\"}"
-  - - "\u0000\u0002cb\u0000\babstract\u0000\bregistry0.24.1"
+    - "{\"native\":\"mock1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcns7ctvz5\"}"
+  - - "\u0000\u0002cb\u0000\babstract\u0000\bregistry0.24.2"
     - "{\"native\":\"mock1cag6cwygef6fuddgq2l44py7crpscufrza4mt3rum2axueemenmqapxshc\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\nibc-client0.24.1"
-    - "{\"native\":\"mock1g86ckugm7v9vvpadq9szg6rlf72pdl4a6n0d8apltq5t0grecpwqtrcaj0\"}"
+    - "{\"native\":\"mock16jzpxp0e8550c9aht6q9svcux30vtyyyyxv5w2l2djjra46580wsgtnl4n\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\u000bstandalone11.0.0"
-    - "{\"standalone\":13}"
+    - "{\"standalone\":11}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\u000bstandalone21.0.0"
-    - "{\"standalone\":14}"
+    - "{\"standalone\":12}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\u000emodule-factory0.24.1"
     - "{\"native\":\"mock1vnj802lyyupfaez73w7axfs3xveraxen370vhcnumaufj29r5rxqwxdk4n\"}"
-  - - "\u0000\u0002cc\u0000\u0000\u0000\u0000\u0000\u0000\u0000\r"
+  - - "\u0000\u0002cc\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u000b"
     - "{\"namespace\":\"abstract\",\"name\":\"standalone1\",\"version\":{\"version\":\"1.0.0\"}}"
-  - - "\u0000\u0002cc\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u000e"
+  - - "\u0000\u0002cc\u0000\u0000\u0000\u0000\u0000\u0000\u0000\f"
     - "{\"namespace\":\"abstract\",\"name\":\"standalone2\",\"version\":{\"version\":\"1.0.0\"}}"
   - - "\u0000\u0002cf\u0000\babstract\u0000\u000bstandalone11.0.0"
     - "{\"monetization\":{\"install_fee\":{\"fee\":{\"denom\":\"token1\",\"amount\":\"42\"}}},\"metadata\":null,\"instantiation_funds\":[]}"
@@ -85,6 +85,6 @@ expression: all_storage
   - - ci
     - "1"
   - - contract_info
-    - "{\"contract\":\"abstract:registry\",\"version\":\"0.24.1\"}"
+    - "{\"contract\":\"abstract:registry\",\"version\":\"0.24.2\"}"
   - - ownership
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"

--- a/framework/contracts/account/tests/snapshots/proxy__account_install_standalone_modules.snap
+++ b/framework/contracts/account/tests/snapshots/proxy__account_install_standalone_modules.snap
@@ -4,9 +4,9 @@ expression: all_storage
 ---
 "abstract:account-local-0":
   - - "\u0000\u0002acabstract:standalone1"
-    - "\"mock12hm8apxqfskv44wgapew6dptfyc44vfrvvkac0c2aq8h7mzvnygst0wqrf\""
+    - "\"mock14vstyxa45gs7xw99kkhykm3dwdnr6ynstnwn5ha8dz9smghcadusly9vqm\""
   - - "\u0000\u0002acabstract:standalone2"
-    - "\"mock1fmsfc9fz2gkc52k885szysmyeunghp07dhg94ll4qqpqhm3t85vsf9xwld\""
+    - "\"mock19654yrhptg06cku2lccahmtf7a7087zpdmdrfjwuz0s2ex6x938q90eqm5\""
   - - aa
     - "false"
   - - ab
@@ -16,7 +16,7 @@ expression: all_storage
   - - ag
     - "{\"trace\":\"local\",\"seq\":0}"
   - - ah
-    - "[[{\"info\":{\"namespace\":\"abstract\",\"name\":\"standalone2\",\"version\":{\"version\":\"1.0.0\"}},\"reference\":{\"standalone\":14}},\"mock1fmsfc9fz2gkc52k885szysmyeunghp07dhg94ll4qqpqhm3t85vsf9xwld\"]]"
+    - "[[{\"info\":{\"namespace\":\"abstract\",\"name\":\"standalone2\",\"version\":{\"version\":\"1.0.0\"}},\"reference\":{\"standalone\":12}},\"mock19654yrhptg06cku2lccahmtf7a7087zpdmdrfjwuz0s2ex6x938q90eqm5\"]]"
   - - ai
     - "[]"
   - - contract_info
@@ -29,7 +29,7 @@ expression: all_storage
   - - cfg
     - "{\"next_unique_pool_id\":1}"
   - - contract_info
-    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.24.1\"}"
+    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.24.2\"}"
   - - ownership
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ibc-client":
@@ -54,23 +54,23 @@ expression: all_storage
 "abstract:registry":
   - - "\u0000\u0002cb\u0000\babstract\u0000\u0007account0.24.1"
     - "{\"account\":5}"
-  - - "\u0000\u0002cb\u0000\babstract\u0000\bans-host0.24.1"
+  - - "\u0000\u0002cb\u0000\babstract\u0000\bans-host0.24.2"
     - "{\"native\":\"mock1wx0qjtlz799pfxl73y2f4dv28nukztpmq2ztavk60v534tat9cds0pnytz\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\bibc-host0.24.1"
-    - "{\"native\":\"mock1ldaf3e9zxja5mrcw3clcu873wggmqhwfvqw9djjcjxxjwv59crqsc6n7r3\"}"
-  - - "\u0000\u0002cb\u0000\babstract\u0000\bregistry0.24.1"
+    - "{\"native\":\"mock1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcns7ctvz5\"}"
+  - - "\u0000\u0002cb\u0000\babstract\u0000\bregistry0.24.2"
     - "{\"native\":\"mock1cag6cwygef6fuddgq2l44py7crpscufrza4mt3rum2axueemenmqapxshc\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\nibc-client0.24.1"
-    - "{\"native\":\"mock1g86ckugm7v9vvpadq9szg6rlf72pdl4a6n0d8apltq5t0grecpwqtrcaj0\"}"
+    - "{\"native\":\"mock16jzpxp0e8550c9aht6q9svcux30vtyyyyxv5w2l2djjra46580wsgtnl4n\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\u000bstandalone11.0.0"
-    - "{\"standalone\":13}"
+    - "{\"standalone\":11}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\u000bstandalone21.0.0"
-    - "{\"standalone\":14}"
+    - "{\"standalone\":12}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\u000emodule-factory0.24.1"
     - "{\"native\":\"mock1vnj802lyyupfaez73w7axfs3xveraxen370vhcnumaufj29r5rxqwxdk4n\"}"
-  - - "\u0000\u0002cc\u0000\u0000\u0000\u0000\u0000\u0000\u0000\r"
+  - - "\u0000\u0002cc\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u000b"
     - "{\"namespace\":\"abstract\",\"name\":\"standalone1\",\"version\":{\"version\":\"1.0.0\"}}"
-  - - "\u0000\u0002cc\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u000e"
+  - - "\u0000\u0002cc\u0000\u0000\u0000\u0000\u0000\u0000\u0000\f"
     - "{\"namespace\":\"abstract\",\"name\":\"standalone2\",\"version\":{\"version\":\"1.0.0\"}}"
   - - "\u0000\u0002ch\u0000\u0005local\u0000\u0000\u0000\u0000"
     - "\"mock1ys8clus4qf2haemyck0uljz74dj2k8hu4ggfpe7vty6zd5j2982q9sf90k\""
@@ -81,6 +81,6 @@ expression: all_storage
   - - ci
     - "1"
   - - contract_info
-    - "{\"contract\":\"abstract:registry\",\"version\":\"0.24.1\"}"
+    - "{\"contract\":\"abstract:registry\",\"version\":\"0.24.2\"}"
   - - ownership
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"

--- a/framework/contracts/account/tests/snapshots/proxy__account_with_response_data.snap
+++ b/framework/contracts/account/tests/snapshots/proxy__account_with_response_data.snap
@@ -19,17 +19,17 @@ expression: all_storage
     - "{\"owner\":{\"monarchy\":{\"monarch\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\"}},\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:account-local-1":
   - - "\u0000\u0002actester:test-module-id"
-    - "\"mock14xc5dkz0rn8j99lxz69mkv3wzawmadg7xurkzy49m9yefmqx5c6s4lc5ql\""
+    - "\"mock1ds5m6wwuu0cr35kmhxmq3up2w0tamsplnna3wm0dkxnyu5x8k03sux5d63\""
   - - aa
     - "false"
   - - ab
     - "{\"name\":\"Default Abstract Account\"}"
   - - af
-    - "[\"mock14xc5dkz0rn8j99lxz69mkv3wzawmadg7xurkzy49m9yefmqx5c6s4lc5ql\"]"
+    - "[\"mock1ds5m6wwuu0cr35kmhxmq3up2w0tamsplnna3wm0dkxnyu5x8k03sux5d63\"]"
   - - ag
     - "{\"trace\":\"local\",\"seq\":1}"
   - - ah
-    - "[[{\"info\":{\"namespace\":\"tester\",\"name\":\"test-module-id\",\"version\":{\"version\":\"0.24.1\"}},\"reference\":{\"adapter\":\"mock14xc5dkz0rn8j99lxz69mkv3wzawmadg7xurkzy49m9yefmqx5c6s4lc5ql\"}},null]]"
+    - "[[{\"info\":{\"namespace\":\"tester\",\"name\":\"test-module-id\",\"version\":{\"version\":\"0.24.1\"}},\"reference\":{\"adapter\":\"mock1ds5m6wwuu0cr35kmhxmq3up2w0tamsplnna3wm0dkxnyu5x8k03sux5d63\"}},null]]"
   - - ai
     - "[]"
   - - contract_info
@@ -42,7 +42,7 @@ expression: all_storage
   - - cfg
     - "{\"next_unique_pool_id\":1}"
   - - contract_info
-    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.24.1\"}"
+    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.24.2\"}"
   - - ownership
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ibc-client":
@@ -64,17 +64,17 @@ expression: all_storage
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:registry":
   - - "\u0000\u0002cb\u0000\u0006tester\u0000\u000etest-module-id0.24.1"
-    - "{\"adapter\":\"mock14xc5dkz0rn8j99lxz69mkv3wzawmadg7xurkzy49m9yefmqx5c6s4lc5ql\"}"
+    - "{\"adapter\":\"mock1ds5m6wwuu0cr35kmhxmq3up2w0tamsplnna3wm0dkxnyu5x8k03sux5d63\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\u0007account0.24.1"
     - "{\"account\":5}"
-  - - "\u0000\u0002cb\u0000\babstract\u0000\bans-host0.24.1"
+  - - "\u0000\u0002cb\u0000\babstract\u0000\bans-host0.24.2"
     - "{\"native\":\"mock1wx0qjtlz799pfxl73y2f4dv28nukztpmq2ztavk60v534tat9cds0pnytz\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\bibc-host0.24.1"
-    - "{\"native\":\"mock1ldaf3e9zxja5mrcw3clcu873wggmqhwfvqw9djjcjxxjwv59crqsc6n7r3\"}"
-  - - "\u0000\u0002cb\u0000\babstract\u0000\bregistry0.24.1"
+    - "{\"native\":\"mock1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcns7ctvz5\"}"
+  - - "\u0000\u0002cb\u0000\babstract\u0000\bregistry0.24.2"
     - "{\"native\":\"mock1cag6cwygef6fuddgq2l44py7crpscufrza4mt3rum2axueemenmqapxshc\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\nibc-client0.24.1"
-    - "{\"native\":\"mock1g86ckugm7v9vvpadq9szg6rlf72pdl4a6n0d8apltq5t0grecpwqtrcaj0\"}"
+    - "{\"native\":\"mock16jzpxp0e8550c9aht6q9svcux30vtyyyyxv5w2l2djjra46580wsgtnl4n\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\u000emodule-factory0.24.1"
     - "{\"native\":\"mock1vnj802lyyupfaez73w7axfs3xveraxen370vhcnumaufj29r5rxqwxdk4n\"}"
   - - "\u0000\u0002ch\u0000\u0005local\u0000\u0000\u0000\u0000"
@@ -92,7 +92,7 @@ expression: all_storage
   - - ci
     - "2"
   - - contract_info
-    - "{\"contract\":\"abstract:registry\",\"version\":\"0.24.1\"}"
+    - "{\"contract\":\"abstract:registry\",\"version\":\"0.24.2\"}"
   - - ownership
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"
 "tester:test-module-id":

--- a/framework/contracts/account/tests/snapshots/proxy__default_without_response_data.snap
+++ b/framework/contracts/account/tests/snapshots/proxy__default_without_response_data.snap
@@ -19,17 +19,17 @@ expression: all_storage
     - "{\"owner\":{\"monarchy\":{\"monarch\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\"}},\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:account-local-1":
   - - "\u0000\u0002actester:test-module-id"
-    - "\"mock14xc5dkz0rn8j99lxz69mkv3wzawmadg7xurkzy49m9yefmqx5c6s4lc5ql\""
+    - "\"mock1ds5m6wwuu0cr35kmhxmq3up2w0tamsplnna3wm0dkxnyu5x8k03sux5d63\""
   - - aa
     - "false"
   - - ab
     - "{\"name\":\"Default Abstract Account\"}"
   - - af
-    - "[\"mock14xc5dkz0rn8j99lxz69mkv3wzawmadg7xurkzy49m9yefmqx5c6s4lc5ql\"]"
+    - "[\"mock1ds5m6wwuu0cr35kmhxmq3up2w0tamsplnna3wm0dkxnyu5x8k03sux5d63\"]"
   - - ag
     - "{\"trace\":\"local\",\"seq\":1}"
   - - ah
-    - "[[{\"info\":{\"namespace\":\"tester\",\"name\":\"test-module-id\",\"version\":{\"version\":\"0.24.1\"}},\"reference\":{\"adapter\":\"mock14xc5dkz0rn8j99lxz69mkv3wzawmadg7xurkzy49m9yefmqx5c6s4lc5ql\"}},null]]"
+    - "[[{\"info\":{\"namespace\":\"tester\",\"name\":\"test-module-id\",\"version\":{\"version\":\"0.24.1\"}},\"reference\":{\"adapter\":\"mock1ds5m6wwuu0cr35kmhxmq3up2w0tamsplnna3wm0dkxnyu5x8k03sux5d63\"}},null]]"
   - - ai
     - "[]"
   - - contract_info
@@ -42,7 +42,7 @@ expression: all_storage
   - - cfg
     - "{\"next_unique_pool_id\":1}"
   - - contract_info
-    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.24.1\"}"
+    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.24.2\"}"
   - - ownership
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ibc-client":
@@ -64,17 +64,17 @@ expression: all_storage
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:registry":
   - - "\u0000\u0002cb\u0000\u0006tester\u0000\u000etest-module-id0.24.1"
-    - "{\"adapter\":\"mock14xc5dkz0rn8j99lxz69mkv3wzawmadg7xurkzy49m9yefmqx5c6s4lc5ql\"}"
+    - "{\"adapter\":\"mock1ds5m6wwuu0cr35kmhxmq3up2w0tamsplnna3wm0dkxnyu5x8k03sux5d63\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\u0007account0.24.1"
     - "{\"account\":5}"
-  - - "\u0000\u0002cb\u0000\babstract\u0000\bans-host0.24.1"
+  - - "\u0000\u0002cb\u0000\babstract\u0000\bans-host0.24.2"
     - "{\"native\":\"mock1wx0qjtlz799pfxl73y2f4dv28nukztpmq2ztavk60v534tat9cds0pnytz\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\bibc-host0.24.1"
-    - "{\"native\":\"mock1ldaf3e9zxja5mrcw3clcu873wggmqhwfvqw9djjcjxxjwv59crqsc6n7r3\"}"
-  - - "\u0000\u0002cb\u0000\babstract\u0000\bregistry0.24.1"
+    - "{\"native\":\"mock1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcns7ctvz5\"}"
+  - - "\u0000\u0002cb\u0000\babstract\u0000\bregistry0.24.2"
     - "{\"native\":\"mock1cag6cwygef6fuddgq2l44py7crpscufrza4mt3rum2axueemenmqapxshc\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\nibc-client0.24.1"
-    - "{\"native\":\"mock1g86ckugm7v9vvpadq9szg6rlf72pdl4a6n0d8apltq5t0grecpwqtrcaj0\"}"
+    - "{\"native\":\"mock16jzpxp0e8550c9aht6q9svcux30vtyyyyxv5w2l2djjra46580wsgtnl4n\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\u000emodule-factory0.24.1"
     - "{\"native\":\"mock1vnj802lyyupfaez73w7axfs3xveraxen370vhcnumaufj29r5rxqwxdk4n\"}"
   - - "\u0000\u0002ch\u0000\u0005local\u0000\u0000\u0000\u0000"
@@ -92,7 +92,7 @@ expression: all_storage
   - - ci
     - "2"
   - - contract_info
-    - "{\"contract\":\"abstract:registry\",\"version\":\"0.24.1\"}"
+    - "{\"contract\":\"abstract:registry\",\"version\":\"0.24.2\"}"
   - - ownership
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"
 "tester:test-module-id":

--- a/framework/contracts/account/tests/snapshots/proxy__exec_on_account.snap
+++ b/framework/contracts/account/tests/snapshots/proxy__exec_on_account.snap
@@ -38,7 +38,7 @@ expression: all_storage
   - - cfg
     - "{\"next_unique_pool_id\":1}"
   - - contract_info
-    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.24.1\"}"
+    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.24.2\"}"
   - - ownership
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ibc-client":
@@ -61,14 +61,14 @@ expression: all_storage
 "abstract:registry":
   - - "\u0000\u0002cb\u0000\babstract\u0000\u0007account0.24.1"
     - "{\"account\":5}"
-  - - "\u0000\u0002cb\u0000\babstract\u0000\bans-host0.24.1"
+  - - "\u0000\u0002cb\u0000\babstract\u0000\bans-host0.24.2"
     - "{\"native\":\"mock1wx0qjtlz799pfxl73y2f4dv28nukztpmq2ztavk60v534tat9cds0pnytz\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\bibc-host0.24.1"
-    - "{\"native\":\"mock1ldaf3e9zxja5mrcw3clcu873wggmqhwfvqw9djjcjxxjwv59crqsc6n7r3\"}"
-  - - "\u0000\u0002cb\u0000\babstract\u0000\bregistry0.24.1"
+    - "{\"native\":\"mock1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcns7ctvz5\"}"
+  - - "\u0000\u0002cb\u0000\babstract\u0000\bregistry0.24.2"
     - "{\"native\":\"mock1cag6cwygef6fuddgq2l44py7crpscufrza4mt3rum2axueemenmqapxshc\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\nibc-client0.24.1"
-    - "{\"native\":\"mock1g86ckugm7v9vvpadq9szg6rlf72pdl4a6n0d8apltq5t0grecpwqtrcaj0\"}"
+    - "{\"native\":\"mock16jzpxp0e8550c9aht6q9svcux30vtyyyyxv5w2l2djjra46580wsgtnl4n\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\u000emodule-factory0.24.1"
     - "{\"native\":\"mock1vnj802lyyupfaez73w7axfs3xveraxen370vhcnumaufj29r5rxqwxdk4n\"}"
   - - "\u0000\u0002ch\u0000\u0005local\u0000\u0000\u0000\u0000"
@@ -82,6 +82,6 @@ expression: all_storage
   - - ci
     - "2"
   - - contract_info
-    - "{\"contract\":\"abstract:registry\",\"version\":\"0.24.1\"}"
+    - "{\"contract\":\"abstract:registry\",\"version\":\"0.24.2\"}"
   - - ownership
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"

--- a/framework/contracts/account/tests/snapshots/proxy__instantiate_account.snap
+++ b/framework/contracts/account/tests/snapshots/proxy__instantiate_account.snap
@@ -38,7 +38,7 @@ expression: all_storage
   - - cfg
     - "{\"next_unique_pool_id\":1}"
   - - contract_info
-    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.24.1\"}"
+    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.24.2\"}"
   - - ownership
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ibc-client":
@@ -61,14 +61,14 @@ expression: all_storage
 "abstract:registry":
   - - "\u0000\u0002cb\u0000\babstract\u0000\u0007account0.24.1"
     - "{\"account\":5}"
-  - - "\u0000\u0002cb\u0000\babstract\u0000\bans-host0.24.1"
+  - - "\u0000\u0002cb\u0000\babstract\u0000\bans-host0.24.2"
     - "{\"native\":\"mock1wx0qjtlz799pfxl73y2f4dv28nukztpmq2ztavk60v534tat9cds0pnytz\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\bibc-host0.24.1"
-    - "{\"native\":\"mock1ldaf3e9zxja5mrcw3clcu873wggmqhwfvqw9djjcjxxjwv59crqsc6n7r3\"}"
-  - - "\u0000\u0002cb\u0000\babstract\u0000\bregistry0.24.1"
+    - "{\"native\":\"mock1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcns7ctvz5\"}"
+  - - "\u0000\u0002cb\u0000\babstract\u0000\bregistry0.24.2"
     - "{\"native\":\"mock1cag6cwygef6fuddgq2l44py7crpscufrza4mt3rum2axueemenmqapxshc\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\nibc-client0.24.1"
-    - "{\"native\":\"mock1g86ckugm7v9vvpadq9szg6rlf72pdl4a6n0d8apltq5t0grecpwqtrcaj0\"}"
+    - "{\"native\":\"mock16jzpxp0e8550c9aht6q9svcux30vtyyyyxv5w2l2djjra46580wsgtnl4n\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\u000emodule-factory0.24.1"
     - "{\"native\":\"mock1vnj802lyyupfaez73w7axfs3xveraxen370vhcnumaufj29r5rxqwxdk4n\"}"
   - - "\u0000\u0002ch\u0000\u0005local\u0000\u0000\u0000\u0000"
@@ -82,6 +82,6 @@ expression: all_storage
   - - ci
     - "2"
   - - contract_info
-    - "{\"contract\":\"abstract:registry\",\"version\":\"0.24.1\"}"
+    - "{\"contract\":\"abstract:registry\",\"version\":\"0.24.2\"}"
   - - ownership
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"

--- a/framework/contracts/account/tests/snapshots/subaccount__account_updating_on_subaccount_should_succeed.snap
+++ b/framework/contracts/account/tests/snapshots/subaccount__account_updating_on_subaccount_should_succeed.snap
@@ -55,7 +55,7 @@ expression: all_storage
   - - cfg
     - "{\"next_unique_pool_id\":1}"
   - - contract_info
-    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.24.1\"}"
+    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.24.2\"}"
   - - ownership
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ibc-client":
@@ -78,14 +78,14 @@ expression: all_storage
 "abstract:registry":
   - - "\u0000\u0002cb\u0000\babstract\u0000\u0007account0.24.1"
     - "{\"account\":5}"
-  - - "\u0000\u0002cb\u0000\babstract\u0000\bans-host0.24.1"
+  - - "\u0000\u0002cb\u0000\babstract\u0000\bans-host0.24.2"
     - "{\"native\":\"mock1wx0qjtlz799pfxl73y2f4dv28nukztpmq2ztavk60v534tat9cds0pnytz\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\bibc-host0.24.1"
-    - "{\"native\":\"mock1ldaf3e9zxja5mrcw3clcu873wggmqhwfvqw9djjcjxxjwv59crqsc6n7r3\"}"
-  - - "\u0000\u0002cb\u0000\babstract\u0000\bregistry0.24.1"
+    - "{\"native\":\"mock1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcns7ctvz5\"}"
+  - - "\u0000\u0002cb\u0000\babstract\u0000\bregistry0.24.2"
     - "{\"native\":\"mock1cag6cwygef6fuddgq2l44py7crpscufrza4mt3rum2axueemenmqapxshc\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\nibc-client0.24.1"
-    - "{\"native\":\"mock1g86ckugm7v9vvpadq9szg6rlf72pdl4a6n0d8apltq5t0grecpwqtrcaj0\"}"
+    - "{\"native\":\"mock16jzpxp0e8550c9aht6q9svcux30vtyyyyxv5w2l2djjra46580wsgtnl4n\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\u000emodule-factory0.24.1"
     - "{\"native\":\"mock1vnj802lyyupfaez73w7axfs3xveraxen370vhcnumaufj29r5rxqwxdk4n\"}"
   - - "\u0000\u0002ch\u0000\u0005local\u0000\u0000\u0000\u0000"
@@ -101,6 +101,6 @@ expression: all_storage
   - - ci
     - "3"
   - - contract_info
-    - "{\"contract\":\"abstract:registry\",\"version\":\"0.24.1\"}"
+    - "{\"contract\":\"abstract:registry\",\"version\":\"0.24.2\"}"
   - - ownership
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"

--- a/framework/contracts/account/tests/snapshots/subaccount__creating_on_subaccount_should_succeed.snap
+++ b/framework/contracts/account/tests/snapshots/subaccount__creating_on_subaccount_should_succeed.snap
@@ -55,7 +55,7 @@ expression: all_storage
   - - cfg
     - "{\"next_unique_pool_id\":1}"
   - - contract_info
-    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.24.1\"}"
+    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.24.2\"}"
   - - ownership
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ibc-client":
@@ -78,14 +78,14 @@ expression: all_storage
 "abstract:registry":
   - - "\u0000\u0002cb\u0000\babstract\u0000\u0007account0.24.1"
     - "{\"account\":5}"
-  - - "\u0000\u0002cb\u0000\babstract\u0000\bans-host0.24.1"
+  - - "\u0000\u0002cb\u0000\babstract\u0000\bans-host0.24.2"
     - "{\"native\":\"mock1wx0qjtlz799pfxl73y2f4dv28nukztpmq2ztavk60v534tat9cds0pnytz\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\bibc-host0.24.1"
-    - "{\"native\":\"mock1ldaf3e9zxja5mrcw3clcu873wggmqhwfvqw9djjcjxxjwv59crqsc6n7r3\"}"
-  - - "\u0000\u0002cb\u0000\babstract\u0000\bregistry0.24.1"
+    - "{\"native\":\"mock1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcns7ctvz5\"}"
+  - - "\u0000\u0002cb\u0000\babstract\u0000\bregistry0.24.2"
     - "{\"native\":\"mock1cag6cwygef6fuddgq2l44py7crpscufrza4mt3rum2axueemenmqapxshc\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\nibc-client0.24.1"
-    - "{\"native\":\"mock1g86ckugm7v9vvpadq9szg6rlf72pdl4a6n0d8apltq5t0grecpwqtrcaj0\"}"
+    - "{\"native\":\"mock16jzpxp0e8550c9aht6q9svcux30vtyyyyxv5w2l2djjra46580wsgtnl4n\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\u000emodule-factory0.24.1"
     - "{\"native\":\"mock1vnj802lyyupfaez73w7axfs3xveraxen370vhcnumaufj29r5rxqwxdk4n\"}"
   - - "\u0000\u0002ch\u0000\u0005local\u0000\u0000\u0000\u0000"
@@ -101,6 +101,6 @@ expression: all_storage
   - - ci
     - "3"
   - - contract_info
-    - "{\"contract\":\"abstract:registry\",\"version\":\"0.24.1\"}"
+    - "{\"contract\":\"abstract:registry\",\"version\":\"0.24.2\"}"
   - - ownership
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"

--- a/framework/contracts/account/tests/snapshots/subaccount__installed_app_updating_on_subaccount_should_succeed.snap
+++ b/framework/contracts/account/tests/snapshots/subaccount__installed_app_updating_on_subaccount_should_succeed.snap
@@ -55,7 +55,7 @@ expression: all_storage
   - - cfg
     - "{\"next_unique_pool_id\":1}"
   - - contract_info
-    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.24.1\"}"
+    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.24.2\"}"
   - - ownership
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ibc-client":
@@ -78,14 +78,14 @@ expression: all_storage
 "abstract:registry":
   - - "\u0000\u0002cb\u0000\babstract\u0000\u0007account0.24.1"
     - "{\"account\":5}"
-  - - "\u0000\u0002cb\u0000\babstract\u0000\bans-host0.24.1"
+  - - "\u0000\u0002cb\u0000\babstract\u0000\bans-host0.24.2"
     - "{\"native\":\"mock1wx0qjtlz799pfxl73y2f4dv28nukztpmq2ztavk60v534tat9cds0pnytz\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\bibc-host0.24.1"
-    - "{\"native\":\"mock1ldaf3e9zxja5mrcw3clcu873wggmqhwfvqw9djjcjxxjwv59crqsc6n7r3\"}"
-  - - "\u0000\u0002cb\u0000\babstract\u0000\bregistry0.24.1"
+    - "{\"native\":\"mock1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcns7ctvz5\"}"
+  - - "\u0000\u0002cb\u0000\babstract\u0000\bregistry0.24.2"
     - "{\"native\":\"mock1cag6cwygef6fuddgq2l44py7crpscufrza4mt3rum2axueemenmqapxshc\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\nibc-client0.24.1"
-    - "{\"native\":\"mock1g86ckugm7v9vvpadq9szg6rlf72pdl4a6n0d8apltq5t0grecpwqtrcaj0\"}"
+    - "{\"native\":\"mock16jzpxp0e8550c9aht6q9svcux30vtyyyyxv5w2l2djjra46580wsgtnl4n\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\u000emodule-factory0.24.1"
     - "{\"native\":\"mock1vnj802lyyupfaez73w7axfs3xveraxen370vhcnumaufj29r5rxqwxdk4n\"}"
   - - "\u0000\u0002ch\u0000\u0005local\u0000\u0000\u0000\u0000"
@@ -101,6 +101,6 @@ expression: all_storage
   - - ci
     - "3"
   - - contract_info
-    - "{\"contract\":\"abstract:registry\",\"version\":\"0.24.1\"}"
+    - "{\"contract\":\"abstract:registry\",\"version\":\"0.24.2\"}"
   - - ownership
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"

--- a/framework/contracts/account/tests/snapshots/subaccount__recursive_updating_on_subaccount_should_succeed.snap
+++ b/framework/contracts/account/tests/snapshots/subaccount__recursive_updating_on_subaccount_should_succeed.snap
@@ -72,7 +72,7 @@ expression: all_storage
   - - cfg
     - "{\"next_unique_pool_id\":1}"
   - - contract_info
-    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.24.1\"}"
+    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.24.2\"}"
   - - ownership
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ibc-client":
@@ -95,14 +95,14 @@ expression: all_storage
 "abstract:registry":
   - - "\u0000\u0002cb\u0000\babstract\u0000\u0007account0.24.1"
     - "{\"account\":5}"
-  - - "\u0000\u0002cb\u0000\babstract\u0000\bans-host0.24.1"
+  - - "\u0000\u0002cb\u0000\babstract\u0000\bans-host0.24.2"
     - "{\"native\":\"mock1wx0qjtlz799pfxl73y2f4dv28nukztpmq2ztavk60v534tat9cds0pnytz\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\bibc-host0.24.1"
-    - "{\"native\":\"mock1ldaf3e9zxja5mrcw3clcu873wggmqhwfvqw9djjcjxxjwv59crqsc6n7r3\"}"
-  - - "\u0000\u0002cb\u0000\babstract\u0000\bregistry0.24.1"
+    - "{\"native\":\"mock1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcns7ctvz5\"}"
+  - - "\u0000\u0002cb\u0000\babstract\u0000\bregistry0.24.2"
     - "{\"native\":\"mock1cag6cwygef6fuddgq2l44py7crpscufrza4mt3rum2axueemenmqapxshc\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\nibc-client0.24.1"
-    - "{\"native\":\"mock1g86ckugm7v9vvpadq9szg6rlf72pdl4a6n0d8apltq5t0grecpwqtrcaj0\"}"
+    - "{\"native\":\"mock16jzpxp0e8550c9aht6q9svcux30vtyyyyxv5w2l2djjra46580wsgtnl4n\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\u000emodule-factory0.24.1"
     - "{\"native\":\"mock1vnj802lyyupfaez73w7axfs3xveraxen370vhcnumaufj29r5rxqwxdk4n\"}"
   - - "\u0000\u0002ch\u0000\u0005local\u0000\u0000\u0000\u0000"
@@ -120,6 +120,6 @@ expression: all_storage
   - - ci
     - "4"
   - - contract_info
-    - "{\"contract\":\"abstract:registry\",\"version\":\"0.24.1\"}"
+    - "{\"contract\":\"abstract:registry\",\"version\":\"0.24.2\"}"
   - - ownership
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"

--- a/framework/contracts/account/tests/snapshots/subaccount__sub_account_move_ownership.snap
+++ b/framework/contracts/account/tests/snapshots/subaccount__sub_account_move_ownership.snap
@@ -53,7 +53,7 @@ expression: all_storage
   - - cfg
     - "{\"next_unique_pool_id\":1}"
   - - contract_info
-    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.24.1\"}"
+    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.24.2\"}"
   - - ownership
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ibc-client":
@@ -76,14 +76,14 @@ expression: all_storage
 "abstract:registry":
   - - "\u0000\u0002cb\u0000\babstract\u0000\u0007account0.24.1"
     - "{\"account\":5}"
-  - - "\u0000\u0002cb\u0000\babstract\u0000\bans-host0.24.1"
+  - - "\u0000\u0002cb\u0000\babstract\u0000\bans-host0.24.2"
     - "{\"native\":\"mock1wx0qjtlz799pfxl73y2f4dv28nukztpmq2ztavk60v534tat9cds0pnytz\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\bibc-host0.24.1"
-    - "{\"native\":\"mock1ldaf3e9zxja5mrcw3clcu873wggmqhwfvqw9djjcjxxjwv59crqsc6n7r3\"}"
-  - - "\u0000\u0002cb\u0000\babstract\u0000\bregistry0.24.1"
+    - "{\"native\":\"mock1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcns7ctvz5\"}"
+  - - "\u0000\u0002cb\u0000\babstract\u0000\bregistry0.24.2"
     - "{\"native\":\"mock1cag6cwygef6fuddgq2l44py7crpscufrza4mt3rum2axueemenmqapxshc\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\nibc-client0.24.1"
-    - "{\"native\":\"mock1g86ckugm7v9vvpadq9szg6rlf72pdl4a6n0d8apltq5t0grecpwqtrcaj0\"}"
+    - "{\"native\":\"mock16jzpxp0e8550c9aht6q9svcux30vtyyyyxv5w2l2djjra46580wsgtnl4n\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\u000emodule-factory0.24.1"
     - "{\"native\":\"mock1vnj802lyyupfaez73w7axfs3xveraxen370vhcnumaufj29r5rxqwxdk4n\"}"
   - - "\u0000\u0002ch\u0000\u0005local\u0000\u0000\u0000\u0000"
@@ -99,6 +99,6 @@ expression: all_storage
   - - ci
     - "3"
   - - contract_info
-    - "{\"contract\":\"abstract:registry\",\"version\":\"0.24.1\"}"
+    - "{\"contract\":\"abstract:registry\",\"version\":\"0.24.2\"}"
   - - ownership
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"

--- a/framework/contracts/account/tests/snapshots/subaccount__sub_account_move_ownership_to_sub_account.snap
+++ b/framework/contracts/account/tests/snapshots/subaccount__sub_account_move_ownership_to_sub_account.snap
@@ -87,7 +87,7 @@ expression: all_storage
   - - cfg
     - "{\"next_unique_pool_id\":1}"
   - - contract_info
-    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.24.1\"}"
+    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.24.2\"}"
   - - ownership
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ibc-client":
@@ -110,14 +110,14 @@ expression: all_storage
 "abstract:registry":
   - - "\u0000\u0002cb\u0000\babstract\u0000\u0007account0.24.1"
     - "{\"account\":5}"
-  - - "\u0000\u0002cb\u0000\babstract\u0000\bans-host0.24.1"
+  - - "\u0000\u0002cb\u0000\babstract\u0000\bans-host0.24.2"
     - "{\"native\":\"mock1wx0qjtlz799pfxl73y2f4dv28nukztpmq2ztavk60v534tat9cds0pnytz\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\bibc-host0.24.1"
-    - "{\"native\":\"mock1ldaf3e9zxja5mrcw3clcu873wggmqhwfvqw9djjcjxxjwv59crqsc6n7r3\"}"
-  - - "\u0000\u0002cb\u0000\babstract\u0000\bregistry0.24.1"
+    - "{\"native\":\"mock1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcns7ctvz5\"}"
+  - - "\u0000\u0002cb\u0000\babstract\u0000\bregistry0.24.2"
     - "{\"native\":\"mock1cag6cwygef6fuddgq2l44py7crpscufrza4mt3rum2axueemenmqapxshc\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\nibc-client0.24.1"
-    - "{\"native\":\"mock1g86ckugm7v9vvpadq9szg6rlf72pdl4a6n0d8apltq5t0grecpwqtrcaj0\"}"
+    - "{\"native\":\"mock16jzpxp0e8550c9aht6q9svcux30vtyyyyxv5w2l2djjra46580wsgtnl4n\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\u000emodule-factory0.24.1"
     - "{\"native\":\"mock1vnj802lyyupfaez73w7axfs3xveraxen370vhcnumaufj29r5rxqwxdk4n\"}"
   - - "\u0000\u0002ch\u0000\u0005local\u0000\u0000\u0000\u0000"
@@ -137,6 +137,6 @@ expression: all_storage
   - - ci
     - "5"
   - - contract_info
-    - "{\"contract\":\"abstract:registry\",\"version\":\"0.24.1\"}"
+    - "{\"contract\":\"abstract:registry\",\"version\":\"0.24.2\"}"
   - - ownership
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"

--- a/framework/contracts/account/tests/snapshots/subaccount__updating_on_subaccount_should_succeed.snap
+++ b/framework/contracts/account/tests/snapshots/subaccount__updating_on_subaccount_should_succeed.snap
@@ -55,7 +55,7 @@ expression: all_storage
   - - cfg
     - "{\"next_unique_pool_id\":1}"
   - - contract_info
-    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.24.1\"}"
+    - "{\"contract\":\"abstract:ans-host\",\"version\":\"0.24.2\"}"
   - - ownership
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"
 "abstract:ibc-client":
@@ -78,14 +78,14 @@ expression: all_storage
 "abstract:registry":
   - - "\u0000\u0002cb\u0000\babstract\u0000\u0007account0.24.1"
     - "{\"account\":5}"
-  - - "\u0000\u0002cb\u0000\babstract\u0000\bans-host0.24.1"
+  - - "\u0000\u0002cb\u0000\babstract\u0000\bans-host0.24.2"
     - "{\"native\":\"mock1wx0qjtlz799pfxl73y2f4dv28nukztpmq2ztavk60v534tat9cds0pnytz\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\bibc-host0.24.1"
-    - "{\"native\":\"mock1ldaf3e9zxja5mrcw3clcu873wggmqhwfvqw9djjcjxxjwv59crqsc6n7r3\"}"
-  - - "\u0000\u0002cb\u0000\babstract\u0000\bregistry0.24.1"
+    - "{\"native\":\"mock1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcns7ctvz5\"}"
+  - - "\u0000\u0002cb\u0000\babstract\u0000\bregistry0.24.2"
     - "{\"native\":\"mock1cag6cwygef6fuddgq2l44py7crpscufrza4mt3rum2axueemenmqapxshc\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\nibc-client0.24.1"
-    - "{\"native\":\"mock1g86ckugm7v9vvpadq9szg6rlf72pdl4a6n0d8apltq5t0grecpwqtrcaj0\"}"
+    - "{\"native\":\"mock16jzpxp0e8550c9aht6q9svcux30vtyyyyxv5w2l2djjra46580wsgtnl4n\"}"
   - - "\u0000\u0002cb\u0000\babstract\u0000\u000emodule-factory0.24.1"
     - "{\"native\":\"mock1vnj802lyyupfaez73w7axfs3xveraxen370vhcnumaufj29r5rxqwxdk4n\"}"
   - - "\u0000\u0002ch\u0000\u0005local\u0000\u0000\u0000\u0000"
@@ -101,6 +101,6 @@ expression: all_storage
   - - ci
     - "3"
   - - contract_info
-    - "{\"contract\":\"abstract:registry\",\"version\":\"0.24.1\"}"
+    - "{\"contract\":\"abstract:registry\",\"version\":\"0.24.2\"}"
   - - ownership
     - "{\"owner\":\"mock14cl2dthqamgucg9sfvv4relp3aa83e40yfzzc8\",\"pending_owner\":null,\"pending_expiry\":null}"

--- a/framework/contracts/native/ibc-client/src/contract.rs
+++ b/framework/contracts/native/ibc-client/src/contract.rs
@@ -121,20 +121,13 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> IbcClientResult<QueryRespon
 }
 
 #[cfg_attr(feature = "export", cosmwasm_std::entry_point)]
-pub fn migrate(deps: DepsMut, env: Env, msg: MigrateMsg) -> IbcClientResult {
-    match msg {
-        MigrateMsg::Instantiate(instantiate_msg) => {
-            abstract_sdk::cw_helpers::migrate_instantiate(deps, env, instantiate_msg, instantiate)
-        }
-        MigrateMsg::Migrate {} => {
-            let to_version: Version = CONTRACT_VERSION.parse().unwrap();
+pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> IbcClientResult {
+    let to_version: Version = CONTRACT_VERSION.parse().unwrap();
 
-            assert_cw_contract_upgrade(deps.storage, IBC_CLIENT, to_version)?;
-            cw2::set_contract_version(deps.storage, IBC_CLIENT, CONTRACT_VERSION)?;
-            migrate_module_data(deps.storage, IBC_CLIENT, CONTRACT_VERSION, None::<String>)?;
-            Ok(IbcClientResponse::action("migrate"))
-        }
-    }
+    assert_cw_contract_upgrade(deps.storage, IBC_CLIENT, to_version)?;
+    cw2::set_contract_version(deps.storage, IBC_CLIENT, CONTRACT_VERSION)?;
+    migrate_module_data(deps.storage, IBC_CLIENT, CONTRACT_VERSION, None::<String>)?;
+    Ok(IbcClientResponse::action("migrate"))
 }
 
 #[cfg(test)]
@@ -221,7 +214,7 @@ mod tests {
 
             let version: Version = CONTRACT_VERSION.parse().unwrap();
 
-            let res = contract::migrate(deps.as_mut(), env, MigrateMsg::Migrate {});
+            let res = contract::migrate(deps.as_mut(), env, MigrateMsg {});
 
             assert_eq!(
                 res,
@@ -248,7 +241,7 @@ mod tests {
 
             let version: Version = CONTRACT_VERSION.parse().unwrap();
 
-            let res = contract::migrate(deps.as_mut(), env, MigrateMsg::Migrate {});
+            let res = contract::migrate(deps.as_mut(), env, MigrateMsg {});
 
             assert_eq!(
                 res,
@@ -274,7 +267,7 @@ mod tests {
             let old_name = "old:contract";
             cw2::set_contract_version(deps.as_mut().storage, old_name, old_version)?;
 
-            let res = contract::migrate(deps.as_mut(), env, MigrateMsg::Migrate {});
+            let res = contract::migrate(deps.as_mut(), env, MigrateMsg {});
 
             assert_eq!(
                 res,
@@ -304,7 +297,7 @@ mod tests {
             .to_string();
             cw2::set_contract_version(deps.as_mut().storage, IBC_CLIENT, small_version)?;
 
-            let res = contract::migrate(deps.as_mut(), env, MigrateMsg::Migrate {})?;
+            let res = contract::migrate(deps.as_mut(), env, MigrateMsg {})?;
             assert!(res.messages.is_empty());
 
             assert_eq!(

--- a/framework/contracts/native/ibc-host/src/contract.rs
+++ b/framework/contracts/native/ibc-host/src/contract.rs
@@ -58,18 +58,11 @@ pub fn reply(deps: DepsMut, env: Env, reply_msg: Reply) -> HostResult {
 }
 
 #[cfg_attr(feature = "export", cosmwasm_std::entry_point)]
-pub fn migrate(deps: DepsMut, env: Env, msg: MigrateMsg) -> HostResult {
-    match msg {
-        MigrateMsg::Instantiate(instantiate_msg) => {
-            abstract_sdk::cw_helpers::migrate_instantiate(deps, env, instantiate_msg, instantiate)
-        }
-        MigrateMsg::Migrate {} => {
-            let to_version: Version = CONTRACT_VERSION.parse().unwrap();
+pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> HostResult {
+    let to_version: Version = CONTRACT_VERSION.parse().unwrap();
 
-            assert_cw_contract_upgrade(deps.storage, IBC_HOST, to_version)?;
-            cw2::set_contract_version(deps.storage, IBC_HOST, CONTRACT_VERSION)?;
-            migrate_module_data(deps.storage, IBC_HOST, CONTRACT_VERSION, None::<String>)?;
-            Ok(HostResponse::action("migrate"))
-        }
-    }
+    assert_cw_contract_upgrade(deps.storage, IBC_HOST, to_version)?;
+    cw2::set_contract_version(deps.storage, IBC_HOST, CONTRACT_VERSION)?;
+    migrate_module_data(deps.storage, IBC_HOST, CONTRACT_VERSION, None::<String>)?;
+    Ok(HostResponse::action("migrate"))
 }

--- a/framework/packages/abstract-adapter/src/endpoints/ibc_callback.rs
+++ b/framework/packages/abstract-adapter/src/endpoints/ibc_callback.rs
@@ -12,7 +12,7 @@ impl<Error: ContractError, CustomInitMsg, CustomExecMsg, CustomQueryMsg, SudoMsg
     for AdapterContract<Error, CustomInitMsg, CustomExecMsg, CustomQueryMsg, SudoMsg>
 {
     fn ibc_client_addr(&self, deps: Deps, env: &Env) -> Result<Addr, Self::Error> {
-        let vc_query_result = self
+        let registry_query_result = self
             .abstract_registry(deps, env)?
             .query_module(
                 ModuleInfo::from_id(
@@ -23,6 +23,6 @@ impl<Error: ContractError, CustomInitMsg, CustomExecMsg, CustomQueryMsg, SudoMsg
             )
             .map_err(Into::<AbstractError>::into)?;
 
-        Ok(vc_query_result.reference.unwrap_native()?)
+        Ok(registry_query_result.reference.unwrap_native()?)
     }
 }

--- a/framework/packages/abstract-adapter/src/endpoints/module_ibc.rs
+++ b/framework/packages/abstract-adapter/src/endpoints/module_ibc.rs
@@ -14,7 +14,7 @@ impl<Error: ContractError, CustomInitMsg, CustomExecMsg, CustomQueryMsg, SudoMsg
         deps: cosmwasm_std::Deps,
         env: &cosmwasm_std::Env,
     ) -> Result<Addr, Self::Error> {
-        let vc_query_result = self
+        let registry_query_result = self
             .abstract_registry(deps, env)?
             .query_module(
                 ModuleInfo::from_id(
@@ -25,6 +25,6 @@ impl<Error: ContractError, CustomInitMsg, CustomExecMsg, CustomQueryMsg, SudoMsg
             )
             .map_err(Into::<AbstractError>::into)?;
 
-        Ok(vc_query_result.reference.unwrap_native()?)
+        Ok(registry_query_result.reference.unwrap_native()?)
     }
 }

--- a/framework/packages/abstract-app/Cargo.toml
+++ b/framework/packages/abstract-app/Cargo.toml
@@ -35,6 +35,7 @@ abstract-testing = { workspace = true, optional = true }
 cw-orch = { workspace = true }
 
 abstract-interface = { version = "0.24.1", path = "../../packages/abstract-interface" }
+abstract-ibc-client = { version = "0.24.1", path = "../../contracts/native/ibc-client", default-features = false }
 abstract-ibc-host = { version = "0.24.1", path = "../../contracts/native/ibc-host", default-features = false }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/framework/packages/abstract-app/src/endpoints/ibc_callback.rs
+++ b/framework/packages/abstract-app/src/endpoints/ibc_callback.rs
@@ -36,34 +36,3 @@ impl<
         Ok(registry_query_result.reference.unwrap_native()?)
     }
 }
-
-#[cfg(test)]
-mod test {
-    use abstract_sdk::base::IbcCallbackEndpoint;
-    use abstract_std::{account::state::ACCOUNT_MODULES, IBC_CLIENT};
-    use abstract_testing::{
-        abstract_mock_querier_builder, mock_env_validated, prelude::test_account,
-    };
-    use cosmwasm_std::Addr;
-
-    use crate::mock::{mock_init, BASIC_MOCK_APP};
-
-    #[coverage_helper::test]
-    fn ibc_client_address() {
-        let mut deps = mock_init();
-        let test_account = test_account(deps.api);
-        let ibc_client_addr = Addr::unchecked("ibc_client");
-
-        deps.querier = abstract_mock_querier_builder(deps.api)
-            .with_contract_map_entry(
-                test_account.addr(),
-                ACCOUNT_MODULES,
-                (IBC_CLIENT, ibc_client_addr.clone()),
-            )
-            .build();
-        let env = mock_env_validated(deps.api);
-
-        let ibc_client = BASIC_MOCK_APP.ibc_client_addr(deps.as_ref(), &env);
-        assert_eq!(ibc_client, Ok(ibc_client_addr))
-    }
-}

--- a/framework/packages/abstract-app/src/endpoints/module_ibc.rs
+++ b/framework/packages/abstract-app/src/endpoints/module_ibc.rs
@@ -1,5 +1,8 @@
-use abstract_sdk::base::ModuleIbcEndpoint;
-use abstract_std::native_addrs;
+use abstract_sdk::{base::ModuleIbcEndpoint, features::AbstractRegistryAccess};
+use abstract_std::{
+    objects::module::{ModuleInfo, ModuleVersion},
+    IBC_HOST,
+};
 use cosmwasm_std::Addr;
 
 use crate::{state::ContractError, AppContract};
@@ -19,11 +22,18 @@ impl<
         deps: cosmwasm_std::Deps,
         env: &cosmwasm_std::Env,
     ) -> Result<Addr, Self::Error> {
-        let hrp = native_addrs::hrp_from_env(env);
-        let ibc_host_canon = native_addrs::ibc_host_address(hrp, deps.api)?;
-        let ibc_host_addr = deps.api.addr_humanize(&ibc_host_canon)?;
+        let registry_query_result = self
+            .abstract_registry(deps, env)?
+            .query_module(
+                ModuleInfo::from_id(
+                    IBC_HOST,
+                    ModuleVersion::from(abstract_ibc_host::contract::CONTRACT_VERSION),
+                )?,
+                &deps.querier,
+            )
+            .map_err(Into::<abstract_std::AbstractError>::into)?;
 
-        Ok(ibc_host_addr)
+        Ok(registry_query_result.reference.unwrap_native()?)
     }
 }
 

--- a/framework/packages/abstract-app/src/endpoints/module_ibc.rs
+++ b/framework/packages/abstract-app/src/endpoints/module_ibc.rs
@@ -36,26 +36,3 @@ impl<
         Ok(registry_query_result.reference.unwrap_native()?)
     }
 }
-
-#[cfg(test)]
-mod test {
-    use abstract_sdk::base::ModuleIbcEndpoint;
-    use abstract_std::native_addrs;
-    use abstract_testing::mock_env_validated;
-    use cosmwasm_std::Api;
-
-    use crate::mock::{mock_init, BASIC_MOCK_APP};
-
-    #[coverage_helper::test]
-    fn ibc_host_address() {
-        let deps = mock_init();
-        let env = mock_env_validated(deps.api);
-        let ibc_host = BASIC_MOCK_APP.ibc_host(deps.as_ref(), &env);
-
-        let hrp = native_addrs::hrp_from_env(&env);
-        let expected_ibc_host_canon = native_addrs::ibc_host_address(hrp, &deps.api).unwrap();
-        let expected_ibc_host = deps.api.addr_humanize(&expected_ibc_host_canon).unwrap();
-
-        assert_eq!(ibc_host, Ok(expected_ibc_host))
-    }
-}

--- a/framework/packages/abstract-interface/src/deployment.rs
+++ b/framework/packages/abstract-interface/src/deployment.rs
@@ -125,22 +125,9 @@ impl<Chain: CwEnv> Deploy<Chain> for Abstract<Chain> {
         )?;
 
         // We also instantiate ibc contracts
-        deployment.ibc.client.deterministic_instantiate(
-            &abstract_std::ibc_client::MigrateMsg::Instantiate(
-                abstract_std::ibc_client::InstantiateMsg {},
-            ),
-            blob_code_id,
-            expected_addr(native_addrs::IBC_CLIENT_SALT)?,
-            Binary::from(native_addrs::IBC_CLIENT_SALT),
-        )?;
-        deployment.ibc.host.deterministic_instantiate(
-            &abstract_std::ibc_host::MigrateMsg::Instantiate(
-                abstract_std::ibc_host::InstantiateMsg {},
-            ),
-            blob_code_id,
-            expected_addr(native_addrs::IBC_HOST_SALT)?,
-            Binary::from(native_addrs::IBC_HOST_SALT),
-        )?;
+        deployment
+            .ibc
+            .instantiate(&Addr::unchecked(admin.clone()))?;
         deployment.ibc.register(&deployment.registry)?;
 
         deployment.registry.register_base(&deployment.account)?;
@@ -372,15 +359,6 @@ mod test {
             module_factory,
             native_addrs::module_factory_address(prefix, api)?
         );
-
-        // IBC_CLIENT
-        let ibc_client = api.addr_canonicalize(&abstr.ibc.client.addr_str()?)?;
-        assert_eq!(ibc_client, native_addrs::ibc_client_address(prefix, api)?);
-
-        // IBC_HOST
-        let ibc_host = api.addr_canonicalize(&abstr.ibc.host.addr_str()?)?;
-        assert_eq!(ibc_host, native_addrs::ibc_host_address(prefix, api)?);
-
         Ok(())
     }
 }

--- a/framework/packages/abstract-interface/src/migrate.rs
+++ b/framework/packages/abstract-interface/src/migrate.rs
@@ -216,10 +216,10 @@ impl<Chain: CwEnv> AbstractIbc<Chain> {
     pub fn migrate_if_needed(&self) -> Result<bool, crate::AbstractInterfaceError> {
         let client = self
             .client
-            .upload_and_migrate_if_needed(&ibc_client::MigrateMsg::Migrate {})?;
+            .upload_and_migrate_if_needed(&ibc_client::MigrateMsg {})?;
         let host = self
             .host
-            .upload_and_migrate_if_needed(&ibc_host::MigrateMsg::Migrate {})?;
+            .upload_and_migrate_if_needed(&ibc_host::MigrateMsg {})?;
         Ok(client.is_some() || host.is_some())
     }
 
@@ -252,10 +252,10 @@ impl<Chain: CwEnv> AbstractIbc<Chain> {
         if version_req.matches(&new_version) {
             // If version is not breaking, simply migrate
             self.client
-                .migrate_if_needed(&ibc_client::MigrateMsg::Migrate {})?
+                .migrate_if_needed(&ibc_client::MigrateMsg {})?
                 .expect("IBC client supposed to be migrated, but skipped instead");
             self.host
-                .migrate_if_needed(&ibc_host::MigrateMsg::Migrate {})?
+                .migrate_if_needed(&ibc_host::MigrateMsg {})?
                 .expect("IBC host supposed to be migrated, but skipped instead");
         } else {
             // Version change is breaking, need to deploy new version

--- a/framework/packages/abstract-interface/tests/instantiate_from_migration.rs
+++ b/framework/packages/abstract-interface/tests/instantiate_from_migration.rs
@@ -1,5 +1,5 @@
-use abstract_interface::{AnsHost, IbcClient, IbcHost, ModuleFactory, Registry};
-use abstract_std::{ANS_HOST, IBC_CLIENT, IBC_HOST, MODULE_FACTORY, REGISTRY};
+use abstract_interface::{AnsHost, ModuleFactory, Registry};
+use abstract_std::{ANS_HOST, MODULE_FACTORY, REGISTRY};
 use cosmwasm_schema::serde::Serialize;
 use cw_blob::interface::CwBlob;
 use cw_orch::{anyhow, mock::MockBase, prelude::*};
@@ -95,19 +95,4 @@ fn module_factory() {
         },
     )
     .unwrap();
-}
-
-#[test]
-fn ibc_host() {
-    let chain = MockBech32::new("mock");
-    let contract = IbcHost::new(IBC_HOST, chain.clone());
-    instantiate_from_blob_same_result(contract, abstract_std::ibc_host::InstantiateMsg {}).unwrap();
-}
-
-#[test]
-fn ibc_client() {
-    let chain = MockBech32::new("mock");
-    let contract = IbcClient::new(IBC_CLIENT, chain.clone());
-    instantiate_from_blob_same_result(contract, abstract_std::ibc_client::InstantiateMsg {})
-        .unwrap();
 }

--- a/framework/packages/abstract-std/src/native/ibc/ibc_client.rs
+++ b/framework/packages/abstract-std/src/native/ibc/ibc_client.rs
@@ -58,12 +58,7 @@ pub mod state {
 pub struct InstantiateMsg {}
 
 #[cosmwasm_schema::cw_serde]
-pub enum MigrateMsg {
-    /// Migrating from blob contract
-    Instantiate(InstantiateMsg),
-    /// Migrating from previous version
-    Migrate {},
-}
+pub struct MigrateMsg {}
 
 #[cosmwasm_schema::cw_serde]
 #[derive(cw_orch::ExecuteFns)]

--- a/framework/packages/abstract-std/src/native/ibc/ibc_host.rs
+++ b/framework/packages/abstract-std/src/native/ibc/ibc_host.rs
@@ -37,12 +37,7 @@ pub mod state {
 pub struct InstantiateMsg {}
 
 #[cosmwasm_schema::cw_serde]
-pub enum MigrateMsg {
-    /// Migrating from blob contract
-    Instantiate(InstantiateMsg),
-    /// Migrating from previous version
-    Migrate {},
-}
+pub struct MigrateMsg {}
 
 // ANCHOR: ibc-host-action
 #[cosmwasm_schema::cw_serde]

--- a/framework/packages/abstract-std/src/native_addrs.rs
+++ b/framework/packages/abstract-std/src/native_addrs.rs
@@ -18,8 +18,6 @@ const TEST_ABSTRACT_CREATOR: [u8; 33] = [
 pub const ANS_HOST_SALT: &[u8] = b"ans";
 pub const REGISTRY_SALT: &[u8] = b"reg";
 pub const MODULE_FACTORY_SALT: &[u8] = b"mf";
-pub const IBC_CLIENT_SALT: &[u8] = b"ic";
-pub const IBC_HOST_SALT: &[u8] = b"ih";
 
 pub fn ans_address(hrp: &str, api: &dyn Api) -> AbstractResult<CanonicalAddr> {
     contract_canon_address(hrp, ANS_HOST_SALT, api)
@@ -31,14 +29,6 @@ pub fn registry_address(hrp: &str, api: &dyn Api) -> AbstractResult<CanonicalAdd
 
 pub fn module_factory_address(hrp: &str, api: &dyn Api) -> AbstractResult<CanonicalAddr> {
     contract_canon_address(hrp, MODULE_FACTORY_SALT, api)
-}
-
-pub fn ibc_client_address(hrp: &str, api: &dyn Api) -> AbstractResult<CanonicalAddr> {
-    contract_canon_address(hrp, IBC_CLIENT_SALT, api)
-}
-
-pub fn ibc_host_address(hrp: &str, api: &dyn Api) -> AbstractResult<CanonicalAddr> {
-    contract_canon_address(hrp, IBC_HOST_SALT, api)
 }
 
 pub fn derive_addr_from_pub_key(hrp: &str, pub_key: &[u8]) -> AbstractResult<String> {


### PR DESCRIPTION
We can't guarantee having non-breaking API for those modules, so making predictable addresses doesn't make sense, as it disallows having multiple versions of ibc-client/ibc-host registered at the same time