### PR TITLE
Add documentation markdown generation

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -46,11 +46,11 @@ jobs:
         run: just docs-build
 
       - name: Copy robots.txt
-        run: cp framework/docs/src/robots.txt framework/docs/book/html/
+        run: cp framework/docs/src/robots.txt framework/docs/book/
 
       - name: Generate sitemap
         run: |
-          cd framework/docs/book/html
+          cd framework/docs/book
           npx sscli --no-clean --base https://docs.abstract.money
 
       - name: Upload artifact
@@ -58,7 +58,7 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           # Upload book repository
-          path: './framework/docs/book/html'
+          path: './framework/docs/book'
 
   # Deploy job
   deploy:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -45,9 +45,12 @@ jobs:
         working-directory: ./framework
         run: just docs-build
 
+      - name: Copy robots.txt
+        run: cp framework/docs/src/robots.txt framework/docs/book/html/
+
       - name: Generate sitemap
         run: |
-          cd framework/docs/book
+          cd framework/docs/book/html
           npx sscli --no-clean --base https://docs.abstract.money
 
       - name: Upload artifact
@@ -55,7 +58,7 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           # Upload book repository
-          path: './framework/docs/book'
+          path: './framework/docs/book/html'
 
   # Deploy job
   deploy:

--- a/framework/docs/book.toml
+++ b/framework/docs/book.toml
@@ -32,3 +32,7 @@ git-repository-url   = "https://github.com/AbstractSDK/abstract/tree/main/framew
 no-section-label     = true
 preferred-dark-theme = "abstract"
 # [output.linkcheck]
+
+[output.llms-txt]
+
+[output.llms-txt-full]

--- a/framework/docs/book.toml
+++ b/framework/docs/book.toml
@@ -1,7 +1,6 @@
 [book]
 authors      = ["cyberhoward"]
 language     = "en"
-multilingual = false
 src          = "src"
 title        = "Abstract Money"
 

--- a/framework/docs/src/robots.txt
+++ b/framework/docs/src/robots.txt
@@ -1,0 +1,24 @@
+User-agent: *
+Allow: /
+
+# Explicitly allow AI crawlers
+User-agent: GPTBot
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: Anthropic-AI
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+# Point to llms.txt for AI agents
+# See: https://llmstxt.org/

--- a/framework/docs/src/robots.txt
+++ b/framework/docs/src/robots.txt
@@ -1,7 +1,15 @@
+# Regular search crawlers - block .md files to avoid duplicate content
+User-agent: Googlebot
+Disallow: /*.md$
+
+User-agent: Bingbot
+Disallow: /*.md$
+
 User-agent: *
 Allow: /
+Disallow: /*.md$
 
-# Explicitly allow AI crawlers
+# AI crawlers - allow everything including .md files
 User-agent: GPTBot
 Allow: /
 

--- a/framework/docs/src/robots.txt
+++ b/framework/docs/src/robots.txt
@@ -1,4 +1,4 @@
-# Regular search crawlers - block .md files to avoid duplicate content
+# Search crawlers - block .md files to avoid duplicate content
 User-agent: Googlebot
 Disallow: /*.md$
 
@@ -7,26 +7,3 @@ Disallow: /*.md$
 
 User-agent: *
 Allow: /
-Disallow: /*.md$
-
-# AI crawlers - allow everything including .md files
-User-agent: GPTBot
-Allow: /
-
-User-agent: ClaudeBot
-Allow: /
-
-User-agent: Claude-Web
-Allow: /
-
-User-agent: Google-Extended
-Allow: /
-
-User-agent: Anthropic-AI
-Allow: /
-
-User-agent: PerplexityBot
-Allow: /
-
-# Point to llms.txt for AI agents
-# See: https://llmstxt.org/

--- a/framework/justfile
+++ b/framework/justfile
@@ -83,6 +83,8 @@ docs-build:
   (cd docs && mdbook build)
   cp docs/book/llms-txt/llms.txt docs/book/html/
   cp docs/book/llms-txt-full/llms-full.txt docs/book/html/
+  # Copy source markdown files for AI agents (excluding SUMMARY.md)
+  cd docs && find src -name "*.md" ! -name "SUMMARY.md" -exec sh -c 'mkdir -p "book/html/$(dirname "${1#src/}")" && cp "$1" "book/html/${1#src/}"' _ {} \;
 
 docs-install:
   cargo install mdbook --vers "0.4.28" --locked

--- a/framework/justfile
+++ b/framework/justfile
@@ -81,10 +81,14 @@ docs-serve *FLAGS:
 
 docs-build:
   (cd docs && mdbook build)
+  # Copy llms.txt files to html directory
   cp docs/book/llms-txt/llms.txt docs/book/html/
   cp docs/book/llms-txt-full/llms-full.txt docs/book/html/
   # Copy source markdown files for AI agents (excluding SUMMARY.md)
   cd docs && find src -name "*.md" ! -name "SUMMARY.md" -exec sh -c 'mkdir -p "book/html/$(dirname "${1#src/}")" && cp "$1" "book/html/${1#src/}"' _ {} \;
+  # Move all content from html/ to book/ root and clean up subdirectories
+  cp -r docs/book/html/. docs/book/
+  rm -rf docs/book/html docs/book/llms-txt docs/book/llms-txt-full
 
 docs-install:
   cargo install mdbook --vers "0.4.28" --locked

--- a/framework/justfile
+++ b/framework/justfile
@@ -81,8 +81,11 @@ docs-serve *FLAGS:
 
 docs-build:
   (cd docs && mdbook build)
+  cp docs/book/llms-txt/llms.txt docs/book/html/
+  cp docs/book/llms-txt-full/llms-full.txt docs/book/html/
 
 docs-install:
   cargo install mdbook --vers "0.4.28" --locked
   cargo install mdbook-mermaid --vers "0.12.6" --locked
   cargo install mdbook-admonish --vers "1.15.0" --locked
+  cargo install mdbook-llms-txt-tools --locked

--- a/framework/justfile
+++ b/framework/justfile
@@ -94,4 +94,4 @@ docs-install:
   cargo install mdbook --vers "0.4.28" --locked
   cargo install mdbook-mermaid --vers "0.12.6" --locked
   cargo install mdbook-admonish --vers "1.15.0" --locked
-  cargo install mdbook-llms-txt-tools --locked
+  cargo install mdbook-llms-txt-tools --vers "0.1.1" --locked


### PR DESCRIPTION
Generate markdown for every documentation page using `mdbook-llms-txt-tools`. Update robots.txt for easy crawling.

### Checklist

- [x] CI is green.
