### PR TITLE
Don't doubly-register native ibc contracts

### DIFF
--- a/framework/packages/abstract-interface/src/deployment.rs
+++ b/framework/packages/abstract-interface/src/deployment.rs
@@ -122,7 +122,6 @@ impl<Chain: CwEnv> Deploy<Chain> for Abstract<Chain> {
         deployment
             .ibc
             .instantiate(&Addr::unchecked(admin.clone()))?;
-        deployment.ibc.register(&deployment.registry)?;
 
         deployment.registry.register_base(&deployment.account)?;
         deployment


### PR DESCRIPTION
Title. We were doubly-registering the IBC contracts that were registered by `register_natives`, resulting in the following error:

```
called `Result::unwrap()` on an `Err` value: status: Unknown, message: "failed to execute message; message index: 0: Module ibc-client provided by abstract with version 0.25.0 cannot be updated: execute wasm contract failed [CosmWasm/wasmd@v0.44.0/x/wasm/keeper/keeper.go:395] With gas wanted: '18446744073709551615' and gas used: '141224' ", details: [], metadata: MetadataMap { headers: {"date": "Fri, 13 Dec 2024 04:48:14 GMT", "content-type": "application/grpc", "content-length": "0", "strict-transport-security": "max-age=31536000; includeSubDomains"} }

```

### Checklist

- [ ] CI is green.
- [ ] Changelog updated.
