### PR TITLE
Minify test artifacts

### DIFF
--- a/framework/Cargo.toml
+++ b/framework/Cargo.toml
@@ -104,11 +104,6 @@ coverage-helper = { version = "0.2.2" }
 # Predictable abstract addresses
 cw-blob = { version = "=0.2.0", features = ["library"] }
 
-[profile.dev]
-opt-level = 1
-[profile.dev.package."*"]
-opt-level = 3
-
 # Backup release profile, will result in warnings during optimization
 [profile.release]
 rpath = false


### PR DESCRIPTION
We have enabled optimization for dev dependencies. Let's try disabling optimization on it and see if we have enough space