### PR TITLE
Fix typos

### DIFF
--- a/framework/contracts/native/ibc-client/src/commands.rs
+++ b/framework/contracts/native/ibc-client/src/commands.rs
@@ -71,7 +71,7 @@ pub fn execute_register_infrastructure(
     REVERSE_POLYTONE_NOTE.save(deps.storage, &note, &host_chain)?;
 
     // When registering a new chain host, we need to get the remote proxy address of the local note.
-    // We do so by calling an empty message on the polytone note. This will come back in form of a execute by callback
+    // We do so by calling an empty message on the polytone note. This will come back in form of an execute by callback
 
     let note_proxy_msg = wasm_execute(
         note,

--- a/framework/contracts/native/ibc-client/src/commands.rs
+++ b/framework/contracts/native/ibc-client/src/commands.rs
@@ -164,7 +164,7 @@ pub fn execute_send_packet(
 
     let note_message = match &action {
         HostAction::Dispatch { .. } | HostAction::Helpers(_) => {
-            // Verify that the sender is a account contract
+            // Verify that the sender is an account contract
             let account = registry.assert_account(&info.sender, &deps.querier)?;
 
             // get account_id
@@ -345,7 +345,7 @@ pub fn execute_register_account(
 
     let registry = RegistryContract::new(deps.as_ref(), abstract_code_id)?;
 
-    // Verify that the sender is a account contract
+    // Verify that the sender is an account contract
     let account = registry.assert_account(&info.sender, &deps.querier)?;
 
     // get account_id
@@ -393,7 +393,7 @@ pub fn execute_send_funds(
 
     let registry = RegistryContract::new(deps.as_ref(), abstract_code_id)?;
     let ans = AnsHost::new(deps.as_ref(), abstract_code_id)?;
-    // Verify that the sender is a account contract
+    // Verify that the sender is an account contract
 
     let account = registry.assert_account(&info.sender, &deps.querier)?;
 
@@ -443,7 +443,7 @@ pub(crate) fn execute_send_funds_with_actions(
     let coin = cw_utils::one_coin(&info)?;
 
     let ibc_infra = IBC_INFRA.load(deps.storage, &host_chain)?;
-    // Verify that the sender is a account contract
+    // Verify that the sender is an account contract
     let abstract_code_id =
         native_addrs::abstract_code_id(&deps.querier, env.contract.address.clone())?;
     let registry = RegistryContract::new(deps.as_ref(), abstract_code_id)?;

--- a/framework/docs/src/ibc/account-ibc.md
+++ b/framework/docs/src/ibc/account-ibc.md
@@ -181,7 +181,7 @@ Interchain Abstract Accounts are traditional Abstract Accounts controlled by the
 
 When an action is triggered by a remote account, the `ibc-host` does the following verifications:
 
-- If an local account already exists on-chain for the remote account, it just dispatches the message to the account.
+- If a local account already exists on-chain for the remote account, it just dispatches the message to the account.
 - If no account exists, it creates one with default metadata and THEN dispatches the messages to this new account.
 
 The Account creation process is therefore not mandatory when interacting with Interchain Abstract Accounts. This is why when you create an Abstract Account, you automatically have an account on every connected chains!

--- a/framework/docs/src/ibc/account-ibc.md
+++ b/framework/docs/src/ibc/account-ibc.md
@@ -75,7 +75,7 @@ Remember that this step is optional as accounts are created automatically when s
 
 ### Account ID structure
 
-The remote Interchain Abstract Account will have the same account sequence but will have a different trace. Let's take an example. A account on `Neutron` with account sequence `42` wants to create accounts on `Osmosis` and `Stargaze`.
+The remote Interchain Abstract Account will have the same account sequence but will have a different trace. Let's take an example. An account on `Neutron` with account sequence `42` wants to create accounts on `Osmosis` and `Stargaze`.
 
 - Their account ID on `Neutron` is `local-42`.
 - Their account ID on `Osmosis` is `neutron-42`.

--- a/framework/packages/abstract-sdk/src/base/contract_base.rs
+++ b/framework/packages/abstract-sdk/src/base/contract_base.rs
@@ -37,7 +37,7 @@ pub type IbcCallbackHandlerFn<Module, Error> =
 // ANCHOR_END: ibc
 
 // ANCHOR: module_ibc
-/// Function signature for an Module to Module IBC handler.
+/// Function signature for a Module to Module IBC handler.
 pub type ModuleIbcHandlerFn<Module, Error> =
     fn(DepsMut, Env, Module, ModuleIbcInfo, Binary) -> Result<Response, Error>;
 // ANCHOR_END: module_ibc

--- a/framework/packages/abstract-std/src/native/ibc/ibc_client.rs
+++ b/framework/packages/abstract-std/src/native/ibc/ibc_client.rs
@@ -118,7 +118,7 @@ pub enum ExecuteMsg {
     },
     /// Only callable by Account
     /// Register an Account on a remote chain over IBC
-    /// This action creates a account for them on the remote chain.
+    /// This action creates an account for them on the remote chain.
     Register {
         /// host chain to be executed on
         /// Example: "osmosis"


### PR DESCRIPTION
This pull request addresses several typographical errors across multiple files:

1. In `commands.rs`, corrected "a account" to "an account" in several places to adhere to grammatical rules.
2. In `account-ibc.md`, fixed "a account" to "an account" for consistency and clarity in documentation.
3. In `contract_base.rs`, modified the function description to improve readability.
4. In `ibc_client.rs`, updated the action description to fix the typo in "a account."
